### PR TITLE
import from mrh -> import from pyscf plus hybrid fnal edge case bug

### DIFF
--- a/pyscf/mcpdft/_libxc.py
+++ b/pyscf/mcpdft/_libxc.py
@@ -124,8 +124,8 @@ def _parse_xc_formula (xc_code):
 def assemble_xc_formula (facs, terms):
     code = []
     for fac, term in zip (facs, terms):
-        if fac==1.0: code.append ('{:s}'.format (fac))
-        elif fac==-1.0: code.append ('-{:s}'.format (fac))
+        if fac==1.0: code.append ('{:s}'.format (term))
+        elif fac==-1.0: code.append ('-{:s}'.format (term))
         elif fac==0.0: continue
         else:
             fac = '{:.16f}'.format (round (fac,14))

--- a/pyscf/prop/trans_dip_moment/mspdft.py
+++ b/pyscf/prop/trans_dip_moment/mspdft.py
@@ -2,10 +2,10 @@ from pyscf.lib import logger
 import numpy as np
 from pyscf.data import nist
 from pyscf import lib
-from mrh.my_pyscf.prop.dip_moment import mspdft
-from mrh.my_pyscf.prop.dip_moment.mspdft import sipdft_HellmanFeynman_dipole, get_guage_origin
-from mrh.my_pyscf.grad.mspdft import mspdft_heff_response
-from mrh.my_pyscf.grad.mspdft import _unpack_state
+from pyscf.prop.dip_moment import mspdft
+from pyscf.prop.dip_moment.mspdft import sipdft_HellmanFeynman_dipole, get_guage_origin
+from pyscf.grad.mspdft import mspdft_heff_response
+from pyscf.grad.mspdft import _unpack_state
 
 class TransitionDipole (mspdft.ElectricDipole):
 


### PR DESCRIPTION
I accidentally left imports from `mrh` in the CMS-PDFT transition dipole moments code. Fortunately there was no issue pointing those to `pyscf`.

ETA: Also fixed an edge case where hybrid on-top functionals with lambda = 0 gives an error.