### PR TITLE
include user-defined cint.h directory for cmake

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -87,6 +87,7 @@ if(NOT PYSCF_SOURCE_DIR)
 endif()
 message(STATUS "Include pyscf source dir: ${PYSCF_SOURCE_DIR}")
 include_directories(${PYSCF_SOURCE_DIR}/lib ${PYSCF_SOURCE_DIR}/lib/deps/include)
+include_directories(${CINT_DIR}/include)
 configure_file(
   "${PYSCF_SOURCE_DIR}/lib/config.h.in"
   "${PYSCF_SOURCE_DIR}/lib/config.h")


### PR DESCRIPTION
Looks like https://github.com/MatthewRHermes/mrh/pull/15 is not applied after migrating to pyscf-forge. Applied in this PR.