### PR TITLE
XMS-PDFT

### DIFF
--- a/doc/mcpdft/README.md
+++ b/doc/mcpdft/README.md
@@ -78,7 +78,7 @@ Features
 [*JCTC* **2021**, *17*, 7586]: http://dx.doi.org/10.1021/acs.jctc.1c00915
 [*JCTC* **2021**, *17*, 2775]: http://dx.doi.org/10.1021/acs.jctc.0c01346
 [*Mol Phys* **2022**, 120]: http://dx.doi.org/10.1080/00268976.2022.2110534
-[*Faraday Discuss* **2020**, *224, 348-372]: http://dx.doi.org/10.1039/D0FD00037J
+[*Faraday Discuss* **2020**, 224, 348-372]: http://dx.doi.org/10.1039/D0FD00037J
 
 [comment]: <> (Code hyperlinks)
 [examples/mcpdft/02-hybrid_functionals.py]: examples/mcpdft/02-hybrid_functionals.py

--- a/doc/mcpdft/README.md
+++ b/doc/mcpdft/README.md
@@ -56,7 +56,7 @@ Features
     - Analytical nuclear gradients (non-hybrid functionals only) for:
         1. Single-state CASSCF wave function: [*JCTC* **2018**, *14*, 126]
         2. State-averaged CASSCF wave functions: [*JCP* **2020**, *153*, 014106]
-        3. CMS-PDFT: **in press**
+        3. CMS-PDFT: [*Mol Phys* **2022**, 120]
     - Permanent electric dipole moment (non-hybrid functionals only) for:
         1. Single-state CASSCF wave function: [*JCTC* **2021**, *17*, 7586]
         2. State-averaged CASSCF wave functions
@@ -76,6 +76,7 @@ Features
 [*JCP* **2020**, *153*, 014106]: http://dx.doi.org/10.1063/5.0007040
 [*JCTC* **2021**, *17*, 7586]: http://dx.doi.org/10.1021/acs.jctc.1c00915
 [*JCTC* **2021**, *17*, 2775]: http://dx.doi.org/10.1021/acs.jctc.0c01346
+[*Mol Phys* **2022**, 120]: http://dx.doi.org/10.1080/00268976.2022.2110534
 
 [comment]: <> (Code hyperlinks)
 [examples/mcpdft/02-hybrid_functionals.py]: examples/mcpdft/02-hybrid_functionals.py

--- a/doc/mcpdft/README.md
+++ b/doc/mcpdft/README.md
@@ -35,6 +35,7 @@ Features
     - CASSCF
     - State-averaged CASSCF (including "mixed" solver with different spins
       and/or point groups)
+    - Extended multi-state MC-PDFT (XMS-PDFT): [*Faraday Discuss* **2020**, 224, 348-372]
     - Compressed multi-state MC-PDFT (CMS-PDFT): [*JCTC* **2020**, *16*, 7444]
 * On-the-fly generation of on-top density functionals from underlying KS-DFT
   'LDA' or 'GGA' exchange-correlation functionals as defined in Libxc.
@@ -77,6 +78,7 @@ Features
 [*JCTC* **2021**, *17*, 7586]: http://dx.doi.org/10.1021/acs.jctc.1c00915
 [*JCTC* **2021**, *17*, 2775]: http://dx.doi.org/10.1021/acs.jctc.0c01346
 [*Mol Phys* **2022**, 120]: http://dx.doi.org/10.1080/00268976.2022.2110534
+[*Faraday Discuss* **2020**, *224, 348-372]: http://dx.doi.org/10.1039/D0FD00037J
 
 [comment]: <> (Code hyperlinks)
 [examples/mcpdft/02-hybrid_functionals.py]: examples/mcpdft/02-hybrid_functionals.py

--- a/examples/mcpdft/16-multi_state.py
+++ b/examples/mcpdft/16-multi_state.py
@@ -4,7 +4,8 @@
 multi-state
 
 A "quasidegenerate" extension of MC-PDFT for states close in energy. Currently
-only "compressed multi-state" (CMS) is supported [JCTC 16, 7444 (2020)]
+only "compressed multi-state" (CMS-) [JCTC 16, 7444 (2020)] and "extended multi-
+state" (XMS-) [Faraday Discuss 224, 348-372 (2020)] is supported.
 '''
 
 from pyscf import gto, scf, mcpdft
@@ -23,7 +24,12 @@ mf.kernel()
 mc = mcpdft.CASSCF(mf, 'tpbe', 2, 2)
 mc.fix_spin_(ss=0) # often necessary!
 mc_sa = mc.state_average ([.5, .5]).run ()
-mc_ms = mc.multi_state ([.5, .5]).run (verbose=4)
+
+# For CMS-PDFT
+mc_cms = mc.multi_state([.5, .5], "cms").run(verbose=4)
+
+# For XMS-PDFT
+mc_xms = mc.multi_state([.5, .5], "xms").run(verbose=4)
 
 print ('{:>21s} {:>12s} {:>12s}'.format ('state 0','state 1', 'gap'))
 fmt_str = '{:>9s} {:12.9f} {:12.9f} {:12.9f}'
@@ -31,5 +37,7 @@ print (fmt_str.format ('CASSCF', mc_sa.e_mcscf[0], mc_sa.e_mcscf[1],
     mc_sa.e_mcscf[1]-mc_sa.e_mcscf[0]))
 print (fmt_str.format ('MC-PDFT', mc_sa.e_states[0], mc_sa.e_states[1],
     mc_sa.e_states[1]-mc_sa.e_states[0]))
-print (fmt_str.format ('CMS-PDFT', mc_ms.e_states[0], mc_ms.e_states[1],
-    mc_ms.e_states[1]-mc_ms.e_states[0]))
+print (fmt_str.format ('CMS-PDFT', mc_cms.e_states[0], mc_cms.e_states[1],
+    mc_cms.e_states[1]-mc_cms.e_states[0]))
+print (fmt_str.format ('XMS-PDFT', mc_xms.e_states[0], mc_xms.e_states[1],
+    mc_xms.e_states[1]-mc_xms.e_states[0]))

--- a/pyscf/mcpdft/mspdft.py
+++ b/pyscf/mcpdft/mspdft.py
@@ -362,7 +362,7 @@ class _MSPDFT (MultiStateMCPDFTSolver):
         self.converged = self.converged and diab_conv
         self.heff_mcscf = self.make_heff_mcscf ()
         e_mcscf, self.si_mcscf = self._eig_si (self.heff_mcscf)
-        if abs (linalg.norm (self.e_mcscf-e_mcscf)) > 1e-10:
+        if abs (linalg.norm (self.e_mcscf-e_mcscf)) > 1e-9:
             raise RuntimeError (("Sanity fault: e_mcscf ({}) != "
                                 "self.e_mcscf ({})").format (e_mcscf,
                                 self.e_mcscf))

--- a/pyscf/mcpdft/mspdft.py
+++ b/pyscf/mcpdft/mspdft.py
@@ -417,7 +417,7 @@ class _MSPDFT (MultiStateMCPDFTSolver):
                                  axes=((1,2),(1,2)))
             u, svals, vh = linalg.svd (ovlp)
             ci = self.get_ci_basis (ci=ci, uci=np.dot (u,vh)) 
-        return self._diabatize (self, ci, **kwargs)
+        return self._diabatize (self, ci=ci, **kwargs)
 
     def diabatizer (self, mo_coeff=None, ci=None):
         '''Computes the value, gradient vector, and Hessian matrix with

--- a/pyscf/mcpdft/mspdft.py
+++ b/pyscf/mcpdft/mspdft.py
@@ -600,8 +600,14 @@ def get_diabfns (obj):
     if obj.upper () == 'CMS':
         from pyscf.mcpdft.cmspdft import e_coul as diabatizer
         diabatize = si_newton
+
+    elif obj.upper() == "XMS":
+        from pyscf.mcpdft.xmspdft import safock_energy as diabatizer
+        from pyscf.mcpdft.xmspdft import solve_safock as diabatize
+
     else:
         raise RuntimeError ('MS-PDFT type not supported')
+
     return diabatizer, diabatize
 
 def multi_state (mc, weights=(0.5,0.5), diabatization='CMS', **kwargs):

--- a/pyscf/mcpdft/test/test_xmspdft.py
+++ b/pyscf/mcpdft/test/test_xmspdft.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+from math import cos, sin, pi
 from pyscf import gto, scf, mcpdft
 
 import unittest
@@ -8,19 +9,29 @@ def get_lih (r):
     mol = gto.M (atom='Li 0 0 0\nH {} 0 0'.format (r), basis='sto3g',
                  output='/dev/null', verbose=0)
     mf = scf.RHF (mol).run ()
-    mc = mcpdft.CASSCF (mf, 'ftLDA,VWN3', 2, 2, grids_level=1)
+    mc = mcpdft.CASSCF (mf, 'tPBE', 2, 2, grids_level=1)
     mc.fix_spin_(ss=0)
     mc = mc.multi_state ([0.5,0.5], 'xms').run (conv_tol=1e-8)
     return mol, mf, mc
 
+def get_h2(r):
+    mol = gto.M(atom='H 0 0 0\n H {} 0 0'.format(r), basis='sto3g', output='/dev/null', verbose=0)
+    mf = scf.RHF(mol).run()
+    mc = mcpdft.CASSCF(mf, 'tPBE', 2, 2, grids_level=6)
+    mc.fix_spin_(ss=0, shift=1)
+    mc = mc.multi_state([0.5, 0.5], 'xms').run(conv_tol=1e-8)
+    return mol, mf, mc
+
+
 def setUpModule():
-    global mol, mf, lih
+    global mol, mf, lih, h2
     mol, mf, lih = get_lih (1.5)
+    _, _, h2 = get_h2(0.8)
 
 def tearDownModule():
-    global mol, mf, lih
+    global mol, mf, lih, h2
     mol.stdout.close ()
-    del mol, mf, lih
+    del mol, mf, lih, h2
 
 class KnownValues(unittest.TestCase):
 
@@ -29,22 +40,34 @@ class KnownValues(unittest.TestCase):
         for first, second in zip(first_list, second_list):
             self.assertAlmostEqual(first, second, expected)
 
-    def test_lih_diabats (self):
-        # Reference values from OpenMolcas v22.02, tag 177-gc48a1862b
-        # Ignoring the PDFT energies and final states because of grid nonsense
+    def test_lih_adiabats(self):
         e_mcscf_avg = np.dot (lih.e_mcscf, lih.weights)
 
         hcoup = abs (lih.heff_mcscf[1,0])
-        ct_mcscf = abs (lih.si_mcscf[0,0])
 
         E_MCSCF_EXPECTED = -7.78902185
-        E_STATES_EXPECTED = [-7.85862852, -7.6998051]
+        E_STATES_EXPECTED = [-7.9108699492171475, -7.7549375652733685]
         HCOUP_EXPECTED = 0.019960046518608488
 
         self.assertAlmostEqual (e_mcscf_avg, E_MCSCF_EXPECTED, 7)
         self.assertListAlmostEqual(lih.e_states, E_STATES_EXPECTED, 7)
         self.assertAlmostEqual (hcoup, HCOUP_EXPECTED, 7)
-        self.assertAlmostEqual (ct_mcscf, 0.9886771524332543, 7)
+
+    def test_h2_adiabats(self):
+        e_mcscf_avg = np.dot(h2.e_mcscf, h2.weights)
+
+        # Reference Values from OpenMolcas v22.10
+        # tag 462-g00b34a15f
+        E_MCSCF_EXPECTED = -0.68103595
+        E_STATES_EXPECTED = [-1.15358469, -0.48247557]
+        HCOUP_EXPECTED = 0
+
+        hcoup = abs(h2.heff_mcscf[1, 0])
+
+        self.assertAlmostEqual(e_mcscf_avg, E_MCSCF_EXPECTED, 5)
+        self.assertListAlmostEqual(h2.e_states, E_STATES_EXPECTED, 5)
+        self.assertAlmostEqual(hcoup, HCOUP_EXPECTED, 5)
+
 
 if __name__ == "__main__":
     print("Full Tests for XMS-PDFT")

--- a/pyscf/mcpdft/test/test_xmspdft.py
+++ b/pyscf/mcpdft/test/test_xmspdft.py
@@ -1,0 +1,51 @@
+
+import numpy as np
+from pyscf import gto, scf, mcpdft
+
+import unittest
+
+def get_lih (r):
+    mol = gto.M (atom='Li 0 0 0\nH {} 0 0'.format (r), basis='sto3g',
+                 output='/dev/null', verbose=0)
+    mf = scf.RHF (mol).run ()
+    mc = mcpdft.CASSCF (mf, 'ftLDA,VWN3', 2, 2, grids_level=1)
+    mc.fix_spin_(ss=0)
+    mc = mc.multi_state ([0.5,0.5], 'xms').run (conv_tol=1e-8)
+    return mol, mf, mc
+
+def setUpModule():
+    global mol, mf, lih
+    mol, mf, lih = get_lih (1.5)
+
+def tearDownModule():
+    global mol, mf, lih
+    mol.stdout.close ()
+    del mol, mf, lih
+
+class KnownValues(unittest.TestCase):
+
+    def assertListAlmostEqual(self, first_list, second_list, expected):
+        self.assertTrue(len(first_list) == len(second_list))
+        for first, second in zip(first_list, second_list):
+            self.assertAlmostEqual(first, second, expected)
+
+    def test_lih_diabats (self):
+        # Reference values from OpenMolcas v22.02, tag 177-gc48a1862b
+        # Ignoring the PDFT energies and final states because of grid nonsense
+        e_mcscf_avg = np.dot (lih.e_mcscf, lih.weights)
+
+        hcoup = abs (lih.heff_mcscf[1,0])
+        ct_mcscf = abs (lih.si_mcscf[0,0])
+
+        E_MCSCF_EXPECTED = -7.78902185
+        E_STATES_EXPECTED = [-7.85862852, -7.6998051]
+        HCOUP_EXPECTED = 0.019960046518608488
+
+        self.assertAlmostEqual (e_mcscf_avg, E_MCSCF_EXPECTED, 7)
+        self.assertListAlmostEqual(lih.e_states, E_STATES_EXPECTED, 7)
+        self.assertAlmostEqual (hcoup, HCOUP_EXPECTED, 7)
+        self.assertAlmostEqual (ct_mcscf, 0.9886771524332543, 7)
+
+if __name__ == "__main__":
+    print("Full Tests for XMS-PDFT")
+    unittest.main()

--- a/pyscf/mcpdft/test/test_xmspdft.py
+++ b/pyscf/mcpdft/test/test_xmspdft.py
@@ -1,37 +1,27 @@
 
 import numpy as np
-from math import cos, sin, pi
 from pyscf import gto, scf, mcpdft
+from pyscf.mcpdft import xmspdft
 
 import unittest
 
-def get_lih (r):
+def get_lih(r):
     mol = gto.M (atom='Li 0 0 0\nH {} 0 0'.format (r), basis='sto3g',
                  output='/dev/null', verbose=0)
     mf = scf.RHF (mol).run ()
-    mc = mcpdft.CASSCF (mf, 'tPBE', 2, 2, grids_level=1)
+    mc = mcpdft.CASSCF (mf, 'ftLDA,VWN3', 2, 2, grids_level=1)
     mc.fix_spin_(ss=0)
     mc = mc.multi_state ([0.5,0.5], 'xms').run (conv_tol=1e-8)
     return mol, mf, mc
 
-def get_h2(r):
-    mol = gto.M(atom='H 0 0 0\n H {} 0 0'.format(r), basis='sto3g', output='/dev/null', verbose=0)
-    mf = scf.RHF(mol).run()
-    mc = mcpdft.CASSCF(mf, 'tPBE', 2, 2, grids_level=6)
-    mc.fix_spin_(ss=0, shift=1)
-    mc = mc.multi_state([0.5, 0.5], 'xms').run(conv_tol=1e-8)
-    return mol, mf, mc
-
-
 def setUpModule():
-    global mol, mf, lih, h2
-    mol, mf, lih = get_lih (1.5)
-    _, _, h2 = get_h2(0.8)
+    global mol, mf, mc
+    mol, mf, mc = get_lih(1.5)
 
 def tearDownModule():
-    global mol, mf, lih, h2
-    mol.stdout.close ()
-    del mol, mf, lih, h2
+    global mol, mf, mc
+    mol.stdout.close()
+    del mol, mf, mc
 
 class KnownValues(unittest.TestCase):
 
@@ -40,34 +30,36 @@ class KnownValues(unittest.TestCase):
         for first, second in zip(first_list, second_list):
             self.assertAlmostEqual(first, second, expected)
 
+    # Reference values from
+    # - PySCF        hash 8ae2bb2eefcd342c52639097517b1eda7ca5d1cd
+    # - PySCF-forge  hash 5b8ab86a31917ca1a6b414f7a590c4046b9a8994
+    #
+    # Implementation with those hashes verified with OpenMolcas
+    # (tag 462-g00b34a15f)
+    def test_lih_diabats(self):
+        e_mcscf_avg = np.dot(mc.e_mcscf, mc.weights)
+        hcoup = abs(mc.heff_mcscf[1,0])
+        ct_mcscf = abs(mc.si_mcscf[0,0])
+
+        HCOUP_EXPECTED = 0.01996004651860848
+        CT_MCSCF_EXPECTED = 0.9886771524332543
+        E_MCSCF_AVG_EXPECTED = -7.789021830554006
+
+        self.assertAlmostEqual (e_mcscf_avg, E_MCSCF_AVG_EXPECTED, 9)
+        self.assertAlmostEqual (hcoup, HCOUP_EXPECTED, 9)
+        self.assertAlmostEqual (ct_mcscf, CT_MCSCF_EXPECTED, 9)
+
+    def test_lih_safock(self):
+        safock = xmspdft.make_fock_mcscf(mc, ci=mc.get_ci_adiabats(uci="MCSCF"))
+        EXPECTED_SA_FOCK_DIAG = [-4.207598506457942, -3.88169762424571]
+        EXPECTED_SA_FOCK_OFFDIAG = 0.05063053788053997
+
+        self.assertListAlmostEqual(safock.diagonal(), EXPECTED_SA_FOCK_DIAG, 9)
+        self.assertAlmostEqual(abs(safock[0,1]),EXPECTED_SA_FOCK_OFFDIAG, 9)
+
     def test_lih_adiabats(self):
-        e_mcscf_avg = np.dot (lih.e_mcscf, lih.weights)
-
-        hcoup = abs (lih.heff_mcscf[1,0])
-
-        E_MCSCF_EXPECTED = -7.78902185
-        E_STATES_EXPECTED = [-7.9108699492171475, -7.7549375652733685]
-        HCOUP_EXPECTED = 0.019960046518608488
-
-        self.assertAlmostEqual (e_mcscf_avg, E_MCSCF_EXPECTED, 7)
-        self.assertListAlmostEqual(lih.e_states, E_STATES_EXPECTED, 7)
-        self.assertAlmostEqual (hcoup, HCOUP_EXPECTED, 7)
-
-    def test_h2_adiabats(self):
-        e_mcscf_avg = np.dot(h2.e_mcscf, h2.weights)
-
-        # Reference Values from OpenMolcas v22.10
-        # tag 462-g00b34a15f
-        E_MCSCF_EXPECTED = -0.68103595
-        E_STATES_EXPECTED = [-1.15358469, -0.48247557]
-        HCOUP_EXPECTED = 0
-
-        hcoup = abs(h2.heff_mcscf[1, 0])
-
-        self.assertAlmostEqual(e_mcscf_avg, E_MCSCF_EXPECTED, 5)
-        self.assertListAlmostEqual(h2.e_states, E_STATES_EXPECTED, 5)
-        self.assertAlmostEqual(hcoup, HCOUP_EXPECTED, 5)
-
+        E_STATES_EXPECTED = [-7.858628517291297, -7.69980510010583]
+        self.assertListAlmostEqual(mc.e_states, E_STATES_EXPECTED, 9)
 
 if __name__ == "__main__":
     print("Full Tests for XMS-PDFT")

--- a/pyscf/mcpdft/xmspdft.py
+++ b/pyscf/mcpdft/xmspdft.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def safock_energies(mc, mo_coeff=None, ci=None, h2eff=None, eris=None):
+    '''The "objective" function we are optimizing when solving for the 
+    SA-Fock eigenstates is that the SA-Fock energy (total or average) is
+    minimized with the constraint to the final states being orthonormal.
+    '''
+    return None, 0, None, 
+
+def solve_safock(mc, mo_coeff=None, ci=None):
+    pass

--- a/pyscf/mcpdft/xmspdft.py
+++ b/pyscf/mcpdft/xmspdft.py
@@ -58,8 +58,8 @@ def fock_h1e_for_cas(mc, sa_casdm1s, mo_coeff=None, ncas=None, ncore=None):
     dm1 = dm1s[0] + dm1s[1]
     v_j, v_k = mc._scf.get_jk(dm=dm1)
 
-    hcore_eff = mc.get_hcore() + v_j - v_k/2.0
-    energy_core = mc._scf.energy_nuc ()
+    hcore_eff = mc.get_hcore() + v_j - v_k / 2.0
+    energy_core = mc._scf.energy_nuc()
 
     if mo_core.size != 0:
         core_dm = np.dot(mo_core, mo_core.conj().T) * 2
@@ -68,6 +68,7 @@ def fock_h1e_for_cas(mc, sa_casdm1s, mo_coeff=None, ncas=None, ncore=None):
     h1eff = reduce(np.dot, (mo_cas.conj().T, hcore_eff, mo_cas))
 
     return h1eff, energy_core
+
 
 def make_fock_mcscf(mc, mo_coeff=None, ci=None, weights=None):
     '''Compute the SA-Fock Hamiltonian/Matrix
@@ -108,7 +109,8 @@ def make_fock_mcscf(mc, mo_coeff=None, ci=None, weights=None):
 
 
 def diagonalize_safock(mc, mo_coeff=None, ci=None):
-    '''Diagonalizes the SA-Fock matrix. Returns the eigenvalues and eigenvectors.'''
+    '''Diagonalizes the SA-Fock matrix. Returns the eigenvalues and
+    eigenvectors. '''
     if mo_coeff is None: mo_coeff = mc.mo_coeff
     if ci is None: ci = mc.ci
 
@@ -138,15 +140,36 @@ def safock_energy(mc, **kwargs):
             Should be the Lagrange multiplier terms. Currently returning None
             since we cannot do gradients yet.
     '''
-    dsa_fock = np.zeros(int(mc.fcisolver.nroots*(mc.fcisolver.nroots-1)/2))
+    dsa_fock = np.zeros(
+        int(mc.fcisolver.nroots * (mc.fcisolver.nroots - 1) / 2))
     # TODO fix, this redundacy...no need to compute fock matrix twice..
     e_states, _ = diagonalize_safock(mc)
 
     return np.dot(e_states, mc.weights), dsa_fock, None
 
 
-def solve_safock(mc, mo_coeff=None, ci=None,):
-    '''Diabatize Function'''
+def solve_safock(mc, mo_coeff=None, ci=None, ):
+    '''Diabatize Function. Finds the SA-Fock Eigenstates within the model space
+    spanned by the CI vectors.
+
+    Args:
+        mc : instance of class _PDFT
+
+        mo_coeff : ndarray of shape (nao,nmo)
+            A full set of molecular orbital coefficients. Taken from
+            self if not provided.
+
+        ci : ndarray of shape (nroots)
+            CI vectors should be from a converged CASSCF/CASCI calculation
+
+    Returns:
+        conv : bool
+            Always true. If there is a convergence issue, scipy will raise an
+            exception.
+
+        ci : list of ndarrays of length = nroots
+            CI vectors of the optimized diabatic states
+    '''
     if mo_coeff is None: mo_coeff = mc.mo_coeff
     if ci is None: ci = mc.ci
 

--- a/pyscf/mcpdft/xmspdft.py
+++ b/pyscf/mcpdft/xmspdft.py
@@ -14,12 +14,129 @@
 # limitations under the License.
 #
 
-def safock_energies(mc, mo_coeff=None, ci=None, h2eff=None, eris=None):
-    '''The "objective" function we are optimizing when solving for the 
-    SA-Fock eigenstates is that the SA-Fock energy (total or average) is
-    minimized with the constraint to the final states being orthonormal.
+from functools import reduce
+import numpy as np
+from scipy import linalg
+
+from pyscf.mcpdft import _dms
+from pyscf.fci import direct_spin1
+
+
+def weighted_average_densities(mc, ci=None, weights=None):
+    '''Compute the weighted average 1- and 2-electron CAS densities.
+    1-electron CAS is returned as spin-separated.
+
+    Args:
+        mc : instance of class _PDFT
+        ci : list of ndarrays of length nroots
+            CI vectors should be from a converged CASSCF/CASCI calculation
+        weights : ndarray of length nroots
+            Weight for each state. If none, uses weights from SA-CASSCF
+            calculation
+    Returns:
+        A tuple, the first is casdm1s and the second is casdm2 where they are
+        weighted averages where the weights are given.
     '''
-    return None, 0, None, 
+
+    return _dms.make_weighted_casdm1s(mc, ci=ci,
+                                      weights=weights), _dms.make_weighted_casdm2(
+        mc, ci=ci, weights=weights)
+
+def fock_h1e_for_cas(mc, sa_casdm1s, mo_coeff=None, ncas=None, ncore=None):
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ncas is None: ncas = mc.ncas
+    if ncore is None: ncore = mc.ncore
+
+    nocc = ncore + ncas
+    mo_core = mo_coeff[:, :ncore]
+    mo_cas = mo_coeff[:, ncore:nocc]
+
+    dm1s = _dms.casdm1s_to_dm1s(mc, casdm1s=sa_casdm1s)
+    dm1 = dm1s[0] + dm1s[1]
+    v_j, v_k = mc._scf.get_jk(dm=dm1)
+
+    hcore_eff = mc.get_hcore() + v_j - v_k/2.0
+    energy_core = mc._scf.energy_nuc ()
+
+    if mo_core.size != 0:
+        core_dm = np.dot(mo_core, mo_core.conj().T) * 2
+        energy_core += np.einsum('ij,ji', core_dm, hcore_eff).real
+
+    h1eff = reduce(np.dot, (mo_cas.conj().T, hcore_eff, mo_cas))
+
+    return h1eff, energy_core
+
+def make_fock_mcscf(mc, mo_coeff=None, ci=None, weights=None):
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+
+    ncas = mc.ncas
+
+    sa_casdm1s = _dms.make_weighted_casdm1s(mc, ci=ci)
+    h1, h0 = fock_h1e_for_cas(mc, sa_casdm1s)
+    hc_all = [direct_spin1.contract_1e(h1, c, ncas, mc.nelecas) for c in ci]
+    safock_ham = np.tensordot(ci, hc_all, axes=((1, 2), (1, 2)))
+    idx = np.diag_indices_from(safock_ham)
+    safock_ham[idx] += h0
+
+    return safock_ham
+
+
+def safock_energy(mc, mo_coeff=None, ci=None, h2eff=None, eris=None):
+    '''Diabatizer Function
+
+    The "objective" function we are optimizing when solving for the
+    SA-Fock eigenstates is that the SA-Fock energy (average) is
+    minimized with the constraint to the final states being orthonormal.
+
+    Returns:
+        SA-Fock Energy : float
+            weighted sum of SA-Fock energies
+        dSA-Fock Energy : ndarray of shape npair = nroots*(nroots - 1)/2
+            first derivative of the SA-Fock energy wrt interstate rotation
+            This is zero by default since we diagonalize a matrix
+        d2SA-Fock Energy : ndarray of shape (npair,npair)
+            Should be the Lagrange multiplier terms. Currently returning None
+            since we cannot do gradients yet.
+    '''
+    dsa_fock = np.zeros(int(mc.fcisolver.nroots*(mc.fcisolver.nroots-1)/2))
+    # TODO fix, this redundacy...no need to compute fock matrix twice..
+    e_states, _ = diagonalize_safock(mc)
+
+    return np.dot(e_states, mc.weights), dsa_fock, None
+
+
+def diagonalize_safock(mc, mo_coeff=None, ci=None):
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+
+    fock = make_fock_mcscf(mc, mo_coeff=mo_coeff, ci=ci)
+    return linalg.eigh(fock)
+
 
 def solve_safock(mc, mo_coeff=None, ci=None):
-    pass
+    '''Diabatize Function'''
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+
+    e_states, si_pdft = diagonalize_safock(mc, mo_coeff, ci)
+
+    ci = np.tensordot(si_pdft.T, ci, 1)
+    conv = True
+
+    return conv, ci
+
+
+if __name__ == "__main__":
+    from pyscf import scf, gto
+    from pyscf import mcpdft
+
+    xyz = '''O  0.00000000   0.08111156   0.00000000
+                 H  0.78620605   0.66349738   0.00000000
+                 H -0.78620605   0.66349738   0.00000000'''
+    mol = gto.M(atom=xyz, basis='sto-3g', symmetry=False,
+                verbose=5)
+    mf = scf.RHF(mol).run()
+    mc = mcpdft.CASSCF(mf, 'tPBE', 4, 4)
+    mc.fix_spin_(ss=0)
+    mc = mc.multi_state([1.0 / 3, ] * 3, 'xms').run()


### PR DESCRIPTION
Implementation of Extended Multi-state Pair-Density Functional Theory (XMS-PDFT) (as described here https://doi.org/10.1039/D0FD00037J)

This method was previously implemented in OpenMolcas. I have verified the results here are consistent with those of OpenMolcas (v22.10, tag 462-g00b34a15f) (including when unequal weights are used to construct the SA-Fock Matrix). In general, the interface is the same as CMS-PDFT (`diabatization="xms`).

Tests for lih with 2 states and unequal weights is provided.

I have updated the MC-PDFT docs as well as the multi-state example.

Note: I believe once either this or my other PR (PR https://github.com/pyscf/pyscf-forge/pull/13) is accepted, a slight merge reconciliation will have to occur as the other PR changes might have affected the interface/docs. I guess we will see.