### PR TITLE
Lpdft samix

### DIFF
--- a/examples/mcpdft/43-multi_state_mix.py
+++ b/examples/mcpdft/43-multi_state_mix.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+
+'''
+Perform multi-state PDFT averaging over states of different spins and/or spatial symmetry
+
+The mcpdft.multi_state function maybe not generate the right spin or spatial
+symmetry as one needs.  This example shows how to put states with different
+spins and spatial symmetry in a state-average solver using the method
+multi_state_mix.
+'''
+
+import numpy as np
+from pyscf import gto, scf, mcpdft, fci
+
+mol = gto.M(atom='''
+   O     0.    0.000    0.1174
+   H     0.    0.757   -0.4696
+   H     0.   -0.757   -0.4696
+      ''', symmetry=True, basis="6-31G", verbose=3)
+
+mf = scf.RHF(mol).run()
+
+#
+# state-average over 1 triplet + 2 singlets
+# Note direct_spin1 solver is called here because the CI solver will take
+# spin-mix solution as initial guess which may break the spin symmetry
+# required by direct_spin0 solver
+#
+weights = np.ones(3) / 3
+solver1 = fci.direct_spin1_symm.FCI(mol)
+solver1.spin = 2
+solver1 = fci.addons.fix_spin(solver1, shift=.2, ss=2)
+solver1.nroots = 1
+solver2 = fci.direct_spin0_symm.FCI(mol)
+solver2.spin = 0
+solver2.nroots = 2
+
+mc = mcpdft.CASSCF(mf, "tPBE", 4, 4, grids_level=1)
+# Currently, only the Linearized PDFT method is available for
+# multi_state_mix
+mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
+mc.run()
+
+
+#
+# Example 2: Mix FCI wavefunctions with different symmetry irreps
+#
+mol = gto.Mole()
+mol.build(atom='''
+ O     0.    0.000    0.1174
+ H     0.    0.757   -0.4696
+ H     0.   -0.757   -0.4696
+''', symmetry=True, basis='631g', verbose=3)
+
+mf = scf.RHF(mol).run()
+
+weights = [.5, .5]
+solver1 = fci.direct_spin1_symm.FCI(mol)
+solver1.wfnsym= 'A1'
+solver1.spin = 0
+solver2 = fci.direct_spin1_symm.FCI(mol)
+solver2.wfnsym= 'A2'
+solver2.spin = 2
+
+mc = mcpdft.CASSCF(mf, "tPBE", 4, 4, grids_level=1)
+mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
+mc.kernel()

--- a/examples/mcpdft/43-multi_state_mix.py
+++ b/examples/mcpdft/43-multi_state_mix.py
@@ -2,7 +2,8 @@
 
 
 '''
-Perform multi-state PDFT averaging over states of different spins and/or spatial symmetry
+Perform multi-state PDFT averaging over states of different spins
+and/or spatial symmetry
 
 The mcpdft.multi_state function maybe not generate the right spin or spatial
 symmetry as one needs.  This example shows how to put states with different
@@ -55,6 +56,8 @@ mol.build(atom='''
 
 mf = scf.RHF(mol).run()
 
+# Also possible to construct 2 solvers of different wfnsym, but
+# of the same spin symmetry
 weights = [.5, .5]
 solver1 = fci.direct_spin1_symm.FCI(mol)
 solver1.wfnsym= 'A1'

--- a/pyscf/mcpdft/_dms.py
+++ b/pyscf/mcpdft/_dms.py
@@ -230,8 +230,7 @@ def make_weighted_casdm1s(mc, ci=None, weights=None):
 
     # There might be a better way to construct all of them, but this should be
     # more cost-effective than what is currently in the _dms file.
-    fcisolver, _, nelecas = _get_fcisolver(mc, ci)
-    casdm1s_all = [fcisolver.make_rdm1s(c, ncas, nelecas) for c in ci]
+    casdm1s_all = [make_one_casdm1s(mc, ci, state) for state in range(len(ci))]
     casdm1s_0 = np.tensordot(weights, casdm1s_all, axes=1)
     return tuple(casdm1s_0)
 
@@ -257,6 +256,13 @@ def make_weighted_casdm2(mc, ci=None, weights=None):
 
     # There might be a better way to construct all of them, but this should be
     # more cost-effective than what is currently in the _dms file.
-    fcisolver, _, nelecas = _get_fcisolver(mc, ci)
-    casdm2_all = [fcisolver.make_rdm2(c, ncas, nelecas) for c in ci]
+    casdm2_all = [make_one_casdm2(mc, ci, state) for state in range(len(ci))]
     return np.tensordot(weights, casdm2_all, axes=1)
+
+def contract_2e(mc, h2eff, ci, state=0):
+    ncas = mc.ncas
+    fcisolver, ci, nelecas = _get_fcisolver(mc, ci, state=state)
+    if hasattr(fcisolver, "orbsym"):
+        fcisolver.orbsym = mc.fcisolver.orbsym
+    return fcisolver.contract_2e(h2eff, ci, ncas, nelecas)
+

--- a/pyscf/mcpdft/_dms.py
+++ b/pyscf/mcpdft/_dms.py
@@ -258,11 +258,3 @@ def make_weighted_casdm2(mc, ci=None, weights=None):
     # more cost-effective than what is currently in the _dms file.
     casdm2_all = [make_one_casdm2(mc, ci, state) for state in range(len(ci))]
     return np.tensordot(weights, casdm2_all, axes=1)
-
-def contract_2e(mc, h2eff, ci, state=0):
-    ncas = mc.ncas
-    fcisolver, ci, nelecas = _get_fcisolver(mc, ci, state=state)
-    if hasattr(fcisolver, "orbsym"):
-        fcisolver.orbsym = mc.fcisolver.orbsym
-    return fcisolver.contract_2e(h2eff, ci, ncas, nelecas)
-

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -426,21 +426,10 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
         nroots = len(self.e_states)
         log.note("%s (final) states:", self.__class__.__name__)
         if log.verbose >= logger.NOTE and getattr(self.fcisolver, 'spin_square',
-                                                  None):
-            if isinstance(mc.fcisolver, StateAverageMixFCISolver):
-                solvers = [_dms._get_fcisolver(mc, self.ci, state)[0] for state in range(nroots)]
+                                                  None) and not isinstance(self.fcisolver, StateAverageMixFCISolver):
+            ci = np.tensordot(self.si_pdft, np.asarray(self.ci), axes=1)
 
-                last_idx = 0
-                ss = []
-                for idx, s in enumerate(solvers):
-                    if s is not solvers[last_idx]:
-                        ci = np.tensordot(self.si_pdft[last_idx:idx,last_idx:idx], np.asarray(self.ci[last_idx:idx,last_idx:idx]), axes=1)
-                        ss.extend(s.states_spin_square(ci, self.ncas, self.nelecas)[0])
-                        last_idx = idx
-
-            else:
-                ci = np.tensordot(self.si_pdft, np.asarray(self.ci), axes=1)
-                ss = self.fcisolver.states_spin_square(ci, self.ncas, self.nelecas)[0]
+            ss = self.fcisolver.states_spin_square(ci, self.ncas, self.nelecas)[0]
 
             for i in range(nroots):
                 log.note('  State %d weight %g  ELPDFT = %.15g  S^2 = %.7f',

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -533,7 +533,7 @@ class _LPDFTMix(_LPDFT):
         adiabat_ci = [np.tensordot(self.si_pdft[irrep_slice, irrep_slice], np.asarray(ci[irrep_slice]), axes=1) for
                       irrep_slice in self._irrep_slices]
         # Flattens it
-        return np.concatenate(adiabat_ci)
+        return [c for ci_irrep in adiabat_ci for c in ci_irrep]
 
 
 def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -436,15 +436,50 @@ def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):
     if isinstance(mc, mcpdft.MultiStateMCPDFTSolver):
         raise RuntimeError('already a multi-state PDFT solver')
 
-    # if isinstance(mc.fcisolver, StateAverageMixFCISolver):
-    #     raise RuntimeError("state-average mix type")
+    if isinstance(mc.fcisolver, StateAverageMixFCISolver):
+        raise RuntimeError("state-average mix type")
 
     if not isinstance(mc, StateAverageMCSCFSolver):
         base_name = mc.__class__.__name__
         mc = mc.state_average(weights=weights, **kwargs)
 
-    elif isinstance(mc.fcisolver, StateAverageMixFCISolver):
+    else:
+        base_name = mc.__class__.bases__[0].__name__
+
+    mcbase_class = mc.__class__
+
+    class LPDFT(_LPDFT, mcbase_class):
+        pass
+
+    LPDFT.__name__ = "LIN" + base_name
+    return LPDFT(mc)
+
+def linear_multi_state_mix(mc, fcisolvers, weights=(0.5, 0.5), **kwargs):
+    ''' Build SA Mix linearized multi-state MC-PDFT method object
+
+    Args:
+        mc : instance of class _PDFT
+
+        fcisolvers : fcisolvers to construct StateAverageMixSolver with
+
+    Kwargs:
+        weights : sequence of floats
+
+    Returns:
+        si : instance of class _LPDFT
+    '''
+    from pyscf.mcscf.addons import StateAverageMCSCFSolver, \
+        StateAverageMixFCISolver
+
+    if isinstance(mc, mcpdft.MultiStateMCPDFTSolver):
+        raise RuntimeError('already a multi-state PDFT solver')
+
+    if not isinstance(mc, StateAverageMCSCFSolver):
         base_name = mc.__class__.__name__
+        mc = mc.state_average_mix(fcisolvers, weights=weights, **kwargs)
+
+    elif not isinstance(mc.fcisolver, StateAverageMixFCISolver):
+        raise RuntimeError("already a StateAverageMCSCF solver")
 
     else:
         base_name = mc.__class__.bases__[0].__name__

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -436,12 +436,15 @@ def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):
     if isinstance(mc, mcpdft.MultiStateMCPDFTSolver):
         raise RuntimeError('already a multi-state PDFT solver')
 
-    if isinstance(mc.fcisolver, StateAverageMixFCISolver):
-        raise RuntimeError("state-average mix type")
+    # if isinstance(mc.fcisolver, StateAverageMixFCISolver):
+    #     raise RuntimeError("state-average mix type")
 
     if not isinstance(mc, StateAverageMCSCFSolver):
         base_name = mc.__class__.__name__
         mc = mc.state_average(weights=weights, **kwargs)
+
+    elif isinstance(mc.fcisolver, StateAverageMixFCISolver):
+        base_name = mc.__class__.__name__
 
     else:
         base_name = mc.__class__.bases__[0].__name__

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -600,6 +600,17 @@ def linear_multi_state_mix(mc, fcisolvers, weights=(0.5, 0.5), **kwargs):
     else:
         base_name = mc.__class__.bases__[0].__name__
 
+    # Have to check if we are trying to do use 2 fci solvers for a singlet
+    # This is not really well-defined for L-PDFT in general, so catch
+    # it now.. Likely they are trying to do 2 solvers with the same spin
+    # but different spatial symmetry. So should we allow the final states
+    # to be no longer pure states? I am not sure..
+    used_spins = []
+    for solver in mc.fcisolver.fcisolvers:
+        if solver.spin in used_spins:
+            raise NotImplementedError("Cannot do L-PDFT with fcisolvers with duplicate spin states")
+        used_spins.append(solver.spin)
+
     mcbase_class = mc.__class__
 
     class LPDFT(_LPDFTMix, mcbase_class):

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -600,17 +600,6 @@ def linear_multi_state_mix(mc, fcisolvers, weights=(0.5, 0.5), **kwargs):
     else:
         base_name = mc.__class__.bases__[0].__name__
 
-    # Have to check if we are trying to do use 2 fci solvers for a singlet
-    # This is not really well-defined for L-PDFT in general, so catch
-    # it now.. Likely they are trying to do 2 solvers with the same spin
-    # but different spatial symmetry. So should we allow the final states
-    # to be no longer pure states? I am not sure..
-    used_spins = []
-    for solver in mc.fcisolver.fcisolvers:
-        if solver.spin in used_spins:
-            raise NotImplementedError("Cannot do L-PDFT with fcisolvers with duplicate spin states")
-        used_spins.append(solver.spin)
-
     mcbase_class = mc.__class__
 
     class LPDFT(_LPDFTMix, mcbase_class):

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Author: Matthew Hennefarth <mhennefarth@uchicago.com>
+
 from functools import reduce
 import numpy as np
 from scipy import linalg

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -620,6 +620,14 @@ class _PDFT ():
          state_average_mix_(self, fcisolvers, weights)
          return self
 
+    def multi_state_mix(self, fcisolvers=None, weights=(0.5,0.5), method='CMS'):
+        if method.upper() == "LIN":
+            from pyscf.mcpdft.lpdft import linear_multi_state_mix
+            return linear_multi_state_mix(self, fcisolvers=fcisolvers, weights=weights)
+
+        else:
+            raise NotImplementedError(f"StateAverageMix not available for {method}")
+
     def multi_state (self, weights=(0.5,0.5), method='CMS'):
         if method.upper() == "LIN":
             from pyscf.mcpdft.lpdft import linear_multi_state

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -38,46 +38,24 @@ def get_lih (r, n_states=2, functional='ftLDA,VWN3', basis='sto3g'):
     mc = mc.run()
     return mc
 
-def get_water(functional='tpbe', basis='6-31g'):
-    mol = gto.M(atom='''
- O     0.    0.000    0.1174
- H     0.    0.757   -0.4696
- H     0.   -0.757   -0.4696
-    ''',symmetry=True, basis=basis, output='/dev/null', verbose=0)
-
-    mf = scf.RHF(mol).run()
-
-    weights = [0.5, 0.5]
-    solver1 = fci.direct_spin1_symm.FCI(mol)
-    solver1.wfnsym = 'A1'
-    solver1.spin = 0
-    solver2 = fci.direct_spin1_symm.FCI(mol)
-    solver2.wfnsym = 'A2'
-    solver2.spin = 0
-
-    mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
-    mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
-    mc.run()
-    return mc
-
-# def get_cc(r, functional='tPBE', basis='6-31G'):
-#     mol = gto.Mole(atom=[
-#         ['C', (0., 0., -r / 2)],
-#         ['C', (0., 0., r / 2)], ], basis=basis, unit='B', symmetry=True, output='/dev/null', verbose=0)
-#     mol.build()
+# def get_water(functional='tpbe', basis='6-31g'):
+#     mol = gto.M(atom='''
+#  O     0.    0.000    0.1174
+#  H     0.    0.757   -0.4696
+#  H     0.   -0.757   -0.4696
+#     ''',symmetry=True, basis=basis, output='/dev/null', verbose=0)
 #
 #     mf = scf.RHF(mol).run()
 #
-#     weights = np.ones(3) / 3
+#     weights = [0.5, 0.5]
 #     solver1 = fci.direct_spin1_symm.FCI(mol)
-#     solver1.spin = 2
-#     solver1 = fci.addons.fix_spin(solver1, shift=.2, ss=2)
-#     solver1.nroots = 1
-#     solver2 = fci.direct_spin0_symm.FCI(mol)
+#     solver1.wfnsym = 'A1'
+#     solver1.spin = 0
+#     solver2 = fci.direct_spin1_symm.FCI(mol)
+#     solver2.wfnsym = 'A2'
 #     solver2.spin = 0
-#     solver2.nroots = 2
 #
-#     mc = mcpdft.CASSCF(mf, functional, 6, 6, grids_level=1)
+#     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
 #     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
 #     mc.run()
 #     return mc
@@ -107,23 +85,21 @@ def get_water_triplet(functional='tPBE', basis="6-31G"):
 
 
 def setUpModule():
-    global lih, lih_4, lih_tpbe, lih_tpbe0, water, t_water
+    global lih, lih_4, lih_tpbe, lih_tpbe0, t_water
     lih = get_lih(1.5)
     lih_4 = get_lih(1.5, n_states=4, basis="6-31G")
     lih_tpbe = get_lih(1.5, functional="tPBE")
     lih_tpbe0 = get_lih(1.5, functional="tPBE0")
-    water = get_water()
     t_water = get_water_triplet()
 
 def tearDownModule():
-    global lih, lih_4, lih_tpbe0, lih_tpbe, water, t_water
+    global lih, lih_4, lih_tpbe0, lih_tpbe, t_water
     lih.mol.stdout.close()
     lih_4.mol.stdout.close()
     lih_tpbe0.mol.stdout.close()
     lih_tpbe.mol.stdout.close()
-    water.mol.stdout.close()
     t_water.mol.stdout.close()
-    del lih, lih_4, lih_tpbe0, lih_tpbe, water, t_water
+    del lih, lih_4, lih_tpbe0, lih_tpbe, t_water
 
 class KnownValues(unittest.TestCase):
 
@@ -197,21 +173,21 @@ class KnownValues(unittest.TestCase):
         self.assertListAlmostEqual(lih_tpbe0.e_states, e_hlpdft, 9)
         self.assertListAlmostEqual(hlpdft_ham.flatten(), lih_tpbe0.lpdft_ham.flatten(), 9)
 
-    def test_water_spatial_samix(self):
-        e_mcscf_avg = np.dot(water.e_mcscf, water.weights)
-        hdiag = water.get_lpdft_diag()
-        e_states = water.e_states
-
-        # References values from
-        #     - PySCF       commit 8ae2bb2eefcd342c52639097517b1eda7ca5d1cd
-        #     - PySCF-forge commit 2c75a59604c458069ebda550e84a866ec1be45dc
-        E_MCSCF_AVG_EXPECTED = -75.81489195169507
-        HDIAG_EXPECTED = [-76.29913074162732, -75.93502437481517]
-
-        self.assertAlmostEqual(e_mcscf_avg, E_MCSCF_AVG_EXPECTED, 7)
-        self.assertListAlmostEqual(hdiag, HDIAG_EXPECTED, 7)
-        # The off-diagonal should be identical to zero because of symmetry
-        self.assertListAlmostEqual(e_states, hdiag, 10)
+    # def test_water_spatial_samix(self):
+    #     e_mcscf_avg = np.dot(water.e_mcscf, water.weights)
+    #     hdiag = water.get_lpdft_diag()
+    #     e_states = water.e_states
+    #
+    #     # References values from
+    #     #     - PySCF       commit 8ae2bb2eefcd342c52639097517b1eda7ca5d1cd
+    #     #     - PySCF-forge commit 2c75a59604c458069ebda550e84a866ec1be45dc
+    #     E_MCSCF_AVG_EXPECTED = -75.81489195169507
+    #     HDIAG_EXPECTED = [-76.29913074162732, -75.93502437481517]
+    #
+    #     self.assertAlmostEqual(e_mcscf_avg, E_MCSCF_AVG_EXPECTED, 7)
+    #     self.assertListAlmostEqual(hdiag, HDIAG_EXPECTED, 7)
+    #     # The off-diagonal should be identical to zero because of symmetry
+    #     self.assertListAlmostEqual(e_states, hdiag, 10)
 
     def test_water_spin_samix(self):
         e_mcscf_avg = np.dot(t_water.e_mcscf, t_water.weights)

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -215,7 +215,7 @@ class KnownValues(unittest.TestCase):
         e_mcscf_avg = np.dot(t_water.e_mcscf, t_water.weights)
         hdiag = t_water.get_lpdft_diag()
         e_states = t_water.e_states
-        hcoup = t_water.get_lpdft_ham()[1,2]
+        hcoup = abs(t_water.get_lpdft_ham()[1,2])
 
         # References values from
         #     - PySCF       commit 8ae2bb2eefcd342c52639097517b1eda7ca5d1cd

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -58,16 +58,14 @@ def get_water(functional='tpbe', basis='6-31g'):
     mc.run()
     return mc
 
-def get_cc(r, functional='tPBE', basis='cc-pvdz'):
+def get_cc(r, functional='tPBE', basis='6-31G'):
     mol = gto.Mole(atom=[
         ['C', (0., 0., -r / 2)],
-        ['C', (0., 0., r / 2)], ], basis=basis, unit='B', symmetry=True, output='tmp.log', verbose=5)
+        ['C', (0., 0., r / 2)], ], basis=basis, unit='B', symmetry=True, output='/dev/null', verbose=0)
+    mol.build()
 
-    mf = scf.RHF(mol)
-    mf.irrep_nelec = {'A1g': 4, 'E1gx': 0, 'E1gy': 0, 'A1u': 4,
-                      'E1uy': 2, 'E1ux': 2, 'E2gx': 0, 'E2gy': 0, 'E2uy': 0, 'E2ux': 0}
+    mf = scf.RHF(mol).run()
 
-    mf.kernel()
     weights = np.ones(3) / 3
     solver1 = fci.direct_spin1_symm.FCI(mol)
     solver1.spin = 2
@@ -77,7 +75,7 @@ def get_cc(r, functional='tPBE', basis='cc-pvdz'):
     solver2.spin = 0
     solver2.nroots = 2
 
-    mc = mcpdft.CASSCF(mf, functional, 8, 8, grids_level=1)
+    mc = mcpdft.CASSCF(mf, functional, 6, 6, grids_level=1)
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
     mc.run()
     return mc

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -53,7 +53,7 @@ def get_water(functional='tpbe', basis='6-31g'):
     solver1.spin = 0
     solver2 = fci.direct_spin1_symm.FCI(mol)
     solver2.wfnsym = 'A2'
-    solver2.spin = 0
+    solver2.spin = 2
 
     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -177,7 +177,6 @@ class KnownValues(unittest.TestCase):
     def test_water_spatial_samix(self):
         e_mcscf_avg = np.dot(water.e_mcscf, water.weights)
         hdiag = water.get_lpdft_diag()
-        hcoup = water.lpdft_ham[0,1]
         e_states = water.e_states
 
         # References values from
@@ -185,12 +184,10 @@ class KnownValues(unittest.TestCase):
         #     - PySCF-forge commit 5338d3060033d60b47e0c89cfcfe9427c34ff24a
         E_MCSCF_AVG_EXPECTED = -75.81489195169507
         HDIAG_EXPECTED = [-76.29913074162732, -75.93502437481517]
-        HCOUP_EXPECTED = 0.0
 
         self.assertAlmostEqual(e_mcscf_avg, E_MCSCF_AVG_EXPECTED, 7)
         self.assertListAlmostEqual(hdiag, HDIAG_EXPECTED, 7)
         # The off-diagonal should be identical to zero because of symmetry
-        self.assertAlmostEqual(hcoup, HCOUP_EXPECTED, 10)
         self.assertListAlmostEqual(e_states, hdiag, 10)
 
     def test_C2_spin_samix(self):

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Author: Matthew Hennefarth <mhennefarth@uchicago.com>
+
 import numpy as np
 from pyscf import gto, scf, fci
 from pyscf import mcpdft

--- a/pyscf/mcpdft/xmspdft.py
+++ b/pyscf/mcpdft/xmspdft.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Author: Matthew Hennefarth <mhennefarth@uchicago.com>
 
 from functools import reduce
 import numpy as np


### PR DESCRIPTION
Implementation of StateAverageMix solvers for L-PDFT. Since the L-PDFT Hamiltonian transforms as the real electronic Hamiltonian, it maintains the same spatial and spin symmetries. This is unlike in other MS-PDFT methods like CMS-PDFT and XMS-PDFT where this behavior is not really well-defined. 

Here I introduce a new function `multi_state_mix()` which acts just like the correspondence between `state_average` and `multi_state` as to the `state_average_mix()` method. The underlying functionality of `make_lpdft_ham()` is generalized to multiple solvers so that it constructs the matrix within each space defined by the solver, but in an efficient manner (ie only a single quadrature calculation). I deal with the necessary headaches of having a list of hamiltonian matrices, diagonalizing, as well as finally transforming the final CI vectors (which may be of different lengths) into their approriate form as the eigenvalues of the L-PDFT Hamiltonian operator (see the `get_adiabat_ci()` method).

I have updated the tests and added a new example of how to use this. 