### PR TITLE
Issue #19 pyprojecttoml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "pyscf", "numpy"]


### PR DESCRIPTION
pip>23.1 no longer emulates setup.py install; see https://github.com/pypa/pip/issues/8559. Is this the way we should go @sunqm? See issue #19 