### PR TITLE
pyscf PR #1623 compatibility and np.int deprecation

### DIFF
--- a/pyscf/grad/test/test_grad_mspdft.py
+++ b/pyscf/grad/test/test_grad_mspdft.py
@@ -81,11 +81,11 @@ class KnownValues(unittest.TestCase):
 
     def test_offdiag_response_sanity (self):
         for mcs, stype in zip (get_mc_list (), ('nosymm','symm')):
-         if 'no' not in stype:
-            continue
-            # TODO: redesign this test case. explicitly mixing CI vectors
-            # like this is undefined behavior
          for mca, atype in zip (mcs, ('nomix','mix')):
+          if 'no' not in atype:
+            continue
+            # TODO: redesign this test case. MS-PDFT "_mix" is undefined except
+            # for L-PDFT and XMS-PDFT, whose gradients aren't implemented yet
           for mc, itype in zip (mca, ('conv', 'DF')):
             ci_arr = np.asarray (mc.ci)
             if itype == 'conv': mc_grad = mc.nuc_grad_method ()
@@ -122,11 +122,11 @@ class KnownValues(unittest.TestCase):
 
     def test_offdiag_grad_sanity (self):
         for mcs, stype in zip (get_mc_list (), ('nosymm','symm')):
-         if 'no' not in stype:
-            continue
-            # TODO: redesign this test case. explicitly mixing CI vectors
-            # like this is undefined behavior
          for mca, atype in zip (mcs, ('nomix','mix')):
+          if 'no' not in atype:
+            continue
+            # TODO: redesign this test case. MS-PDFT "_mix" is undefined except
+            # for L-PDFT and XMS-PDFT, whose gradients aren't implemented yet
           for mc, itype in zip (mca, ('conv', 'DF')):
             ci_arr = np.asarray (mc.ci)
             if itype == 'conv': mc_grad = mc.nuc_grad_method ()

--- a/pyscf/grad/test/test_grad_mspdft.py
+++ b/pyscf/grad/test/test_grad_mspdft.py
@@ -81,6 +81,10 @@ class KnownValues(unittest.TestCase):
 
     def test_offdiag_response_sanity (self):
         for mcs, stype in zip (get_mc_list (), ('nosymm','symm')):
+         if 'no' not in stype:
+            continue
+            # TODO: redesign this test case. explicitly mixing CI vectors
+            # like this is undefined behavior
          for mca, atype in zip (mcs, ('nomix','mix')):
           for mc, itype in zip (mca, ('conv', 'DF')):
             ci_arr = np.asarray (mc.ci)
@@ -118,6 +122,10 @@ class KnownValues(unittest.TestCase):
 
     def test_offdiag_grad_sanity (self):
         for mcs, stype in zip (get_mc_list (), ('nosymm','symm')):
+         if 'no' not in stype:
+            continue
+            # TODO: redesign this test case. explicitly mixing CI vectors
+            # like this is undefined behavior
          for mca, atype in zip (mcs, ('nomix','mix')):
           for mc, itype in zip (mca, ('conv', 'DF')):
             ci_arr = np.asarray (mc.ci)

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -368,6 +368,9 @@ class KnownValues(unittest.TestCase):
                 e_mcscf = np.atleast_1d (mc.e_mcscf)[0]
                 ci = np.zeros_like (mc.ci)
                 ci.flat[0] = 1.0
+                if nroots>1: ci = list (ci)
+                # pyscf PR #1623 made direct_spin1_symm unable to interpret
+                # a 3D fci vector array
                 mc.compute_pdft_energy_(ci=ci)
                 with self.subTest (part='pdft1', symmetry=symmetry, nroots=nroots):
                     self.assertEqual (lib.fp (np.array(mc.ci)), lib.fp (ci), 9)

--- a/pyscf/mcpdft/test/test_otfnal.py
+++ b/pyscf/mcpdft/test/test_otfnal.py
@@ -16,11 +16,13 @@
 import numpy as np
 from scipy import linalg
 from pyscf import gto, scf, lib, mcscf
-from pyscf.dft.libxc import XC_KEYS, XC_ALIAS, is_meta_gga, hybrid_coeff, rsh_coeff
+from pyscf.dft.libxc import XC_KEYS, XC_ALIAS, hybrid_coeff, rsh_coeff
+from pyscf.dft.libxc import parse_xc, is_nlc, _itrf
 from pyscf import mcpdft
 from pyscf.mcpdft.otfnal import make_hybrid_fnal
 from pyscf.mcpdft.otpd import get_ontop_pair_density
 import unittest
+import ctypes
 from itertools import product
 
 h2 = scf.RHF (gto.M (atom = 'H 0 0 0; H 1.2 0 0', basis = 'sto-3g', 
@@ -39,13 +41,31 @@ def test_hybrid_and_decomp (kv, xc):
     e_hyb = mc.energy_tot (otxc=htxc)[0]
     kv.assertAlmostEqual (e_hyb, 0.75*e_pdft+0.25*mc.e_mcscf, 10)
 
+# _itrf.LIBXC_is_meta_gga returns an error code (-1) if the functional isn't found
+# Abuse this to screen broken or unavailable KS-DFT functionals
+# Cf. PySCF issue #1692
+# TODO: revisit after _itrf or libxc.py is improved to handle error codes
+def is_meta_gga_or_broken(xc_code):
+    if xc_code is None:
+        return None
+    elif isinstance(xc_code, str):
+        if is_nlc(xc_code):
+            return 'NLC'
+        hyb, fn_facs = parse_xc(xc_code)
+    else:
+        fn_facs = [(xc_code, 1)]  # mimic fn_facs
+    if not fn_facs:
+        return False
+    else:
+        return any(_itrf.LIBXC_is_meta_gga(ctypes.c_int(xid)) for xid, fac in fn_facs)
+
 def _skip_key (key):
     xc = str (key)
     return (xc in LIBXC_KILLS
             or '_XC_' in xc
             or '_K_' in xc
             or xc.startswith ('HYB_')
-            or is_meta_gga (xc)
+            or is_meta_gga_or_broken (xc)
             or hybrid_coeff (xc)
             or rsh_coeff (xc)[0])
 


### PR DESCRIPTION
PySCF PR #[1623](https://github.com/pyscf/pyscf/pull/1623) made symmetry FCI solvers unable to interpret a 3d ndarray (`shape=(n,*,*)`) as a list of _n_ CI vectors, which was used by one unit test. Here, those are explicitly cast to a list of 2d ndarrays. Also remove a certain unit test case which was always undefined behavior. This presumes PySCF PR #[1721](https://github.com/pyscf/pyscf/pull/1721). See issue #19 and PR #20 concerning the inevitable CI failure. I redid this from PR #18 after getting sick of my master branch git log constantly having a bunch of meaningless "merge master from origin" lines in it.