### PR TITLE
Upgrade einsum calls

### DIFF
--- a/pyscf/grad/cmspdft.py
+++ b/pyscf/grad/cmspdft.py
@@ -206,7 +206,7 @@ def diab_response_o0 (mc_grad, Lis, mo=None, ci=None, eris=None, **kwargs):
     hx_orb, hx_ci = mc_grad.unpack_uniq_var (hx)
     hx_ci = np.asarray (hx_ci)
     hx_is = lib.einsum ('pab,qab->pq', hx_ci, ci_arr.conj ())
-    hx_ci -= lib.einsum ('pq,qab->pab', hx_is, ci_arr)
+    hx_ci -= np.tensordot(hx_is, ci_arr, axes=1)
 
     return mc_grad.pack_uniq_var (hx_orb, hx_ci)
 

--- a/pyscf/grad/cmspdft.py
+++ b/pyscf/grad/cmspdft.py
@@ -205,8 +205,8 @@ def diab_response_o0 (mc_grad, Lis, mo=None, ci=None, eris=None, **kwargs):
     hx *= nroots
     hx_orb, hx_ci = mc_grad.unpack_uniq_var (hx)
     hx_ci = np.asarray (hx_ci)
-    hx_is = np.einsum ('pab,qab->pq', hx_ci, ci_arr.conj ())
-    hx_ci -= np.einsum ('pq,qab->pab', hx_is, ci_arr)
+    hx_is = lib.einsum ('pab,qab->pq', hx_ci, ci_arr.conj ())
+    hx_ci -= lib.einsum ('pq,qab->pab', hx_is, ci_arr)
 
     return mc_grad.pack_uniq_var (hx_orb, hx_ci)
 
@@ -291,10 +291,10 @@ def diab_grad (mc_grad, Lis, atmlst=None, mo=None, ci=None, eris=None,
     aoslices = mol.aoslice_by_atom()
     for k, ia in enumerate(atmlst):
         shl0, shl1, p0, p1 = aoslices[ia]
-        de_renorm[k] -= np.einsum('xpq,pq->x', s1[:,p0:p1], dme0[p0:p1]) * 2
-        de_direct[k] += np.einsum('xipq,ipq->x', dvj[:,:,p0:p1],
+        de_renorm[k] -= lib.einsum('xpq,pq->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+        de_direct[k] += lib.einsum('xipq,ipq->x', dvj[:,:,p0:p1],
             edm1_ao[:,p0:p1]) * 2
-        de_direct[k] += np.einsum('xipq,ipq->x', devj[:,:,p0:p1],
+        de_direct[k] += lib.einsum('xipq,ipq->x', devj[:,:,p0:p1],
             dm1_ao[:,p0:p1]) * 2
     dvj_aux = dvj_aux[:,:,atmlst,:]
     de_aux = (np.trace (dvj_aux, offset=nroots, axis1=0, axis2=1)
@@ -363,14 +363,14 @@ if __name__ == '__main__':
         eris=eris)
     dworb_test, dwci_test = mc_grad.unpack_uniq_var (dw_test)
     dwci_test = np.asarray (dwci_test)
-    dwis_test = np.einsum ('pab,qab->pq', dwci_test, ci_arr.conj ())
-    dwci_test -= np.einsum ('pq,qab->pab', dwis_test, ci_arr)
+    dwis_test = lib.einsum ('pab,qab->pq', dwci_test, ci_arr.conj ())
+    dwci_test -= lib.einsum ('pq,qab->pab', dwis_test, ci_arr)
     dw_ref = diab_response_o0 (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci,
         eris=eris)
     dworb_ref, dwci_ref = mc_grad.unpack_uniq_var (dw_ref)
     dwci_ref = np.asarray (dwci_ref)
-    dwis_ref = np.einsum ('pab,qab->pq', dwci_ref, ci_arr.conj ())
-    dwci_ref -= np.einsum ('pq,qab->pab', dwis_ref, ci_arr)
+    dwis_ref = lib.einsum ('pab,qab->pq', dwci_ref, ci_arr.conj ())
+    dwci_ref -= lib.einsum ('pq,qab->pab', dwis_ref, ci_arr)
     dh_test = diab_grad (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris)
     dh_ref = diab_grad_o0 (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris)
 

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -267,9 +267,9 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     for k, ia in enumerate(atmlst):
         shl0, shl1, p0, p1 = aoslices[ia]
         h1ao = hcore_deriv(ia) # MRH: this should be the TRUE hcore
-        de_hcore[k] += einsum('xij,ij->x', h1ao, dm1)
-        de_renorm[k] -= einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
-        de_coul[k] += einsum('xij,ij->x', vj[:,p0:p1], dm1[p0:p1]) * 2
+        de_hcore[k] += np.tensordot(h1ao, dm1)
+        de_renorm[k] -= np.tensordot(s1[:,p0:p1], dme0[p0:p1]) * 2
+        de_coul[k] += np.tensordot(vj[:,p0:p1], dm1[p0:p1])*2
         de_xc[k] += dvxc[:,p0:p1].sum (1) * 2 # All grids; only some orbitals
 
     de_nuc = mf_grad.grad_nuc(mol, atmlst)

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -16,7 +16,7 @@
 from pyscf.mcscf import newton_casscf, casci, mc1step
 from pyscf.grad import rks as rks_grad
 from pyscf.dft import gen_grid
-from pyscf.lib import logger, pack_tril, current_memory, tag_array
+from pyscf.lib import logger, pack_tril, current_memory, einsum, tag_array
 #from pyscf.grad import sacasscf
 from pyscf.grad import sacasscf
 from pyscf.mcscf.casci import cas_natorb
@@ -83,7 +83,7 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     gfock = np.zeros ((nmo, nmo))
     gfock[:,:ncore] = (h1e_mo[:,:ncore] + vhf_a[:,:ncore]) * 2
     gfock[:,ncore:nocc] = h1e_mo[:,ncore:nocc] @ casdm1
-    gfock[:,ncore:nocc] += np.einsum('uviw,vuwt->it', aapa, casdm2)
+    gfock[:,ncore:nocc] += einsum('uviw,vuwt->it', aapa, casdm2)
     dme0 = reduce(np.dot, (mo_coeff, (gfock+gfock.T)*.5, mo_coeff.T))
     aapa = vhf_a = h1e_mo = gfock = None
 
@@ -267,9 +267,9 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     for k, ia in enumerate(atmlst):
         shl0, shl1, p0, p1 = aoslices[ia]
         h1ao = hcore_deriv(ia) # MRH: this should be the TRUE hcore
-        de_hcore[k] += np.einsum('xij,ij->x', h1ao, dm1)
-        de_renorm[k] -= np.einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
-        de_coul[k] += np.einsum('xij,ij->x', vj[:,p0:p1], dm1[p0:p1]) * 2
+        de_hcore[k] += einsum('xij,ij->x', h1ao, dm1)
+        de_renorm[k] -= einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+        de_coul[k] += einsum('xij,ij->x', vj[:,p0:p1], dm1[p0:p1]) * 2
         de_xc[k] += dvxc[:,p0:p1].sum (1) * 2 # All grids; only some orbitals
 
     de_nuc = mf_grad.grad_nuc(mol, atmlst)

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -21,7 +21,7 @@ from scipy import linalg
 
 from pyscf.lib import logger
 from pyscf.fci import direct_spin1
-from pyscf import mcpdft
+from pyscf import mcpdft, lib
 from pyscf.mcpdft import _dms
 from pyscf.mcscf.addons import StateAverageMCSCFSolver, \
     StateAverageMixFCISolver
@@ -195,7 +195,7 @@ def transformed_h1e_for_cas(mc, veff1_0, veff2_0, casdm1s_0, casdm2_0,
         core_dm = np.dot(mo_core, mo_core.conj().T) * 2
         # This is precomputed in MRH's ERIS object
         energy_core += veff2_0.energy_core
-        energy_core += np.einsum('ij,ji', core_dm, hcore_eff).real
+        energy_core += np.tensordot(core_dm, hcore_eff).real 
 
     h1eff = reduce(np.dot, (mo_cas.conj().T, hcore_eff, mo_cas))
     # Add in the 2-electron portion that acts as a 1-electron operator

--- a/pyscf/mcpdft/xmspdft.py
+++ b/pyscf/mcpdft/xmspdft.py
@@ -64,7 +64,7 @@ def fock_h1e_for_cas(mc, sa_casdm1s, mo_coeff=None, ncas=None, ncore=None):
 
     if mo_core.size != 0:
         core_dm = np.dot(mo_core, mo_core.conj().T) * 2
-        energy_core += np.einsum('ij,ji', core_dm, hcore_eff).real
+        energy_core += np.tensordot(core_dm, hcore_eff).real 
 
     h1eff = reduce(np.dot, (mo_cas.conj().T, hcore_eff, mo_cas))
 

--- a/pyscf/prop/dip_moment/mcpdft.py
+++ b/pyscf/prop/dip_moment/mcpdft.py
@@ -29,9 +29,9 @@ def get_guage_origin(mol,origin):
         if origin.upper() == 'COORD_CENTER':
             center = (0,0,0)
         elif origin.upper() == 'MASS_CENTER':
-            center = np.einsum('i,ij->j', mass, coords) / mass.sum()
+            center = lib.einsum('i,ij->j', mass, coords) / mass.sum()
         elif origin.upper() == 'CHARGE_CENTER':
-            center = np.einsum('z,zx->x', charges, coords) / charges.sum()
+            center = lib.einsum('z,zx->x', charges, coords) / charges.sum()
         else:
             raise RuntimeError ("Gauge origin is not recognized")
     elif isinstance(center,str):
@@ -65,7 +65,7 @@ def mcpdft_HellmanFeynman_dipole (mc, mo_coeff=None, ci=None, origin='Coord_Cent
     center = get_guage_origin(mol,origin)
     with mol.with_common_orig(center):
         ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-    elec_term = -np.einsum('xij,ij->x', ao_dip, dm).real
+    elec_term = -lib.einsum('xij,ij->x', ao_dip, dm).real
     return elec_term
 
 def nuclear_dipole(mc,origin='Coord_Center'):
@@ -75,7 +75,7 @@ def nuclear_dipole(mc,origin='Coord_Center'):
     charges = mol.atom_charges()                           
     coords  = mol.atom_coords()
     coords -= center
-    nucl_term = np.einsum('i,ix->x', charges, coords)
+    nucl_term = lib.einsum('i,ix->x', charges, coords)
     return nucl_term
 
 # TODO: docstring?
@@ -180,7 +180,7 @@ class ElectricDipole (mcpdft_grad.Gradients):
         center = get_guage_origin(mol, origin)
         with mol.with_common_orig(center):
             ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-        mol_dip_L = -np.einsum('xij,ji->x', ao_dip, dm).real
+        mol_dip_L = -lib.einsum('xij,ji->x', ao_dip, dm).real
 
         return mol_dip_L 
 

--- a/pyscf/prop/dip_moment/mcpdft.py
+++ b/pyscf/prop/dip_moment/mcpdft.py
@@ -29,9 +29,9 @@ def get_guage_origin(mol,origin):
         if origin.upper() == 'COORD_CENTER':
             center = (0,0,0)
         elif origin.upper() == 'MASS_CENTER':
-            center = lib.einsum('i,ij->j', mass, coords) / mass.sum()
+            center = mass.dot(coords) / mass.sum()
         elif origin.upper() == 'CHARGE_CENTER':
-            center = lib.einsum('z,zx->x', charges, coords) / charges.sum()
+            center = charges.dot(coords)/charges.sum()
         else:
             raise RuntimeError ("Gauge origin is not recognized")
     elif isinstance(center,str):
@@ -65,7 +65,7 @@ def mcpdft_HellmanFeynman_dipole (mc, mo_coeff=None, ci=None, origin='Coord_Cent
     center = get_guage_origin(mol,origin)
     with mol.with_common_orig(center):
         ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-    elec_term = -lib.einsum('xij,ij->x', ao_dip, dm).real
+    elec_term = -np.tensordot(ao_dip, dm).real
     return elec_term
 
 def nuclear_dipole(mc,origin='Coord_Center'):
@@ -75,7 +75,7 @@ def nuclear_dipole(mc,origin='Coord_Center'):
     charges = mol.atom_charges()                           
     coords  = mol.atom_coords()
     coords -= center
-    nucl_term = lib.einsum('i,ix->x', charges, coords)
+    nucl_term = charges.dot(coords)
     return nucl_term
 
 # TODO: docstring?
@@ -180,7 +180,7 @@ class ElectricDipole (mcpdft_grad.Gradients):
         center = get_guage_origin(mol, origin)
         with mol.with_common_orig(center):
             ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-        mol_dip_L = -lib.einsum('xij,ji->x', ao_dip, dm).real
+        mol_dip_L = -np.tensordot(ao_dip, dm).real
 
         return mol_dip_L 
 

--- a/pyscf/prop/dip_moment/mspdft.py
+++ b/pyscf/prop/dip_moment/mspdft.py
@@ -60,7 +60,7 @@ def sipdft_HellmanFeynman_dipole (mc, si_bra=None, si_ket=None,
     center = get_guage_origin(mol,origin)
     with mol.with_common_orig(center):
         ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-    elec_term = -lib.einsum('xij,ij->x', ao_dip, dm).real
+    elec_term = -np.tensordot(ao_dip, dm).real
     return elec_term
 
 class ElectricDipole (mspdft.Gradients):
@@ -181,6 +181,6 @@ class ElectricDipole (mspdft.Gradients):
         center = get_guage_origin(mol,origin)
         with mol.with_common_orig(center):
             ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-        mol_dip_L = -lib.einsum('xij,ji->x', ao_dip, dm).real
+        mol_dip_L = -np.tensordot(ao_dip, dm).real
 
         return mol_dip_L

--- a/pyscf/prop/dip_moment/mspdft.py
+++ b/pyscf/prop/dip_moment/mspdft.py
@@ -60,7 +60,7 @@ def sipdft_HellmanFeynman_dipole (mc, si_bra=None, si_ket=None,
     center = get_guage_origin(mol,origin)
     with mol.with_common_orig(center):
         ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-    elec_term = -np.einsum('xij,ij->x', ao_dip, dm).real
+    elec_term = -lib.einsum('xij,ij->x', ao_dip, dm).real
     return elec_term
 
 class ElectricDipole (mspdft.Gradients):
@@ -181,6 +181,6 @@ class ElectricDipole (mspdft.Gradients):
         center = get_guage_origin(mol,origin)
         with mol.with_common_orig(center):
             ao_dip = mol.intor_symmetric('int1e_r', comp=3)
-        mol_dip_L = -np.einsum('xij,ji->x', ao_dip, dm).real
+        mol_dip_L = -lib.einsum('xij,ji->x', ao_dip, dm).real
 
         return mol_dip_L


### PR DESCRIPTION
This PR either replaces `np.einsum` with `np.tensordot` or `np.dot`. However, if neither of the above 2 is feasibly, then it replaced by the `pyscf.lib.einsum` call instead. Only if none of these calls are valid, is it left as a np.einsum.
