### PR TITLE
_dms.py args -> kwargs ; _mcscf_env clean

### DIFF
--- a/pyscf/mcpdft/_dms.py
+++ b/pyscf/mcpdft/_dms.py
@@ -29,7 +29,7 @@ except ImportError as e:
     class DMRGCI (object):
         pass
 
-def _get_fcisolver (mc, ci, state=0):
+def _get_fcisolver (mc, ci=None, state=0):
     '''Find the appropriate FCI solver, CI vector, and nelecas tuple to
     build single-state reduced density matrices. If state_average or
     state_average_mix is involved this takes a bit of work.
@@ -63,7 +63,7 @@ def _get_fcisolver (mc, ci, state=0):
         ci = solver_state_index # DMRGCI takes state index in place of ci vector
     return fcisolver, ci, nelecas
 
-def make_one_casdm1s (mc, ci, state=0):
+def make_one_casdm1s (mc, ci=None, state=0):
     '''
     Construct the spin-separated active-space one-body reduced density
     matrix for a single state. This API is not consistently available
@@ -75,7 +75,7 @@ def make_one_casdm1s (mc, ci, state=0):
     fcisolver, ci, nelecas = _get_fcisolver (mc, ci, state=state)
     return fcisolver.make_rdm1s (ci, ncas, nelecas)
 
-def make_one_casdm2 (mc, ci, state=0):
+def make_one_casdm2 (mc, ci=None, state=0):
     '''
     Construct the spin-summed active-space two-body reduced density
     matrix for a single state. This API is not consistently available
@@ -94,7 +94,7 @@ def make_one_casdm2 (mc, ci, state=0):
     return casdm2
     
 
-def dm2_cumulant (dm2, dm1s):
+def dm2_cumulant (dm2=None, dm1s=None):
     '''
     Evaluate the spin-summed two-body cumulant reduced density
     matrix:
@@ -103,7 +103,7 @@ def dm2_cumulant (dm2, dm1s):
                        + dm1s[0][p,s]*dm1s[0][r,q]
                        + dm1s[1][p,s]*dm1s[1][r,q])
 
-    Args:
+    Kwargs:
         dm2 : ndarray of shape [norb,]*4
             Contains spin-summed 2-RDMs
         dm1s : ndarray (or compatible) of overall shape [2,norb,norb]
@@ -126,7 +126,7 @@ def dm2_cumulant (dm2, dm1s):
     cm2 += np.multiply.outer (dm1s[1], dm1s[1]).transpose (0, 3, 2, 1)
     return cm2
 
-def dm2s_cumulant (dm2s, dm1s):
+def dm2s_cumulant (dm2s=None, dm1s=None):
     '''Evaluate the spin-summed two-body cumulant reduced density
     matrix:
 
@@ -136,7 +136,7 @@ def dm2s_cumulant (dm2s, dm1s):
     cm2s[2][p,q,r,s] = (dm2s[2][p,q,r,s] - dm1s[1][p,q]*dm1s[1][r,s]
                        + dm1s[1][p,s]*dm1s[1][r,q])
 
-    Args:
+    Kwargs:
         dm2s : ndarray of shape [norb,]*4
             Contains spin-separated 2-RDMs
         dm1s : ndarray (or compatible) of overall shape [2,norb,norb]
@@ -162,17 +162,19 @@ def dm2s_cumulant (dm2s, dm1s):
     cm2s[2] += np.multiply.outer (dm1s[1], dm1s[1]).transpose (0, 3, 2, 1)
     return tuple (cm2s)
 
-def casdm1s_to_dm1s (mc, casdm1s, mo_coeff=None, ncore=None, ncas=None):
+def casdm1s_to_dm1s (mc, casdm1s=None, mo_coeff=None, ncore=None, ncas=None):
     '''Generate AO-basis spin-separated 1-RDM from active space part.
     This is necessary because the StateAverageMCSCFSolver class doesn't
     have API for getting the AO-basis density matrix of a single state.
 
     Args:
         mc : object of CASCI or CASSCF class
-        casdm1s : ndarray or compatible of shape (2,ncas,ncas)
-            Active-space spin-separated 1-RDM
 
     Kwargs:
+        casdm1s : ndarray or compatible of shape (2,ncas,ncas)
+            Active-space spin-separated 1-RDM
+        mo_coeff : ndarray
+            Molecular orbital coefficients
         ncore : integer
             Number of occupied inactive orbitals
         ncas : integer

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -345,9 +345,11 @@ class _mcscf_env (object):
     def __enter__(self):
         self.mc._in_mcscf_env = True
     def __exit__(self, type, value, traceback):
-        self.mc.e_tot = self.e_tot
         if getattr (self.mc, 'e_states', None) is not None:
             self.mc.e_mcscf = np.array (self.mc.e_states)
+        else:
+            self.mc.e_mcscf = self.mc.e_tot
+        self.mc.e_tot = self.e_tot
         if self.e_states is not None:
             try:
                 self.mc.e_states = self.e_states
@@ -440,10 +442,7 @@ class _PDFT ():
     def optimize_mcscf_(self, mo_coeff=None, ci0=None, **kwargs):
         '''Optimize the MC-SCF wave function underlying an MC-PDFT calculation.
         Has the same calling signature as the parent kernel method. '''
-        with _mcscf_env (self):
-            self.e_mcscf, self.e_cas, self.ci, self.mo_coeff, self.mo_energy = \
-                self._mc_class.kernel (self, mo_coeff, ci0=ci0, **kwargs)
-        return self.e_mcscf, self.e_cas, self.ci, self.mo_coeff, self.mo_energy
+        with _mcscf_env (self): return self._mc_class.kernel (self, mo_coeff, ci0=ci0, **kwargs)
 
     def compute_pdft_energy_(self, mo_coeff=None, ci=None, ot=None, otxc=None,
                              grids_level=None, grids_attr=None, **kwargs):


### PR DESCRIPTION
Fix a bug where make_one_casdm* takes ci as an arg despite it sometime being called with ci as a kwarg. (kwargs are safer here). Also automate more variable name reassignments in optimize_mcscf_ so that its easier to apply PDFT to MC-SCF subclasses that happen to have different kernel return signatures.