### PR TITLE
PDFT Chkfile Support

### DIFF
--- a/pyscf/grad/lpdft.py
+++ b/pyscf/grad/lpdft.py
@@ -652,6 +652,8 @@ class Gradients(sacasscf.Gradients):
 
         hop, Adiag = newton_casscf.gen_g_hop(fcasscf, mo, ci, eris, verbose)[2:]
 
+        # TODO: (MR Hennefarth) This is not safe way to check if something is a
+        # mixed solver, can probably do better than this...
         if hasattr(self.base, "_irrep_slices"):
             for ham_slice in ham_od:
                 ham_slice[np.diag_indices_from(ham_slice)] = 0.0

--- a/pyscf/grad/test/test_grad_mcpdft.py
+++ b/pyscf/grad/test/test_grad_mcpdft.py
@@ -54,12 +54,12 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0'):
     solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
     solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
     mcp_sa_1 = mcp_ss_nosym.state_average_mix (
-        [solver_S,solver_T], [1.0/5,]*5).run ()
+        [solver_S,solver_T], [1.0/5,]*5).set(ci=None).run ()
     solver_A1 = fci.solver (mol_sym).set (wfnsym='A1', nroots=3)
     solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
     solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)
     mcp_sa_2 = mcp_ss_sym.state_average_mix (
-        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).run ()
+        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None).run ()
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -20,6 +20,7 @@ from pyscf.lib.chkfile import load_mol, load, dump
 from pyscf.lib import H5FileWrap
 from pyscf.mcscf.addons import StateAverageMixFCISolver
 
+
 def load_pdft(chkfile):
     return load_mol(chkfile), load(chkfile, "pdft")
 
@@ -120,9 +121,7 @@ def dump_lpdft(
             store("ci", ci)
 
         if mcscf_key in fh5:
-            hard_links = {
-                "mo_coeff": "mo_coeff"
-            }
+            hard_links = {"mo_coeff": "mo_coeff"}
             for s, d in hard_links.items():
                 if s in fh5[mcscf_key]:
                     fh5[key + "/" + d] = fh5[mcscf_key + "/" + s]

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -19,27 +19,32 @@ import h5py
 from pyscf.lib.chkfile import load_mol, load
 from pyscf.lib import H5FileWrap
 
+
 def load_pdft(chkfile):
     return load_mol(chkfile), load(chkfile, "pdft")
 
+
 def dump_mcpdft(mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=None):
     """Save MC-PDFT calculation results in chkfile"""
-    if chkfile is None: chkfile = mc.chkfile
-    if e_tot is None: e_tot = mc.e_tot
-    if e_ot is None: e_ot = mc.e_ot
+    if chkfile is None:
+        chkfile = mc.chkfile
+    if e_tot is None:
+        e_tot = mc.e_tot
+    if e_ot is None:
+        e_ot = mc.e_ot
 
     if h5py.is_hdf5(chkfile):
-        mode = 'a'
+        mode = "a"
     else:
-        mode = 'w'
+        mode = "w"
 
     with H5FileWrap(chkfile, mode) as fh5:
         if mode == "a" and key in fh5:
-            del (fh5[key])
-    
+            del fh5[key]
+
         def store(subkey, val):
             if val is not None:
-                fh5[key+"/"+subkey] = val
+                fh5[key + "/" + subkey] = val
 
         store("e_tot", e_tot)
         store("e_ot", e_ot)

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -27,7 +27,6 @@ def dump_mcpdft(mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=No
     if chkfile is None: chkfile = mc.chkfile
     if e_tot is None: e_tot = mc.e_tot
     if e_ot is None: e_ot = mc.e_ot
-    if e_states is None: e_states = mc.e_states
 
     if h5py.is_hdf5(chkfile):
         mode = 'a'

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -15,11 +15,33 @@
 #
 # Author: Matthew Hennefath <mhennefarth@uchicago.edu>
 
+import h5py
 from pyscf.lib.chkfile import load_mol, load
+from pyscf.lib import H5FileWrap
 
 def load_pdft(chkfile):
     return load_mol(chkfile), load(chkfile, "pdft")
 
-def dump_pdft(mc, chkfile=None, key="pdft", ):
+def dump_mcpdft(mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=None):
     """Save MC-PDFT calculation results in chkfile"""
     if chkfile is None: chkfile = mc.chkfile
+    if e_tot is None: e_tot = mc.e_tot
+    if e_ot is None: e_ot = mc.e_ot
+    if e_states is None: e_states = mc.e_states
+
+    if h5py.is_hdf5(chkfile):
+        mode = 'a'
+    else:
+        mode = 'w'
+
+    with H5FileWrap(chkfile, mode) as fh5:
+        if mode == "a" and key in fh5:
+            del (fh5[key])
+    
+        def store(subkey, val):
+            if val is not None:
+                fh5[key+"/"+subkey] = val
+
+        store("e_tot", e_tot)
+        store("e_ot", e_ot)
+        store("e_states", e_states)

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -24,7 +24,9 @@ def load_pdft(chkfile):
     return load_mol(chkfile), load(chkfile, "pdft")
 
 
-def dump_mcpdft(mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=None):
+def dump_mcpdft(
+    mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=None, e_mcscf=None
+):
     """Save MC-PDFT calculation results in chkfile"""
     if chkfile is None:
         chkfile = mc.chkfile
@@ -49,3 +51,4 @@ def dump_mcpdft(mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=No
         store("e_tot", e_tot)
         store("e_ot", e_ot)
         store("e_states", e_states)
+        store("e_mcscf", e_mcscf)

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -25,7 +25,14 @@ def load_pdft(chkfile):
 
 
 def dump_mcpdft(
-    mc, chkfile=None, key="pdft", e_tot=None, e_ot=None, e_states=None, e_mcscf=None
+    mc,
+    chkfile=None,
+    key="pdft",
+    e_tot=None,
+    e_ot=None,
+    e_states=None,
+    e_mcscf=None,
+    mcscf_key="mcscf",
 ):
     """Save MC-PDFT calculation results in chkfile"""
     if chkfile is None:
@@ -46,6 +53,7 @@ def dump_mcpdft(
 
         def store(subkey, val):
             if val is not None:
+
                 fh5[key + "/" + subkey] = val
 
         store("e_tot", e_tot)
@@ -53,7 +61,30 @@ def dump_mcpdft(
         store("e_states", e_states)
         store("e_mcscf", e_mcscf)
 
-def dump_lpdft(mc, chkfile=None, key="pdft", e_tot=None, e_states=None, e_mcscf=None, ci=None, veff1=None, veff2=None):
+        # Now lets link
+        if mcscf_key in fh5:
+            hard_links = {
+                "mo_coeff": "mo_coeff",
+                "ci__from_list__": "ci__from_list__",
+                "ci": "ci",
+            }
+
+            for s, d in hard_links.items():
+                if s in fh5[mcscf_key]:
+                    fh5[key + "/" + d] = fh5[mcscf_key + "/" + s]
+
+
+def dump_lpdft(
+    mc,
+    chkfile=None,
+    key="pdft",
+    e_tot=None,
+    e_states=None,
+    e_mcscf=None,
+    ci=None,
+    veff1=None,
+    veff2=None,
+):
     """Save L-PDFT calculation results in chkfile"""
     if chkfile is None:
         chkfile = mc.chkfile

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Matthew Hennefath <mhennefarth@uchicago.edu>
+
+from pyscf.lib.chkfile import load_mol, load
+
+def load_pdft(chkfile):
+    return load_mol(chkfile), load(chkfile, "pdft")
+
+def dump_pdft(mc, chkfile=None, key="pdft", ):
+    """Save MC-PDFT calculation results in chkfile"""
+    if chkfile is None: chkfile = mc.chkfile

--- a/pyscf/mcpdft/chkfile.py
+++ b/pyscf/mcpdft/chkfile.py
@@ -52,3 +52,38 @@ def dump_mcpdft(
         store("e_ot", e_ot)
         store("e_states", e_states)
         store("e_mcscf", e_mcscf)
+
+def dump_lpdft(mc, chkfile=None, key="pdft", e_tot=None, e_states=None, e_mcscf=None, ci=None, veff1=None, veff2=None):
+    """Save L-PDFT calculation results in chkfile"""
+    if chkfile is None:
+        chkfile = mc.chkfile
+
+    if e_tot is None:
+        e_tot = mc.e_tot
+
+    if e_states is None:
+        e_states = mc.e_states
+
+    if e_mcscf is None:
+        e_mcscf = mc.e_mcscf
+
+    if h5py.is_hdf5(chkfile):
+        mode = "a"
+
+    else:
+        mode = "w"
+
+    with H5FileWrap(chkfile, mode) as fh5:
+        if mode == "a" and key in fh5:
+            del fh5[key]
+
+        def store(subkey, val):
+            if val is not None:
+                fh5[key + "/" + subkey] = val
+
+        store("e_tot", e_tot)
+        store("e_states", e_states)
+        store("e_mcscf", e_mcscf)
+        store("ci", ci)
+        store("veff1", veff1)
+        store("veff2", veff2)

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Matthew Hennefarth <mhennefarth@uchicago.com>
+# Author: Matthew Hennefarth <mhennefarth@uchicago.edu>
 
 import numpy as np
 from scipy import linalg

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -337,7 +337,7 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
             Relevant 2-body effective potential in the MO basis.
     '''
 
-    chk_veff = getattr(__config__, 'mcpdft_lpdft_chk_veff', False)
+    # chk_veff = getattr(__config__, 'mcpdft_lpdft_chk_veff', False)
 
     def __init__(self, mc):
         self.__dict__.update(mc.__dict__)
@@ -516,17 +516,11 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
             if self.chk_ci:
                 ci = envs["ci"]
 
-            if self.chk_veff:
-                veff1 = self.veff1
-                veff2 = self.veff2 
+            # if self.chk_veff:
+                # veff1 = self.veff1
+                # veff2 = self.veff2 
 
-            if "e_mcscf" in envs:
-                e_mcscf = envs["e_mcscf"]
-
-            else:
-                e_mcscf = self.e_mcscf
-
-            chkfile.dump_lpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_states=envs["e_states"], e_mcscf=e_mcscf, ci=ci, veff1=veff1, veff2=veff2)
+            chkfile.dump_lpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_states=envs["e_states"], e_mcscf=self.e_mcscf, ci=ci)
 
         return self
 

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -28,7 +28,7 @@ from pyscf.mcpdft import chkfile
 
 
 def weighted_average_densities(mc, ci=None, weights=None):
-    '''Compute the weighted average 1- and 2-electron CAS densities.
+    """Compute the weighted average 1- and 2-electron CAS densities.
     1-electron CAS is returned as spin-separated.
 
     Args:
@@ -44,16 +44,26 @@ def weighted_average_densities(mc, ci=None, weights=None):
     Returns:
         A tuple, the first is casdm1s and the second is casdm2 where they are
         weighted averages where the weights are given.
-    '''
+    """
 
     return _dms.make_weighted_casdm1s(
         mc, ci=ci, weights=weights
     ), _dms.make_weighted_casdm2(mc, ci=ci, weights=weights)
 
 
-def get_lpdft_hconst(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, ncas=None, ncore=None, veff1=None, veff2=None,
-                     mo_coeff=None):
-    ''' Compute h_const for the L-PDFT Hamiltonian
+def get_lpdft_hconst(
+    mc,
+    E_ot,
+    casdm1s_0,
+    casdm2_0,
+    hyb=1.0,
+    ncas=None,
+    ncore=None,
+    veff1=None,
+    veff2=None,
+    mo_coeff=None,
+):
+    """Compute h_const for the L-PDFT Hamiltonian
 
     Args:
         mc : instance of class _PDFT
@@ -88,7 +98,7 @@ def get_lpdft_hconst(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, ncas=None, ncore=No
 
     Returns:
         Constant term h_const for the expansion term.
-    '''
+    """
 
     if ncas is None:
         ncas = mc.ncas
@@ -110,21 +120,24 @@ def get_lpdft_hconst(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, ncas=None, ncore=No
 
     # Coulomb interaction
     vj = mc._scf.get_j(dm=dm1)
-    e_veff1_j = np.tensordot(veff1 + hyb*0.5*vj, dm1)
+    e_veff1_j = np.tensordot(veff1 + hyb * 0.5 * vj, dm1)
 
     # Deal with 2-electron on-top potential energy
     e_veff2 = veff2.energy_core
     e_veff2 += np.tensordot(veff2.vhf_c[ncore:nocc, ncore:nocc], casdm1_0)
-    e_veff2 += 0.5 * np.tensordot(veff2.papa[ncore:nocc, :, ncore:nocc, :], casdm2_0, axes=4)
+    e_veff2 += 0.5 * np.tensordot(
+        veff2.papa[ncore:nocc, :, ncore:nocc, :], casdm2_0, axes=4
+    )
 
     # h_nuc + E_ot - 1/2 g_pqrs D_pq D_rs - V_pq D_pq - 1/2 v_pqrs d_pqrs
     energy_core = hyb * mc.energy_nuc() + E_ot - e_veff1_j - e_veff2
     return energy_core
 
 
-def transformed_h1e_for_cas(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0,
-                            mo_coeff=None, ncas=None, ncore=None):
-    '''Compute the CAS one-particle L-PDFT Hamiltonian
+def transformed_h1e_for_cas(
+    mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, mo_coeff=None, ncas=None, ncore=None
+):
+    """Compute the CAS one-particle L-PDFT Hamiltonian
 
     Args:
         mc : instance of a _PDFT object
@@ -157,10 +170,13 @@ def transformed_h1e_for_cas(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0,
         A tuple, the first is the effective one-electron linear PDFT
         Hamiltonian defined in CAS space, the second is the modified core
         energy.
-    '''
-    if mo_coeff is None: mo_coeff = mc.mo_coeff
-    if ncas is None: ncas = mc.ncas
-    if ncore is None: ncore = mc.ncore
+    """
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
+    if ncas is None:
+        ncas = mc.ncas
+    if ncore is None:
+        ncore = mc.ncore
 
     nocc = ncore + ncas
     mo_core = mo_coeff[:, :ncore]
@@ -184,7 +200,7 @@ def transformed_h1e_for_cas(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0,
 
 
 def get_transformed_h2eff_for_cas(mc, ncore=None, ncas=None):
-    '''Compute the CAS two-particle linear PDFT Hamiltonian
+    """Compute the CAS two-particle linear PDFT Hamiltonian
 
     Args:
         ncore : int
@@ -195,15 +211,17 @@ def get_transformed_h2eff_for_cas(mc, ncore=None, ncas=None):
 
     Returns:
         ndarray of shape (ncas,ncas,ncas,ncas) which contain v_vwxy
-    '''
-    if ncore is None: ncore = mc.ncore
-    if ncas is None: ncas = mc.ncas
+    """
+    if ncore is None:
+        ncore = mc.ncore
+    if ncas is None:
+        ncas = mc.ncas
     nocc = ncore + ncas
     return mc.veff2.papa[ncore:nocc, :, ncore:nocc, :]
 
 
 def make_lpdft_ham_(mc, mo_coeff=None, ci=None, ot=None):
-    '''Compute the L-PDFT Hamiltonian
+    """Compute the L-PDFT Hamiltonian
 
     Args:
         mo_coeff : ndarray of shape (nao, nmo)
@@ -221,11 +239,14 @@ def make_lpdft_ham_(mc, mo_coeff=None, ci=None, ot=None):
             hamiltonian in the basis provided by the CI vectors. If
             StateAverageMix, then returns the block diagonal of the lpdft
             hamiltonian for each irrep.
-    '''
+    """
 
-    if mo_coeff is None: mo_coeff = mc.mo_coeff
-    if ci is None: ci = mc.ci
-    if ot is None: ot = mc.otfnal
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
+    if ci is None:
+        ci = mc.ci
+    if ot is None:
+        ot = mc.otfnal
 
     ot.reset(mol=mc.mol)
 
@@ -235,18 +256,24 @@ def make_lpdft_ham_(mc, mo_coeff=None, ci=None, ot=None):
         raise NotImplementedError("range-separated on-top functionals")
     if abs(hyb[0] - hyb[1]) > 1e-11:
         raise NotImplementedError(
-            "hybrid functionals with different exchange, correlations components")
+            "hybrid functionals with different exchange, correlations components"
+        )
 
     cas_hyb = hyb[0]
 
     ncas = mc.ncas
     casdm1s_0, casdm2_0 = mc.get_casdm12_0(ci=ci)
 
-    mc.veff1, mc.veff2, E_ot = mc.get_pdft_veff(mo=mo_coeff, casdm1s=casdm1s_0,
-                                        casdm2=casdm2_0, drop_mcwfn=True, incl_energy=True)
+    mc.veff1, mc.veff2, E_ot = mc.get_pdft_veff(
+        mo=mo_coeff,
+        casdm1s=casdm1s_0,
+        casdm2=casdm2_0,
+        drop_mcwfn=True,
+        incl_energy=True,
+    )
 
     # This is all standard procedure for generating the hamiltonian in PySCF
-    h1, h0 = mc.get_h1lpdft(E_ot, casdm1s_0, casdm2_0, hyb=1.0-cas_hyb)
+    h1, h0 = mc.get_h1lpdft(E_ot, casdm1s_0, casdm2_0, hyb=1.0 - cas_hyb)
     h2 = mc.get_h2lpdft()
     h2eff = direct_spin1.absorb_h1e(h1, h2, ncas, mc.nelecas, 0.5)
 
@@ -272,13 +299,17 @@ def make_lpdft_ham_(mc, mo_coeff=None, ci=None, ot=None):
         mc._irrep_slices.append(slice(start, end))
         start = end
 
-    return [construct_ham_slice(s, irrep, mc.fcisolver._get_nelec(s, mc.nelecas))
-            for s, irrep in zip(mc.fcisolver.fcisolvers, mc._irrep_slices)]
+    return [
+        construct_ham_slice(s, irrep, mc.fcisolver._get_nelec(s, mc.nelecas))
+        for s, irrep in zip(mc.fcisolver.fcisolvers, mc._irrep_slices)
+    ]
 
 
 def kernel(mc, mo_coeff=None, ci0=None, ot=None, dump_chk=True, **kwargs):
-    if ot is None: ot = mc.otfnal
-    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ot is None:
+        ot = mc.otfnal
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
 
     mc.optimize_mcscf_(mo_coeff=mo_coeff, ci0=ci0)
     ci_mcscf = mc.ci
@@ -300,20 +331,18 @@ def kernel(mc, mo_coeff=None, ci0=None, ot=None, dump_chk=True, **kwargs):
 
     e_tot = np.dot(e_states, mc.weights)
     ci = mc._get_ci_adiabats(ci_mcscf)
-    
+
     mc.e_tot = e_tot
     mc.ci = ci
 
     if dump_chk:
         mc.dump_chk(locals())
 
-    return (
-        mc.e_tot, mc.e_mcscf, mc.e_cas, mc.ci,
-        mc.mo_coeff, mc.mo_energy)
+    return (mc.e_tot, mc.e_mcscf, mc.e_cas, mc.ci, mc.mo_coeff, mc.mo_energy)
 
 
 class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
-    '''Linerized PDFT
+    """Linerized PDFT
 
     Saved Results
 
@@ -335,13 +364,13 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
             zeroth-order densities.
         veff2 : pyscf.mcscf.mc_ao2mo._ERIS instance
             Relevant 2-body effective potential in the MO basis.
-    '''
+    """
 
     # chk_veff = getattr(__config__, 'mcpdft_lpdft_chk_veff', False)
 
     def __init__(self, mc):
         self.__dict__.update(mc.__dict__)
-        keys = set(('lpdft_ham', 'si_pdft', 'veff1', 'veff2'))
+        keys = set(("lpdft_ham", "si_pdft", "veff1", "veff2"))
         self.lpdft_ham = None
         self.si_pdft = None
         self.veff1 = None
@@ -377,7 +406,7 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
     get_casdm12_0.__doc__ = weighted_average_densities.__doc__
 
     def get_lpdft_diag(self):
-        '''Diagonal elements of the L-PDFT Hamiltonian matrix
+        """Diagonal elements of the L-PDFT Hamiltonian matrix
             (H_00^L-PDFT, H_11^L-PDFT, H_22^L-PDFT, ...)
 
         Returns:
@@ -385,21 +414,21 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
                 Contains the linear approximation to the MC-PDFT energy. These
                 are also the diagonal elements of the L-PDFT Hamiltonian
                 matrix.
-        '''
+        """
         return np.diagonal(self.lpdft_ham).copy()
 
     def get_lpdft_ham(self):
-        '''The L-PDFT effective Hamiltonian matrix
+        """The L-PDFT effective Hamiltonian matrix
 
-            Returns:
-                lpdft_ham : ndarray of shape (nroots, nroots)
-                    Contains L-PDFT Hamiltonian elements on the off-diagonals
-                    and PDFT approx energies on the diagonals
-                '''
+        Returns:
+            lpdft_ham : ndarray of shape (nroots, nroots)
+                Contains L-PDFT Hamiltonian elements on the off-diagonals
+                and PDFT approx energies on the diagonals
+        """
         return self.lpdft_ham
 
     def kernel(self, mo_coeff=None, ci0=None, ot=None, verbose=None):
-        '''
+        """
         Returns:
             6 elements, they are
             total energy,
@@ -411,8 +440,9 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
 
         They are attributes of the QLPDFT object, which can be accessed by
         .e_tot, .e_mcscf, .e_cas, .ci, .mo_coeff, .mo_energy
-        '''
-        if ot is None: ot = self.otfnal
+        """
+        if ot is None:
+            ot = self.otfnal
         ot.reset(mol=self.mol)  # scanner mode safety
 
         if mo_coeff is None:
@@ -422,80 +452,97 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
 
         log = logger.new_logger(self, verbose)
 
-        if ci0 is None and isinstance(getattr(self, 'ci', None), list):
+        if ci0 is None and isinstance(getattr(self, "ci", None), list):
             ci0 = [c.copy() for c in self.ci]
 
         kernel(self, mo_coeff, ci0, ot=ot, verbose=log, dump_chk=True)
         self._finalize_lin()
         return (
-            self.e_tot, self.e_mcscf, self.e_cas, self.ci,
-            self.mo_coeff, self.mo_energy)
+            self.e_tot,
+            self.e_mcscf,
+            self.e_cas,
+            self.ci,
+            self.mo_coeff,
+            self.mo_energy,
+        )
 
     def _finalize_lin(self):
         log = logger.Logger(self.stdout, self.verbose)
         nroots = len(self.e_states)
         log.note("%s (final) states:", self.__class__.__name__)
-        if log.verbose >= logger.NOTE and getattr(self.fcisolver, 'spin_square',
-                                                  None):
+        if log.verbose >= logger.NOTE and getattr(self.fcisolver, "spin_square", None):
             ss = self.fcisolver.states_spin_square(self.ci, self.ncas, self.nelecas)[0]
 
             for i in range(nroots):
-                log.note('  State %d weight %g  ELPDFT = %.15g  S^2 = %.7f',
-                         i, self.weights[i], self.e_states[i], ss[i])
+                log.note(
+                    "  State %d weight %g  ELPDFT = %.15g  S^2 = %.7f",
+                    i,
+                    self.weights[i],
+                    self.e_states[i],
+                    ss[i],
+                )
 
         else:
             for i in range(nroots):
-                log.note('  State %d weight %g  ELPDFT = %.15g', i,
-                         self.weights[i], self.e_states[i])
+                log.note(
+                    "  State %d weight %g  ELPDFT = %.15g",
+                    i,
+                    self.weights[i],
+                    self.e_states[i],
+                )
 
     def _get_ci_adiabats(self, ci_mcscf):
-        '''Get the CI vertors in eigenbasis of L-PDFT Hamiltonian
+        """Get the CI vertors in eigenbasis of L-PDFT Hamiltonian
 
-            Kwargs:
-                ci : list of length nroots
-                    MC-SCF ci vectors; defaults to self.ci_mcscf
+        Kwargs:
+            ci : list of length nroots
+                MC-SCF ci vectors; defaults to self.ci_mcscf
 
-            Returns:
-                ci : list of length nroots
-                    CI vectors in basis of L-PDFT Hamiltonian eigenvectors
-        '''
+        Returns:
+            ci : list of length nroots
+                CI vectors in basis of L-PDFT Hamiltonian eigenvectors
+        """
         return list(np.tensordot(self.si_pdft.T, np.asarray(ci_mcscf), axes=1))
 
     def _eig_si(self, ham):
         return linalg.eigh(ham)
 
     def get_lpdft_hcore_only(self, casdm1s_0, hyb=1.0):
-        '''
+        """
         Returns the lpdft hcore AO integrals weighted by the
         hybridization factor. Excludes the MC-SCF (wfn) component.
-        '''
+        """
 
         dm1s = _dms.casdm1s_to_dm1s(self, casdm1s=casdm1s_0)
         dm1 = dm1s[0] + dm1s[1]
         v_j = self._scf.get_j(dm=dm1)
-        return hyb*self.get_hcore() + self.veff1 + hyb * v_j
-
+        return hyb * self.get_hcore() + self.veff1 + hyb * v_j
 
     def get_lpdft_hcore(self, casdm1s_0=None):
-        '''
+        """
         Returns the full lpdft hcore AO integrals. Includes the MC-SCF
         (wfn) component for hybrid functionals.
-        '''
+        """
         if casdm1s_0 is None:
             casdm1s_0 = self.get_casdm12_0()[0]
 
         spin = abs(self.nelecas[0] - self.nelecas[1])
-        cas_hyb = self.otfnal._numint.rsh_and_hybrid_coeff(self.otfnal.otxc, spin=spin)[2]
+        cas_hyb = self.otfnal._numint.rsh_and_hybrid_coeff(self.otfnal.otxc, spin=spin)[
+            2
+        ]
         hyb = 1.0 - cas_hyb[0]
 
-        return cas_hyb[0] * self.get_hcore() + self.get_lpdft_hcore_only(casdm1s_0, hyb=hyb)
+        return cas_hyb[0] * self.get_hcore() + self.get_lpdft_hcore_only(
+            casdm1s_0, hyb=hyb
+        )
 
     def nuc_grad_method(self, state=None):
         from pyscf.mcscf import mc1step
         from pyscf.mcscf.df import _DFCASSCF
+
         if not isinstance(self, mc1step.CASSCF):
             raise NotImplementedError("CASCI-based LPDFT nuclear gradients")
-        elif getattr(self, 'frozen', None) is not None:
+        elif getattr(self, "frozen", None) is not None:
             raise NotImplementedError("LPDFT nuclear gradients with frozen orbitals")
         elif isinstance(self, _DFCASSCF):
             from pyscf.df.grad.lpdft import Gradients
@@ -512,21 +559,29 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
             self._mc_class.dump_chk(self, envs)
 
         else:
-            ci = veff1 = veff2 = None
+            ci = None
             if self.chk_ci:
                 ci = envs["ci"]
 
             # if self.chk_veff:
-                # veff1 = self.veff1
-                # veff2 = self.veff2 
+            # veff1 = self.veff1
+            # veff2 = self.veff2
 
-            chkfile.dump_lpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_states=envs["e_states"], e_mcscf=self.e_mcscf, ci=ci)
+            chkfile.dump_lpdft(
+                self,
+                chkfile=self.chkfile,
+                key="pdft",
+                e_tot=envs["e_tot"],
+                e_states=envs["e_states"],
+                e_mcscf=self.e_mcscf,
+                ci=ci,
+            )
 
         return self
 
 
 class _LPDFTMix(_LPDFT):
-    '''State Averaged Mixed Linerized PDFT
+    """State Averaged Mixed Linerized PDFT
 
     Saved Results
 
@@ -544,7 +599,7 @@ class _LPDFTMix(_LPDFT):
             Energies of the MC-SCF adiabatic states
         lpdft_ham : list of ndarray of shape (nirreps, nroots, nroots)
             L-PDFT Hamiltonian in the MC-SCF adiabatic basis within each irrep
-    '''
+    """
 
     def __init__(self, mc):
         super().__init__(mc)
@@ -552,7 +607,7 @@ class _LPDFTMix(_LPDFT):
         self._irrep_slices = None
 
     def get_lpdft_diag(self):
-        '''Diagonal elements of the L-PDFT Hamiltonian matrix
+        """Diagonal elements of the L-PDFT Hamiltonian matrix
             (H_00^L-PDFT, H_11^L-PDFT, H_22^L-PDFT, ...)
 
         Returns:
@@ -560,31 +615,39 @@ class _LPDFTMix(_LPDFT):
                 Contains the linear approximation to the MC-PDFT energy. These
                 are also the diagonal elements of the L-PDFT Hamiltonian
                 matrix.
-        '''
-        return np.concatenate([np.diagonal(irrep_ham).copy() for irrep_ham in self.lpdft_ham])
+        """
+        return np.concatenate(
+            [np.diagonal(irrep_ham).copy() for irrep_ham in self.lpdft_ham]
+        )
 
     def get_lpdft_ham(self):
-        '''The L-PDFT effective Hamiltonian matrix
+        """The L-PDFT effective Hamiltonian matrix
 
-            Returns:
-                lpdft_ham : ndarray of shape (nroots, nroots)
-                    Contains L-PDFT Hamiltonian elements on the off-diagonals
-                    and PDFT approx energies on the diagonals
-        '''
+        Returns:
+            lpdft_ham : ndarray of shape (nroots, nroots)
+                Contains L-PDFT Hamiltonian elements on the off-diagonals
+                and PDFT approx energies on the diagonals
+        """
         return linalg.block_diag(*self.lpdft_ham)
 
     def _get_ci_adiabats(self, ci_mcscf):
-        '''Get the CI vertors in eigenbasis of L-PDFT Hamiltonian
+        """Get the CI vertors in eigenbasis of L-PDFT Hamiltonian
 
+        ci : list of length nroots
+            MC-SCF ci vectors
+
+        Returns:
             ci : list of length nroots
-                MC-SCF ci vectors
-
-            Returns:
-                ci : list of length nroots
-                    CI vectors in basis of L-PDFT Hamiltonian eigenvectors
-        '''
-        adiabat_ci = [np.tensordot(self.si_pdft[irrep_slice, irrep_slice],
-                                   np.asarray(ci_mcscf[irrep_slice]), axes=1) for irrep_slice in self._irrep_slices]
+                CI vectors in basis of L-PDFT Hamiltonian eigenvectors
+        """
+        adiabat_ci = [
+            np.tensordot(
+                self.si_pdft[irrep_slice, irrep_slice],
+                np.asarray(ci_mcscf[irrep_slice]),
+                axes=1,
+            )
+            for irrep_slice in self._irrep_slices
+        ]
         # Flattens it
         return [c for ci_irrep in adiabat_ci for c in ci_irrep]
 
@@ -593,7 +656,7 @@ class _LPDFTMix(_LPDFT):
 
 
 def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):
-    ''' Build linearized multi-state MC-PDFT method object
+    """Build linearized multi-state MC-PDFT method object
 
     Args:
         mc : instance of class _PDFT
@@ -603,12 +666,11 @@ def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):
 
     Returns:
         si : instance of class _LPDFT
-    '''
-    from pyscf.mcscf.addons import StateAverageMCSCFSolver, \
-        StateAverageMixFCISolver
+    """
+    from pyscf.mcscf.addons import StateAverageMCSCFSolver, StateAverageMixFCISolver
 
     if isinstance(mc, mcpdft.MultiStateMCPDFTSolver):
-        raise RuntimeError('already a multi-state PDFT solver')
+        raise RuntimeError("already a multi-state PDFT solver")
 
     if isinstance(mc.fcisolver, StateAverageMixFCISolver):
         raise RuntimeError("state-average mix type")
@@ -628,8 +690,9 @@ def linear_multi_state(mc, weights=(0.5, 0.5), **kwargs):
     LPDFT.__name__ = "LIN" + base_name
     return LPDFT(mc)
 
+
 def linear_multi_state_mix(mc, fcisolvers, weights=(0.5, 0.5), **kwargs):
-    ''' Build SA Mix linearized multi-state MC-PDFT method object
+    """Build SA Mix linearized multi-state MC-PDFT method object
 
     Args:
         mc : instance of class _PDFT
@@ -641,12 +704,11 @@ def linear_multi_state_mix(mc, fcisolvers, weights=(0.5, 0.5), **kwargs):
 
     Returns:
         si : instance of class _LPDFT
-    '''
-    from pyscf.mcscf.addons import StateAverageMCSCFSolver, \
-        StateAverageMixFCISolver
+    """
+    from pyscf.mcscf.addons import StateAverageMCSCFSolver, StateAverageMixFCISolver
 
     if isinstance(mc, mcpdft.MultiStateMCPDFTSolver):
-        raise RuntimeError('already a multi-state PDFT solver')
+        raise RuntimeError("already a multi-state PDFT solver")
 
     if not isinstance(mc, StateAverageMCSCFSolver):
         base_name = mc.__class__.__name__
@@ -672,22 +734,29 @@ if __name__ == "__main__":
     from mrh.my_pyscf import mcpdft
     from mrh.my_pyscf.fci import csf_solver
 
-    mol = gto.M(atom='''H 0 0 0
-                       H 1.5 0 0''',
-                basis='sto-3g',
-                verbose=5,
-                spin=0,
-                unit="AU",
-                symmetry=True)
+    mol = gto.M(
+        atom="""H 0 0 0
+                       H 1.5 0 0""",
+        basis="sto-3g",
+        verbose=5,
+        spin=0,
+        unit="AU",
+        symmetry=True,
+    )
 
     mf = scf.RHF(mol).run()
 
-    mc = mcpdft.CASSCF(mf, 'tPBE', 2, 2, grids_level=6)
+    mc = mcpdft.CASSCF(mf, "tPBE", 2, 2, grids_level=6)
     mc.fcisolver = csf_solver(mol, smult=1)
 
     N_STATES = 2
 
-    mc = mc.state_average([1.0 / float(N_STATES), ] * N_STATES)
+    mc = mc.state_average(
+        [
+            1.0 / float(N_STATES),
+        ]
+        * N_STATES
+    )
 
     sc = linear_multi_state(mc)
     sc.kernel()

--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -46,7 +46,9 @@ def weighted_average_densities(mc, ci=None, weights=None):
         weighted averages where the weights are given.
     '''
 
-    return _dms.make_weighted_casdm1s(mc, ci=ci, weights=weights), _dms.make_weighted_casdm2(mc, ci=ci, weights=weights)
+    return _dms.make_weighted_casdm1s(
+        mc, ci=ci, weights=weights
+    ), _dms.make_weighted_casdm2(mc, ci=ci, weights=weights)
 
 
 def get_lpdft_hconst(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, ncas=None, ncore=None, veff1=None, veff2=None,
@@ -87,11 +89,17 @@ def get_lpdft_hconst(mc, E_ot, casdm1s_0, casdm2_0, hyb=1.0, ncas=None, ncore=No
     Returns:
         Constant term h_const for the expansion term.
     '''
-    if ncas is None: ncas = mc.ncas
-    if ncore is None: ncore = mc.ncore
-    if veff1 is None: veff1 = mc.veff1
-    if veff2 is None: veff2 = mc.veff2
-    if mo_coeff is None: mo_coeff = mc.mo_coeff
+
+    if ncas is None:
+        ncas = mc.ncas
+    if ncore is None:
+        ncore = mc.ncore
+    if veff1 is None:
+        veff1 = mc.veff1
+    if veff2 is None:
+        veff2 = mc.veff2
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
 
     nocc = ncore + ncas
 

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -781,6 +781,7 @@ class _PDFT:
                 e_tot=envs["e_tot"],
                 e_ot=envs["e_ot"],
                 e_states=e_states,
+                e_mcscf=envs["e_mcscf"]
             )
 
         return self

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -25,6 +25,7 @@ from pyscf.mcscf.df import _DFCASSCF, _DFCAS
 from pyscf.mcpdft import pdft_veff, pdft_feff
 from pyscf.mcpdft.otfnal import transfnal, get_transfnal
 from pyscf.mcpdft import _dms
+from pyscf.mcpdft import chkfile
 
 def energy_tot(mc, mo_coeff=None, ci=None, ot=None, state=0, verbose=None):
     '''Calculate MC-PDFT total energy
@@ -454,7 +455,7 @@ class _PDFT:
         return self.e_mcscf, self.e_cas, self.ci, self.mo_coeff, self.mo_energy
 
     def compute_pdft_energy_(self, mo_coeff=None, ci=None, ot=None, otxc=None,
-                             grids_level=None, grids_attr=None, **kwargs):
+                             grids_level=None, grids_attr=None, dump_chk=True, **kwargs):
         '''Compute the MC-PDFT energy(ies) (and update stored data)
         with the MC-SCF wave function fixed. '''
         if mo_coeff is not None: self.mo_coeff = mo_coeff
@@ -487,6 +488,10 @@ class _PDFT:
         else:  # nroots==1 not StateAverage class
             self.e_tot, self.e_ot = epdft[0]
             e_states = [self.e_tot]
+
+        if dump_chk:
+            self.dump_chk(locals())
+
         return self.e_tot, self.e_ot, e_states
 
     def kernel(self, mo_coeff=None, ci0=None, otxc=None, grids_attr=None,
@@ -747,6 +752,13 @@ class _PDFT:
                     e_tot, ot.otxc, e_ot)
         return e_tot, e_ot
 
+    def dump_chk(self, envs):
+        if not self.chkfile:
+            return self
+
+        self._mc_class.dump_chk(self, envs)
+
+        chkfile.dump_pdft(self, chkfile=self.chkfile, key="pdft")
 
 def get_mcpdft_child_class(mc, ot, **kwargs):
     # Inheritance magic

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -756,6 +756,7 @@ class _PDFT:
         return e_tot, e_ot
 
     def dump_chk(self, envs):
+        """Dumps information to the chkfile. If called within mcscf environment, it forwards to the mcscf dump_chk. Else, it dumps only the pdft information."""
         if not self.chkfile:
             return self
 
@@ -765,7 +766,13 @@ class _PDFT:
             self._mc_class.dump_chk(self, envs)
 
         else:
-            chkfile.dump_mcpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_ot=envs["e_ot"], e_states=envs["e_states"])
+            e_states = None
+            if len(envs["e_states"]) > 1 :
+                e_states = envs["e_states"]
+
+            chkfile.dump_mcpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_ot=envs["e_ot"], e_states=e_states)
+
+        return self
 
     def update_from_chk(self, chkfile=None, mcscf_key="mcscf", pdft_key="pdft"):
         if chkfile is None:

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -781,16 +781,16 @@ class _PDFT:
                 e_tot=envs["e_tot"],
                 e_ot=envs["e_ot"],
                 e_states=e_states,
-                e_mcscf=envs["e_mcscf"]
+                e_mcscf=self.e_mcscf,
             )
 
         return self
 
-    def update_from_chk(self, chkfile=None, mcscf_key="mcscf", pdft_key="pdft"):
+    def update_from_chk(self, chkfile=None, pdft_key="pdft"):
         if chkfile is None:
             chkfile = self.chkfile
-
-        self.__dict__.update(lib.chkfile.load(chkfile, mcscf_key))
+        
+        # When the chkfile is saved, we utilize hard links to the mcscf data
         self.__dict__.update(lib.chkfile.load(chkfile, pdft_key))
         return self
 

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -756,7 +756,11 @@ class _PDFT:
         return e_tot, e_ot
 
     def dump_chk(self, envs):
-        """Dumps information to the chkfile. If called within mcscf environment, it forwards to the mcscf dump_chk. Else, it dumps only the pdft information."""
+        """
+        Dumps information to the chkfile. If called within mcscf environment,
+        it forwards to the mcscf dump_chk. Else, it dumps only the pdft
+        information.
+        """
         if not self.chkfile:
             return self
 
@@ -767,10 +771,17 @@ class _PDFT:
 
         else:
             e_states = None
-            if len(envs["e_states"]) > 1 :
+            if len(envs["e_states"]) > 1:
                 e_states = envs["e_states"]
 
-            chkfile.dump_mcpdft(self, chkfile=self.chkfile, key="pdft", e_tot=envs["e_tot"], e_ot=envs["e_ot"], e_states=e_states)
+            chkfile.dump_mcpdft(
+                self,
+                chkfile=self.chkfile,
+                key="pdft",
+                e_tot=envs["e_tot"],
+                e_ot=envs["e_ot"],
+                e_states=e_states,
+            )
 
         return self
 
@@ -781,7 +792,7 @@ class _PDFT:
         self.__dict__.update(lib.chkfile.load(chkfile, mcscf_key))
         self.__dict__.update(lib.chkfile.load(chkfile, pdft_key))
         return self
-    
+
     update = update_from_chk
 
 def get_mcpdft_child_class(mc, ot, **kwargs):

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -789,7 +789,7 @@ class _PDFT:
     def update_from_chk(self, chkfile=None, pdft_key="pdft"):
         if chkfile is None:
             chkfile = self.chkfile
-        
+
         # When the chkfile is saved, we utilize hard links to the mcscf data
         self.__dict__.update(lib.chkfile.load(chkfile, pdft_key))
         return self

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -58,6 +58,7 @@ def get_water(functional='tpbe', basis='6-31g'):
 
     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
     mc.chkfile = tempfile.NamedTemporaryFile().name 
+    mc.chk_ci = True
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
     mc.run()
     return mc
@@ -81,6 +82,8 @@ def get_water_triplet(functional='tPBE', basis="6-31G"):
     solver2.nroots = 2
 
     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
+    mc.chkfile = tempfile.NamedTemporaryFile().name 
+    mc.chk_ci = True
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
     mc.run()
     return mc
@@ -214,11 +217,17 @@ class KnownValues(unittest.TestCase):
 
     def test_chkfile(self):
         for mc, case in zip([water, t_water], ["SA", "SA Mix"]):
+            print(mc.chkfile)
             with self.subTest(case=case):
                 self.assertTrue(h5py.is_hdf5(mc.chkfile))
-                self.assertEqual(lib.fp(mc.mo_coeff), lib.fp(lib.chkfile.load(mc.chkfile, "mcscf/mo_coeff")))
+                self.assertEqual(lib.fp(mc.mo_coeff), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/mo_coeff")))
+                self.assertEqual(mc.e_tot, lib.chkfile.load(mc.chkfile, "pdft/e_tot"))
+                self.assertEqual(lib.fp(mc.e_mcscf), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_mcscf")))
+                self.assertEqual(lib.fp(mc.e_states), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_states")))        
 
-
+                for state, (c_ref, c) in enumerate(zip(mc.ci, lib.chkfile.load(mc.chkfile, "pdft/ci"))):
+                    with self.subTest(state=state):
+                        self.assertEqual(lib.fp(c_ref), lib.fp(c))
 
 if __name__ == "__main__":
     print("Full Tests for Linearized-PDFT")

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -58,7 +58,7 @@ def get_water(functional='tpbe', basis='6-31g'):
 
     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
     mc.chkfile = tempfile.NamedTemporaryFile().name 
-    mc.chk_ci = True
+    # mc.chk_ci = True
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
     mc.run()
     return mc
@@ -83,7 +83,7 @@ def get_water_triplet(functional='tPBE', basis="6-31G"):
 
     mc = mcpdft.CASSCF(mf, functional, 4, 4, grids_level=1)
     mc.chkfile = tempfile.NamedTemporaryFile().name 
-    mc.chk_ci = True
+    # mc.chk_ci = True
     mc = mc.multi_state_mix([solver1, solver2], weights, "lin")
     mc.run()
     return mc
@@ -225,9 +225,10 @@ class KnownValues(unittest.TestCase):
                 self.assertEqual(lib.fp(mc.e_mcscf), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_mcscf")))
                 self.assertEqual(lib.fp(mc.e_states), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_states")))        
 
-                for state, (c_ref, c) in enumerate(zip(mc.ci, lib.chkfile.load(mc.chkfile, "pdft/ci"))):
-                    with self.subTest(state=state):
-                        self.assertEqual(lib.fp(c_ref), lib.fp(c))
+                # Requires PySCF version > 2.6.2 which is not available on pip currently
+                # for state, (c_ref, c) in enumerate(zip(mc.ci, lib.chkfile.load(mc.chkfile, "pdft/ci"))):
+                    # with self.subTest(state=state):
+                        # self.assertEqual(lib.fp(c_ref), lib.fp(c))
 
 if __name__ == "__main__":
     print("Full Tests for Linearized-PDFT")

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -30,6 +30,7 @@
 # Some assertAlmostTrue thresholds are loose because we are only
 # trying to test the API here; we need tight convergence and grids
 # to reproduce well when OMP is on.
+import tempfile
 import numpy as np
 from pyscf import gto, scf, mcscf, lib, fci, df
 from pyscf.fci.addons import fix_spin_
@@ -48,7 +49,7 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0', fnal='tPBE'):
     mf_sym = scf.RHF (mol_sym).run ()
     mc_sym = mcscf.CASSCF (mf_sym, 5, 2).run (conv_tol=1e-8)
     mcp_ss_nosym = mcpdft.CASSCF (mc_nosym, fnal, 5, 2).run (conv_tol=1e-8)
-    mcp_ss_sym = mcpdft.CASSCF (mc_sym, fnal, 5, 2).run (conv_tol=1e-8)
+    mcp_ss_sym = mcpdft.CASSCF (mc_sym, fnal, 5, 2).set(chkfile=tempfile.NamedTemporaryFile().name).run (conv_tol=1e-8)
     mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5).run (conv_tol=1e-8)
     solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
     solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
@@ -58,7 +59,7 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0', fnal='tPBE'):
     solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
     solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)
     mcp_sa_2 = mcp_ss_sym.state_average_mix (
-        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None).run (conv_tol=1e-8)
+        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None, chkfile=tempfile.NamedTemporaryFile().name).run (conv_tol=1e-8)
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -549,7 +549,7 @@ class KnownValues(unittest.TestCase):
     def test_scanner(self):
         # Putting more energy into CASSCF than CASCI scanner because this is
         # necessary for geometry optimization, which isn't available for CASCI
-        mcp1 = auto_setup(xyz="Li 0 0 0\nH 1.55 0 0")[-1]
+        mcp1 = auto_setup(xyz="Li 0 0 0\nH 1.55 0 0")[-2]
         for mol0, mc0, mc1 in zip([mol_nosym, mol_sym], mcp[0], mcp1[0]):
             mc_scan = mc1.as_scanner()
             with self.subTest(case="SS CASSCF", symm=mol0.symmetry):

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -40,10 +40,8 @@ import unittest
 
 mol_nosym = mol_sym = mf_nosym = mf_sym = mc_nosym = mc_sym = mcp = None
 def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0', fnal='tPBE'):
-    mol_nosym = gto.M (atom = xyz, basis = 'sto3g',
-                       output = '/dev/null', verbose = 0)
-    mol_sym = gto.M (atom = xyz, basis = 'sto3g', symmetry=True,
-                     output = '/dev/null', verbose = 0)
+    mol_nosym = gto.M (atom = xyz, basis = 'sto3g', verbose = 0)
+    mol_sym = gto.M (atom = xyz, basis = 'sto3g', symmetry=True, verbose = 0)
     mf_nosym = scf.RHF (mol_nosym).run ()
     mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2).run (conv_tol=1e-8)
     mf_sym = scf.RHF (mol_sym).run ()

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -53,12 +53,12 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0', fnal='tPBE'):
     solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
     solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
     mcp_sa_1 = mcp_ss_nosym.state_average_mix (
-        [solver_S,solver_T], [1.0/5,]*5).run (conv_tol=1e-8)
+        [solver_S,solver_T], [1.0/5,]*5).set(ci=None).run (conv_tol=1e-8)
     solver_A1 = fci.solver (mol_sym).set (wfnsym='A1', nroots=3)
     solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
     solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)
     mcp_sa_2 = mcp_ss_sym.state_average_mix (
-        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).run (conv_tol=1e-8)
+        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None).run (conv_tol=1e-8)
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -18,7 +18,7 @@
 #   1. kernel (done)
 #   2. optimize_mcscf_ (done)
 #   3. compute_pdft_ (done)
-#   4. energy_tot (done) 
+#   4. energy_tot (done)
 #   5. get_energy_decomposition (done)
 #   6. checkpoint stuff
 #   7. get_pdft_veff (maybe this elsewhere?)
@@ -30,431 +30,603 @@
 # Some assertAlmostTrue thresholds are loose because we are only
 # trying to test the API here; we need tight convergence and grids
 # to reproduce well when OMP is on.
-import tempfile
+import tempfile, h5py
 import numpy as np
-from pyscf import gto, scf, mcscf, lib, fci, df
-from pyscf.fci.addons import fix_spin_
+from pyscf import gto, scf, mcscf, lib, fci
 from pyscf import mcpdft
 import unittest
 
 
-mol_nosym = mol_sym = mf_nosym = mf_sym = mc_nosym = mc_sym = mcp = None
-def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0', fnal='tPBE'):
-    mol_nosym = gto.M (atom = xyz, basis = 'sto3g', verbose = 0)
-    mol_sym = gto.M (atom = xyz, basis = 'sto3g', symmetry=True, verbose = 0)
-    mf_nosym = scf.RHF (mol_nosym).run ()
-    mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2).run (conv_tol=1e-8)
-    mf_sym = scf.RHF (mol_sym).run ()
-    mc_sym = mcscf.CASSCF (mf_sym, 5, 2).run (conv_tol=1e-8)
-    mcp_ss_nosym = mcpdft.CASSCF (mc_nosym, fnal, 5, 2).run (conv_tol=1e-8)
-    mcp_ss_sym = mcpdft.CASSCF (mc_sym, fnal, 5, 2).set(chkfile=tempfile.NamedTemporaryFile().name).run (conv_tol=1e-8)
-    mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5).run (conv_tol=1e-8)
-    solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
-    solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
-    mcp_sa_1 = mcp_ss_nosym.state_average_mix (
-        [solver_S,solver_T], [1.0/5,]*5).set(ci=None).run (conv_tol=1e-8)
-    solver_A1 = fci.solver (mol_sym).set (wfnsym='A1', nroots=3)
-    solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
-    solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)
-    mcp_sa_2 = mcp_ss_sym.state_average_mix (
-        [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None, chkfile=tempfile.NamedTemporaryFile().name).run (conv_tol=1e-8)
+mol_nosym = mol_sym = mf_nosym = mf_sym = mc_nosym = mc_sym = mcp = mc_chk = None
+
+
+def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
+    mol_nosym = gto.M(atom=xyz, basis="sto3g", verbose=0, output="/dev/null")
+    mol_sym = gto.M(
+        atom=xyz, basis="sto3g", symmetry=True, verbose=0, output="/dev/null"
+    )
+    mf_nosym = scf.RHF(mol_nosym).run()
+    mc_nosym = mcscf.CASSCF(mf_nosym, 5, 2).run(conv_tol=1e-8)
+    mf_sym = scf.RHF(mol_sym).run()
+    mc_sym = mcscf.CASSCF(mf_sym, 5, 2).run(conv_tol=1e-8)
+    mcp_ss_nosym = mcpdft.CASSCF(mc_nosym, fnal, 5, 2).run(conv_tol=1e-8)
+    mcp_ss_sym = (
+        mcpdft.CASSCF(mc_sym, fnal, 5, 2)
+        .set(chkfile=tempfile.NamedTemporaryFile().name)
+        .run(conv_tol=1e-8)
+    )
+    mcp_sa_0 = mcp_ss_nosym.state_average(
+        [
+            1.0 / 5,
+        ]
+        * 5
+    ).run(conv_tol=1e-8)
+    solver_S = fci.solver(mol_nosym, singlet=True).set(spin=0, nroots=2)
+    solver_T = fci.solver(mol_nosym, singlet=False).set(spin=2, nroots=3)
+    mcp_sa_1 = (
+        mcp_ss_nosym.state_average_mix(
+            [solver_S, solver_T],
+            [
+                1.0 / 5,
+            ]
+            * 5,
+        )
+        .set(ci=None)
+        .run(conv_tol=1e-8)
+    )
+    solver_A1 = fci.solver(mol_sym).set(wfnsym="A1", nroots=3)
+    solver_E1x = fci.solver(mol_sym).set(wfnsym="E1x", nroots=1, spin=2)
+    solver_E1y = fci.solver(mol_sym).set(wfnsym="E1y", nroots=1, spin=2)
+    mcp_sa_2 = (
+        mcp_ss_sym.state_average_mix(
+            [solver_A1, solver_E1x, solver_E1y],
+            [
+                1.0 / 5,
+            ]
+            * 5,
+        )
+        .set(ci=None, chkfile=tempfile.NamedTemporaryFile().name)
+        .run(conv_tol=1e-8)
+    )
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]
-    return nosym, sym, mcp
+    mc_chk = [mcp_ss_sym, mcp_sa_2]
+    return nosym, sym, mcp, mc_chk
+
 
 def setUpModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
-    nosym, sym, mcp = auto_setup ()
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+    nosym, sym, mcp, mc_chk = auto_setup()
     mol_nosym, mf_nosym, mc_nosym = nosym
     mol_sym, mf_sym, mc_sym = sym
 
+
 def tearDownModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
-    mol_nosym.stdout.close ()
-    mol_sym.stdout.close ()
-    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+    mol_nosym.stdout.close()
+    mol_sym.stdout.close()
+    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+
 
 class KnownValues(unittest.TestCase):
 
-    def test_init (self):
+    def test_init(self):
         ref_e = -7.924089707
         for symm in False, True:
             mol = (mol_nosym, mol_sym)[int(symm)]
             mf = (mf_nosym, mf_sym)[int(symm)]
             mc0 = (mc_nosym, mc_sym)[int(symm)]
-            for i, cls in enumerate ((mcpdft.CASCI, mcpdft.CASSCF)):
-                scf = bool (i)
+            for i, cls in enumerate((mcpdft.CASCI, mcpdft.CASSCF)):
+                scf = bool(i)
                 for my_init in (mol, mf, mc0):
                     init_name = my_init.__class__.__name__
-                    if init_name == 'Mole' and symm: continue
+                    if init_name == "Mole" and symm:
+                        continue
                     # ^ The underlying PySCF modules can't do this as of 02/06/2022
                     my_kwargs = {}
-                    if isinstance (my_init, gto.Mole) or (not scf):
-                        my_kwargs['mo_coeff'] = mc0.mo_coeff
-                    with self.subTest (symm=symm, scf=scf, init=init_name):
-                        mc = cls (my_init, 'tPBE', 5, 2).run (**my_kwargs)
-                        self.assertAlmostEqual (mc.e_tot, ref_e, delta=1e-6)
-                        self.assertTrue (mc.converged)
+                    if isinstance(my_init, gto.Mole) or (not scf):
+                        my_kwargs["mo_coeff"] = mc0.mo_coeff
+                    with self.subTest(symm=symm, scf=scf, init=init_name):
+                        mc = cls(my_init, "tPBE", 5, 2).run(**my_kwargs)
+                        self.assertAlmostEqual(mc.e_tot, ref_e, delta=1e-6)
+                        self.assertTrue(mc.converged)
 
-    def test_df (self):
+    def test_df(self):
         ref_e = -7.924259
         ref_e0_sa = -7.923959
-        for mf, symm in zip ((mf_nosym, mf_sym), (False, True)):
-            mf_df = mf.density_fit ()
+        for mf, symm in zip((mf_nosym, mf_sym), (False, True)):
+            mf_df = mf.density_fit()
             mo = (mc_nosym, mc_sym)[int(symm)].mo_coeff
-            for i, cls in enumerate ((mcpdft.CASCI, mcpdft.CASSCF)):
-                scf = bool (i)
-                mc = cls (mf_df, 'tPBE', 5, 2).run (mo_coeff=mo)
-                with self.subTest (symm=symm, scf=scf, nroots=1):
-                    self.assertAlmostEqual (mc.e_tot, ref_e, delta=1e-6)
-                    self.assertTrue (mc.converged)
+            for i, cls in enumerate((mcpdft.CASCI, mcpdft.CASSCF)):
+                scf = bool(i)
+                mc = cls(mf_df, "tPBE", 5, 2).run(mo_coeff=mo)
+                with self.subTest(symm=symm, scf=scf, nroots=1):
+                    self.assertAlmostEqual(mc.e_tot, ref_e, delta=1e-6)
+                    self.assertTrue(mc.converged)
                 nroots = 3
                 if scf:
-                    mc = mc.state_average ([1.0/nroots,]*nroots).run ()
+                    mc = mc.state_average(
+                        [
+                            1.0 / nroots,
+                        ]
+                        * nroots
+                    ).run()
                     e_states = mc.e_states
                     ref = ref_e0_sa
                 else:
                     mc.fcisolver.nroots = nroots
-                    mc.kernel ()
+                    mc.kernel()
                     e_states = mc.e_tot
                     ref = ref_e
-                with self.subTest (symm=symm, scf=scf, nroots=nroots):
-                    self.assertAlmostEqual (e_states[0], ref, delta=1e-6)
-                    self.assertTrue (mc.converged)
-                
+                with self.subTest(symm=symm, scf=scf, nroots=nroots):
+                    self.assertAlmostEqual(e_states[0], ref, delta=1e-6)
+                    self.assertTrue(mc.converged)
 
-    def test_state_average (self): 
+    def test_state_average(self):
         # grids_level = 6
-        #ref = np.array ([-7.9238958646710085,-7.7887395616498125,-7.7761692676370355,
-        #                 -7.754856419853813,-7.754856419853812,]) 
+        # ref = np.array ([-7.9238958646710085,-7.7887395616498125,-7.7761692676370355,
+        #                 -7.754856419853813,-7.754856419853812,])
         # grids_level = 5
-        #ref = np.array ([-7.923895345983219,-7.788739501036741,-7.776168040902887,
+        # ref = np.array ([-7.923895345983219,-7.788739501036741,-7.776168040902887,
         #                 -7.75485647715595,-7.7548564771559505])
         # grids_level = 4
-        #ref = np.array ([-7.923894841822498,-7.788739444709943,-7.776169108993544,
+        # ref = np.array ([-7.923894841822498,-7.788739444709943,-7.776169108993544,
         #                 -7.754856321482755,-7.754856321482756])
         # grids_level = 3
-        ref = np.array ([-7.923894179700609,-7.7887396628199,-7.776172495309403,
-                         -7.754856085624646,-7.754856085624647])
+        ref = np.array(
+            [
+                -7.923894179700609,
+                -7.7887396628199,
+                -7.776172495309403,
+                -7.754856085624646,
+                -7.754856085624647,
+            ]
+        )
         # TODO: figure out why SA always needs more precision than SS to get
         # the same repeatability. Fix if possible? In the mean time, loose
         # deltas below for the sake of speed.
-        for ix, mc in enumerate (mcp[1]):
-            with self.subTest (symmetry=bool(ix//2), triplet_ms=(0,1,'mixed')[ix]):
-                self.assertTrue (mc.converged)
-                self.assertAlmostEqual (lib.fp (np.sort (mc.e_states)), lib.fp (ref), delta=1e-5)
-                self.assertAlmostEqual (mc.e_tot, np.average (ref), delta=1e-5)
+        for ix, mc in enumerate(mcp[1]):
+            with self.subTest(symmetry=bool(ix // 2), triplet_ms=(0, 1, "mixed")[ix]):
+                self.assertTrue(mc.converged)
+                self.assertAlmostEqual(
+                    lib.fp(np.sort(mc.e_states)), lib.fp(ref), delta=1e-5
+                )
+                self.assertAlmostEqual(mc.e_tot, np.average(ref), delta=1e-5)
 
-    def test_casci_multistate (self):
+    def test_casci_multistate(self):
         # grids_level = 3
-        ref = np.array ([-7.923894179700609,-7.7887396628199,-7.776172495309403,
-                         -7.754856085624646,-7.754856085624647])
-        mc = mcpdft.CASCI (mcp[1][0], 'tPBE', 5, 2)
+        ref = np.array(
+            [
+                -7.923894179700609,
+                -7.7887396628199,
+                -7.776172495309403,
+                -7.754856085624646,
+                -7.754856085624647,
+            ]
+        )
+        mc = mcpdft.CASCI(mcp[1][0], "tPBE", 5, 2)
         mc.fcisolver.nroots = 5
-        mc.kernel ()
-        with self.subTest (symmetry=False):
-            self.assertTrue (mc.converged)
-            self.assertAlmostEqual (lib.fp (np.sort (mc.e_tot)), lib.fp (ref), delta=1e-5)
-            self.assertAlmostEqual (np.average (mc.e_tot), np.average (ref), delta=1e-5)
+        mc.kernel()
+        with self.subTest(symmetry=False):
+            self.assertTrue(mc.converged)
+            self.assertAlmostEqual(lib.fp(np.sort(mc.e_tot)), lib.fp(ref), delta=1e-5)
+            self.assertAlmostEqual(np.average(mc.e_tot), np.average(ref), delta=1e-5)
         e_tot = []
-        mc = mcpdft.CASCI (mcp[1][2], 'tPBE', 5, 2)
+        mc = mcpdft.CASCI(mcp[1][2], "tPBE", 5, 2)
         ci_ref = mcp[1][2].ci
-        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[:3], 3, 'A1'
-        mc.kernel ()
-        self.assertTrue (mc.converged)
-        e_tot.extend (mc.e_tot)
-        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[3], 1, 'E1x'
+        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[:3], 3, "A1"
+        mc.kernel()
+        self.assertTrue(mc.converged)
+        e_tot.extend(mc.e_tot)
+        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[3], 1, "E1x"
         mc.fcisolver.spin = 2
-        mc.kernel ()
-        self.assertTrue (mc.converged)
-        e_tot.append (mc.e_tot)
-        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[4], 1, 'E1y'
-        mc.kernel ()
-        self.assertTrue (mc.converged)
-        e_tot.append (mc.e_tot)
-        with self.subTest (symmetry=True):
-            self.assertTrue (mc.converged)
-            self.assertAlmostEqual (lib.fp (np.sort (e_tot)), lib.fp (ref), delta=1e-5)
-            self.assertAlmostEqual (np.average (e_tot), np.average (ref), delta=1e-5)
+        mc.kernel()
+        self.assertTrue(mc.converged)
+        e_tot.append(mc.e_tot)
+        mc.ci, mc.fcisolver.nroots, mc.fcisolver.wfnsym = ci_ref[4], 1, "E1y"
+        mc.kernel()
+        self.assertTrue(mc.converged)
+        e_tot.append(mc.e_tot)
+        with self.subTest(symmetry=True):
+            self.assertTrue(mc.converged)
+            self.assertAlmostEqual(lib.fp(np.sort(e_tot)), lib.fp(ref), delta=1e-5)
+            self.assertAlmostEqual(np.average(e_tot), np.average(ref), delta=1e-5)
 
-    def test_decomposition_ss (self): # TODO
-        ref = [1.0583544218,-12.5375911135, 5.8093938665, -2.1716353580, -0.0826115115, -2.2123063329]
-        terms = ['nuc', 'core', 'Coulomb', 'OT(X)', 'OT(C)', 'WFN(XC)']
-        for ix, mc in enumerate (mcp[0]):
-            casci = mcpdft.CASCI (mc, 'tPBE', 5, 2).run ()
-            for obj, objtype in zip ((mc, casci), ('CASSCF', 'CASCI')):
-                test = obj.get_energy_decomposition ()
-                for t, r, term in zip (test, ref, terms):
-                    with self.subTest (objtype=objtype, symmetry=bool(ix), term=term):
-                        self.assertAlmostEqual (t, r, delta=1e-5)
-                with self.subTest (objtype=objtype, symmetry=bool(ix), term='sanity'):
-                    self.assertAlmostEqual (np.sum (test[:-1]), obj.e_tot, 9)
-            
+    def test_decomposition_ss(self):  # TODO
+        ref = [
+            1.0583544218,
+            -12.5375911135,
+            5.8093938665,
+            -2.1716353580,
+            -0.0826115115,
+            -2.2123063329,
+        ]
+        terms = ["nuc", "core", "Coulomb", "OT(X)", "OT(C)", "WFN(XC)"]
+        for ix, mc in enumerate(mcp[0]):
+            casci = mcpdft.CASCI(mc, "tPBE", 5, 2).run()
+            for obj, objtype in zip((mc, casci), ("CASSCF", "CASCI")):
+                test = obj.get_energy_decomposition()
+                for t, r, term in zip(test, ref, terms):
+                    with self.subTest(objtype=objtype, symmetry=bool(ix), term=term):
+                        self.assertAlmostEqual(t, r, delta=1e-5)
+                with self.subTest(objtype=objtype, symmetry=bool(ix), term="sanity"):
+                    self.assertAlmostEqual(np.sum(test[:-1]), obj.e_tot, 9)
 
-    def test_decomposition_sa (self):
+    def test_decomposition_sa(self):
         ref_nuc = 1.0583544218
-        ref_states = np.array ([[-12.5385413915, 5.8109724796, -2.1720331222, -0.0826465641, -2.2127964255],
-                                [-12.1706553996, 5.5463231972, -2.1601539256, -0.0626079593, -2.1943087132],
-                                [-12.1768195314, 5.5632261670, -2.1552571900, -0.0656763663, -2.1887042769],
-                                [-12.1874226655, 5.5856701424, -2.1481995107, -0.0632609608, -2.1690856659],
-                                [-12.1874226655, 5.5856701424, -2.1481995107, -0.0632609608, -2.1690856659]])
-        terms = ['core', 'Coulomb', 'OT(X)', 'OT(C)', 'WFN(XC)']
-        for ix, (mc,ms) in enumerate (zip (mcp[1], [0,1,'mixed'])):
-            s = bool(ix//2)
-            objs = [mc,]
-            objtypes = ['CASSCF',]
-            if ix != 1: # There is no CASCI equivalent to mcp[1][1]
-                casci = mcpdft.CASCI (mc, 'tPBE', 5, 2)
-                casci.fcisolver.nroots = 5-ix # Just check the A1 roots when symmetry is enabled
-                casci.ci = mc.ci[:5-ix]
-                casci.kernel ()
-                objs.append (casci)
-                objtypes.append ('CASCI')
-            for obj, objtype in zip (objs, objtypes):
-                test = obj.get_energy_decomposition ()
-                test_nuc, test_states = test[0], np.array (test[1:]).T
+        ref_states = np.array(
+            [
+                [
+                    -12.5385413915,
+                    5.8109724796,
+                    -2.1720331222,
+                    -0.0826465641,
+                    -2.2127964255,
+                ],
+                [
+                    -12.1706553996,
+                    5.5463231972,
+                    -2.1601539256,
+                    -0.0626079593,
+                    -2.1943087132,
+                ],
+                [
+                    -12.1768195314,
+                    5.5632261670,
+                    -2.1552571900,
+                    -0.0656763663,
+                    -2.1887042769,
+                ],
+                [
+                    -12.1874226655,
+                    5.5856701424,
+                    -2.1481995107,
+                    -0.0632609608,
+                    -2.1690856659,
+                ],
+                [
+                    -12.1874226655,
+                    5.5856701424,
+                    -2.1481995107,
+                    -0.0632609608,
+                    -2.1690856659,
+                ],
+            ]
+        )
+        terms = ["core", "Coulomb", "OT(X)", "OT(C)", "WFN(XC)"]
+        for ix, (mc, ms) in enumerate(zip(mcp[1], [0, 1, "mixed"])):
+            s = bool(ix // 2)
+            objs = [
+                mc,
+            ]
+            objtypes = [
+                "CASSCF",
+            ]
+            if ix != 1:  # There is no CASCI equivalent to mcp[1][1]
+                casci = mcpdft.CASCI(mc, "tPBE", 5, 2)
+                casci.fcisolver.nroots = (
+                    5 - ix
+                )  # Just check the A1 roots when symmetry is enabled
+                casci.ci = mc.ci[: 5 - ix]
+                casci.kernel()
+                objs.append(casci)
+                objtypes.append("CASCI")
+            for obj, objtype in zip(objs, objtypes):
+                test = obj.get_energy_decomposition()
+                test_nuc, test_states = test[0], np.array(test[1:]).T
                 # Arrange states in ascending energy order
-                e_states = getattr (obj, 'e_states', obj.e_tot)
-                idx = np.argsort (e_states)
-                test_states = test_states[idx,:]
-                e_ref = np.array (e_states)[idx] 
-                with self.subTest (objtype=objtype, symmetry=s, triplet_ms=ms, term='nuc'):
-                    self.assertAlmostEqual (test_nuc, ref_nuc, 9)
-                for state, (test, ref) in enumerate (zip (test_states, ref_states)):
-                    for t, r, term in zip (test, ref, terms):
-                        with self.subTest (objtype=objtype, symmetry=s, triplet_ms=ms, term=term, state=state):
-                            self.assertAlmostEqual (t, r, delta=1e-5)
-                    with self.subTest (objtype=objtype, symmetry=s, triplet_ms=ms, term='sanity', state=state):
-                        self.assertAlmostEqual (np.sum (test[:-1])+test_nuc, e_ref[state], 9)
+                e_states = getattr(obj, "e_states", obj.e_tot)
+                idx = np.argsort(e_states)
+                test_states = test_states[idx, :]
+                e_ref = np.array(e_states)[idx]
+                with self.subTest(
+                    objtype=objtype, symmetry=s, triplet_ms=ms, term="nuc"
+                ):
+                    self.assertAlmostEqual(test_nuc, ref_nuc, 9)
+                for state, (test, ref) in enumerate(zip(test_states, ref_states)):
+                    for t, r, term in zip(test, ref, terms):
+                        with self.subTest(
+                            objtype=objtype,
+                            symmetry=s,
+                            triplet_ms=ms,
+                            term=term,
+                            state=state,
+                        ):
+                            self.assertAlmostEqual(t, r, delta=1e-5)
+                    with self.subTest(
+                        objtype=objtype,
+                        symmetry=s,
+                        triplet_ms=ms,
+                        term="sanity",
+                        state=state,
+                    ):
+                        self.assertAlmostEqual(
+                            np.sum(test[:-1]) + test_nuc, e_ref[state], 9
+                        )
 
-
-    def test_energy_tot (self):
+    def test_energy_tot(self):
         # Test both correctness and energy_tot function purity
-        def get_attr (mc):
-            mo_ref = lib.fp (mc.mo_coeff)
-            ci_ref = lib.fp (np.concatenate (mc.ci, axis=None))
-            e_states_ref = lib.fp (getattr (mc, 'e_states', 0))
+        def get_attr(mc):
+            mo_ref = lib.fp(mc.mo_coeff)
+            ci_ref = lib.fp(np.concatenate(mc.ci, axis=None))
+            e_states_ref = lib.fp(getattr(mc, "e_states", 0))
             return mo_ref, ci_ref, mc.e_tot, e_states_ref, mc.grids.level, mc.otxc
-        def test_energy_tot_crunch (test_list, ref_list, casestr):
-            for ix, (t, r) in enumerate (zip (test_list, ref_list)):
-                with self.subTest (case=casestr, item=ix):
-                    if isinstance (t, (float, np.floating)):
-                        self.assertAlmostEqual (t, r, delta=1e-5)
-                    else:
-                        self.assertEqual (t, r)
-        def test_energy_tot_loop_ss (e_ref_ss, diff, **kwargs):
-            for ix, mc in enumerate (mcp[0]):
-                ref_list = [e_ref_ss] + list (get_attr (mc))
-                e_test = mc.energy_tot (**kwargs)[0]
-                test_list = [e_test] + list (get_attr (mc))
-                casestr = 'diff={}; SS; symmetry={}'.format (diff, bool(ix))
-                test_energy_tot_crunch (test_list, ref_list, casestr)
-        def test_energy_tot_loop_sa (e_ref_sa, diff, **kwargs):
-            for ix, mc in enumerate (mcp[1]):
-                ref_list = [e_ref_sa] + list (get_attr (mc))
-                e_s0_test = mc.energy_tot (**kwargs)[0]
-                test_list = [e_s0_test] + list (get_attr (mc))
-                sym = bool(ix//2)
-                tms = (0,1,'mixed')[ix]
-                casestr = 'diff={}; SA; symmetry={}; triplet_ms={}'.format (diff, sym, tms)
-                test_energy_tot_crunch (test_list, ref_list, casestr)
-        def test_energy_tot_loop (e_ref_ss, e_ref_sa, diff, **kwargs):
-            test_energy_tot_loop_ss (e_ref_ss, diff, **kwargs)
-            test_energy_tot_loop_sa (e_ref_sa, diff, **kwargs)
-        # tBLYP
-        e_ref_ss = mcpdft.CASSCF (mcp[0][0], 'tBLYP', 5, 2).kernel ()[0]
-        mc_ref = mcpdft.CASSCF (mcp[1][0], 'tBLYP', 5, 2).state_average ([1.0/5,]*5).run ()
-        e_ref_sa = mc_ref.e_states[0]
-        test_energy_tot_loop (e_ref_ss, e_ref_sa, 'fnal', otxc='tBLYP')
-        # grids_level = 2
-        e_ref_ss = mcpdft.CASSCF (mcp[0][0], 'tPBE', 5, 2, grids_level=2).kernel ()[0]
-        mc_ref = mcpdft.CASSCF (mcp[1][0], 'tPBE', 5, 2, grids_level=2).state_average ([1.0/5,]*5).run ()
-        e_ref_sa = mc_ref.e_states[0]
-        test_energy_tot_loop (e_ref_ss, e_ref_sa, 'grids', grids_level=2)
-        # CASCI wfn
-        mc_ref = mcpdft.CASCI (mf_nosym, 'tPBE', 5, 2).run ()
-        test_energy_tot_loop_ss (mc_ref.e_tot, 'wfn', mo_coeff=mc_ref.mo_coeff, ci=mc_ref.ci)
-        fake_ci = [c.copy () for c in mcp[1][0].ci]
-        fake_ci[0] = mc_ref.ci.copy ()
-        test_energy_tot_loop_sa (mc_ref.e_tot, 'wfn', mo_coeff=mc_ref.mo_coeff, ci=fake_ci)
 
-    def test_kernel_steps_casscf (self):
+        def test_energy_tot_crunch(test_list, ref_list, casestr):
+            for ix, (t, r) in enumerate(zip(test_list, ref_list)):
+                with self.subTest(case=casestr, item=ix):
+                    if isinstance(t, (float, np.floating)):
+                        self.assertAlmostEqual(t, r, delta=1e-5)
+                    else:
+                        self.assertEqual(t, r)
+
+        def test_energy_tot_loop_ss(e_ref_ss, diff, **kwargs):
+            for ix, mc in enumerate(mcp[0]):
+                ref_list = [e_ref_ss] + list(get_attr(mc))
+                e_test = mc.energy_tot(**kwargs)[0]
+                test_list = [e_test] + list(get_attr(mc))
+                casestr = "diff={}; SS; symmetry={}".format(diff, bool(ix))
+                test_energy_tot_crunch(test_list, ref_list, casestr)
+
+        def test_energy_tot_loop_sa(e_ref_sa, diff, **kwargs):
+            for ix, mc in enumerate(mcp[1]):
+                ref_list = [e_ref_sa] + list(get_attr(mc))
+                e_s0_test = mc.energy_tot(**kwargs)[0]
+                test_list = [e_s0_test] + list(get_attr(mc))
+                sym = bool(ix // 2)
+                tms = (0, 1, "mixed")[ix]
+                casestr = "diff={}; SA; symmetry={}; triplet_ms={}".format(
+                    diff, sym, tms
+                )
+                test_energy_tot_crunch(test_list, ref_list, casestr)
+
+        def test_energy_tot_loop(e_ref_ss, e_ref_sa, diff, **kwargs):
+            test_energy_tot_loop_ss(e_ref_ss, diff, **kwargs)
+            test_energy_tot_loop_sa(e_ref_sa, diff, **kwargs)
+
+        # tBLYP
+        e_ref_ss = mcpdft.CASSCF(mcp[0][0], "tBLYP", 5, 2).kernel()[0]
+        mc_ref = (
+            mcpdft.CASSCF(mcp[1][0], "tBLYP", 5, 2)
+            .state_average(
+                [
+                    1.0 / 5,
+                ]
+                * 5
+            )
+            .run()
+        )
+        e_ref_sa = mc_ref.e_states[0]
+        test_energy_tot_loop(e_ref_ss, e_ref_sa, "fnal", otxc="tBLYP")
+        # grids_level = 2
+        e_ref_ss = mcpdft.CASSCF(mcp[0][0], "tPBE", 5, 2, grids_level=2).kernel()[0]
+        mc_ref = (
+            mcpdft.CASSCF(mcp[1][0], "tPBE", 5, 2, grids_level=2)
+            .state_average(
+                [
+                    1.0 / 5,
+                ]
+                * 5
+            )
+            .run()
+        )
+        e_ref_sa = mc_ref.e_states[0]
+        test_energy_tot_loop(e_ref_ss, e_ref_sa, "grids", grids_level=2)
+        # CASCI wfn
+        mc_ref = mcpdft.CASCI(mf_nosym, "tPBE", 5, 2).run()
+        test_energy_tot_loop_ss(
+            mc_ref.e_tot, "wfn", mo_coeff=mc_ref.mo_coeff, ci=mc_ref.ci
+        )
+        fake_ci = [c.copy() for c in mcp[1][0].ci]
+        fake_ci[0] = mc_ref.ci.copy()
+        test_energy_tot_loop_sa(
+            mc_ref.e_tot, "wfn", mo_coeff=mc_ref.mo_coeff, ci=fake_ci
+        )
+
+    def test_kernel_steps_casscf(self):
         ref_tot = -7.919939037859329
         ref_ot = -2.2384273324895165
         mo_ref = 0.9925428665189101
         ci_ref = 0.9886507094634355
-        for ix, mc in enumerate (mcp[0]):
+        for ix, mc in enumerate(mcp[0]):
             e_tot = mc.e_tot
             e_ot = mc.e_ot
             e_mcscf = mc.e_mcscf
-            mo = (mf_nosym, mf_sym)[ix].mo_coeff.copy ()
-            ci = np.zeros_like (mc.ci)
-            ci[0,0] = 1.0
+            mo = (mf_nosym, mf_sym)[ix].mo_coeff.copy()
+            ci = np.zeros_like(mc.ci)
+            ci[0, 0] = 1.0
             mc.compute_pdft_energy_(mo_coeff=mo, ci=ci)
-            with self.subTest (case='SS', part='pdft1', symmetry=bool(ix)):
-                self.assertEqual (lib.fp (mc.mo_coeff), lib.fp (mo))
-                self.assertEqual (lib.fp (mc.ci), lib.fp (ci))
-                self.assertEqual (mc.e_mcscf, e_mcscf)
-                self.assertAlmostEqual (mc.e_tot, ref_tot, 9)
-                self.assertAlmostEqual (mc.e_ot, ref_ot, 7)
+            with self.subTest(case="SS", part="pdft1", symmetry=bool(ix)):
+                self.assertEqual(lib.fp(mc.mo_coeff), lib.fp(mo))
+                self.assertEqual(lib.fp(mc.ci), lib.fp(ci))
+                self.assertEqual(mc.e_mcscf, e_mcscf)
+                self.assertAlmostEqual(mc.e_tot, ref_tot, 9)
+                self.assertAlmostEqual(mc.e_ot, ref_ot, 7)
             mc.e_tot = 0.0
             mc.e_ot = 0.0
             mc.optimize_mcscf_()
-            with self.subTest (case='SS', part='mcscf', symmetry=bool(ix)):
-                self.assertEqual (mc.e_tot, 0.0)
-                self.assertEqual (mc.e_ot, 0.0)
-                self.assertAlmostEqual (abs(mc.mo_coeff[0,0]), mo_ref, delta=1e-5)
-                self.assertAlmostEqual (abs(mc.ci[0,0]), ci_ref, delta=1e-5)
-                self.assertAlmostEqual (mc.e_mcscf, e_mcscf, 9)
+            with self.subTest(case="SS", part="mcscf", symmetry=bool(ix)):
+                self.assertEqual(mc.e_tot, 0.0)
+                self.assertEqual(mc.e_ot, 0.0)
+                self.assertAlmostEqual(abs(mc.mo_coeff[0, 0]), mo_ref, delta=1e-5)
+                self.assertAlmostEqual(abs(mc.ci[0, 0]), ci_ref, delta=1e-5)
+                self.assertAlmostEqual(mc.e_mcscf, e_mcscf, 9)
             mc.compute_pdft_energy_()
-            with self.subTest (case='SS', part='pdft2', symmetry=bool(ix)):
-                self.assertAlmostEqual (mc.e_tot, e_tot, delta=1e-6)
-                self.assertAlmostEqual (mc.e_ot, e_ot, delta=1e-6)
+            with self.subTest(case="SS", part="pdft2", symmetry=bool(ix)):
+                self.assertAlmostEqual(mc.e_tot, e_tot, delta=1e-6)
+                self.assertAlmostEqual(mc.e_ot, e_ot, delta=1e-6)
         mo_ref = 0.9908324004974881
         ci_ref = 0.988599145861302
         ref_avg = -7.7986453
-        for ix, mc in enumerate (mcp[1]):
-            sym = bool(ix//2)
-            tms = (0,1,'mixed')[ix]
+        for ix, mc in enumerate(mcp[1]):
+            sym = bool(ix // 2)
+            tms = (0, 1, "mixed")[ix]
             e_tot = mc.e_tot
-            e_ot = np.array (mc.e_ot)
-            e_mcscf = np.array (mc.e_mcscf)
-            e_states = np.array (mc.e_states)
-            nroots = len (e_mcscf)
-            mo = (mf_nosym, mf_sym)[int(sym)].mo_coeff.copy ()
-            ci = [c.copy () for c in mc.ci]
-            ci[0][:,:] = 0.0
-            ci[0][0,0] = 1.0
-            fp_fake_ci = lib.fp (np.concatenate (ci, axis=None))
+            e_ot = np.array(mc.e_ot)
+            e_mcscf = np.array(mc.e_mcscf)
+            e_states = np.array(mc.e_states)
+            nroots = len(e_mcscf)
+            mo = (mf_nosym, mf_sym)[int(sym)].mo_coeff.copy()
+            ci = [c.copy() for c in mc.ci]
+            ci[0][:, :] = 0.0
+            ci[0][0, 0] = 1.0
+            fp_fake_ci = lib.fp(np.concatenate(ci, axis=None))
             mc.compute_pdft_energy_(mo_coeff=mo, ci=ci)
-            with self.subTest (case='SA', part='pdft1', symmetry=sym, triplet_ms=tms):
-                self.assertEqual (lib.fp (mc.mo_coeff), lib.fp (mo))
-                self.assertEqual (lib.fp (np.concatenate (mc.ci, axis=None)), fp_fake_ci)
-                self.assertEqual (lib.fp (mc.e_mcscf), lib.fp (e_mcscf))
-                self.assertAlmostEqual (mc.e_tot, ref_avg, delta=1e-5)
-                self.assertAlmostEqual (mc.e_states[0], ref_tot, 9)
-                self.assertAlmostEqual (mc.e_ot[0], ref_ot, 7)
+            with self.subTest(case="SA", part="pdft1", symmetry=sym, triplet_ms=tms):
+                self.assertEqual(lib.fp(mc.mo_coeff), lib.fp(mo))
+                self.assertEqual(lib.fp(np.concatenate(mc.ci, axis=None)), fp_fake_ci)
+                self.assertEqual(lib.fp(mc.e_mcscf), lib.fp(e_mcscf))
+                self.assertAlmostEqual(mc.e_tot, ref_avg, delta=1e-5)
+                self.assertAlmostEqual(mc.e_states[0], ref_tot, 9)
+                self.assertAlmostEqual(mc.e_ot[0], ref_ot, 7)
             mc.e_tot = 0.0
-            mc.e_ot = [0.0,]*len(mc.e_ot)
-            mc.fcisolver.e_states = [0.0,]*len(mc.e_states)
+            mc.e_ot = [
+                0.0,
+            ] * len(mc.e_ot)
+            mc.fcisolver.e_states = [
+                0.0,
+            ] * len(mc.e_states)
             mc.optimize_mcscf_()
-            with self.subTest (case='SA', part='mcscf', symmetry=sym, triplet_ms=tms):
-                self.assertEqual (mc.e_tot, 0.0)
-                self.assertEqual (lib.fp (mc.e_ot), 0.0)
-                self.assertEqual (lib.fp (mc.e_states), 0.0)
-                self.assertAlmostEqual (abs(mc.mo_coeff[0,0]), mo_ref, delta=1e-5)
-                self.assertAlmostEqual (abs(mc.ci[0][0,0]), ci_ref, delta=1e-5)
-                self.assertAlmostEqual (lib.fp (mc.e_mcscf), lib.fp (e_mcscf), 7)
+            with self.subTest(case="SA", part="mcscf", symmetry=sym, triplet_ms=tms):
+                self.assertEqual(mc.e_tot, 0.0)
+                self.assertEqual(lib.fp(mc.e_ot), 0.0)
+                self.assertEqual(lib.fp(mc.e_states), 0.0)
+                self.assertAlmostEqual(abs(mc.mo_coeff[0, 0]), mo_ref, delta=1e-5)
+                self.assertAlmostEqual(abs(mc.ci[0][0, 0]), ci_ref, delta=1e-5)
+                self.assertAlmostEqual(lib.fp(mc.e_mcscf), lib.fp(e_mcscf), 7)
             mc.compute_pdft_energy_()
-            with self.subTest (case='SA', part='pdft2', symmetry=sym, triplet_ms=tms):
-                self.assertAlmostEqual (mc.e_tot, e_tot, delta=1e-5)
-                self.assertAlmostEqual (lib.fp (mc.e_ot), lib.fp (e_ot), delta=1e-5)
-                self.assertAlmostEqual (lib.fp (mc.e_states), lib.fp (e_states), delta=1e-5)
+            with self.subTest(case="SA", part="pdft2", symmetry=sym, triplet_ms=tms):
+                self.assertAlmostEqual(mc.e_tot, e_tot, delta=1e-5)
+                self.assertAlmostEqual(lib.fp(mc.e_ot), lib.fp(e_ot), delta=1e-5)
+                self.assertAlmostEqual(
+                    lib.fp(mc.e_states), lib.fp(e_states), delta=1e-5
+                )
 
-    def test_kernel_steps_casci (self):
+    def test_kernel_steps_casci(self):
         ref_tot = -7.919924747436255
         ref_ot = -2.238538447576774
         ci_ref = 0.9886507094634355
-        for nroots in range (1,3):
-            for init, symmetry in zip (mcp[0], (False, True)):
-                mc = mcpdft.CASCI (init, 'tPBE', 5, 2)
+        for nroots in range(1, 3):
+            for init, symmetry in zip(mcp[0], (False, True)):
+                mc = mcpdft.CASCI(init, "tPBE", 5, 2)
                 mc.fcisolver.nroots = nroots
-                if nroots>1: mc.ci = None
-                mc.kernel ()
-                e_tot = np.atleast_1d (mc.e_tot)[0]
-                e_ot = np.atleast_1d (mc.e_ot)[0]
-                e_mcscf = np.atleast_1d (mc.e_mcscf)[0]
-                ci = np.zeros_like (mc.ci)
+                if nroots > 1:
+                    mc.ci = None
+                mc.kernel()
+                e_tot = np.atleast_1d(mc.e_tot)[0]
+                e_ot = np.atleast_1d(mc.e_ot)[0]
+                e_mcscf = np.atleast_1d(mc.e_mcscf)[0]
+                ci = np.zeros_like(mc.ci)
                 ci.flat[0] = 1.0
-                if nroots>1: ci = list (ci)
+                if nroots > 1:
+                    ci = list(ci)
                 # pyscf PR #1623 made direct_spin1_symm unable to interpret
                 # a 3D fci vector array
                 mc.compute_pdft_energy_(ci=ci)
-                with self.subTest (part='pdft1', symmetry=symmetry, nroots=nroots):
-                    self.assertEqual (lib.fp (np.array(mc.ci)), lib.fp (ci), 9)
-                    self.assertEqual (np.atleast_1d (mc.e_mcscf)[0], e_mcscf)
-                    self.assertAlmostEqual (np.atleast_1d (mc.e_tot)[0], ref_tot, 7)
-                    self.assertAlmostEqual (np.atleast_1d (mc.e_ot)[0], ref_ot, 7)
+                with self.subTest(part="pdft1", symmetry=symmetry, nroots=nroots):
+                    self.assertEqual(lib.fp(np.array(mc.ci)), lib.fp(ci), 9)
+                    self.assertEqual(np.atleast_1d(mc.e_mcscf)[0], e_mcscf)
+                    self.assertAlmostEqual(np.atleast_1d(mc.e_tot)[0], ref_tot, 7)
+                    self.assertAlmostEqual(np.atleast_1d(mc.e_ot)[0], ref_ot, 7)
                 mc.e_tot = 0.0
                 mc.e_ot = 0.0
                 mc.optimize_mcscf_()
-                with self.subTest (part='mcscf', symmetry=symmetry, nroots=nroots):
-                    self.assertEqual (np.atleast_1d (mc.e_tot)[0], 0.0)
-                    self.assertEqual (np.atleast_1d (mc.e_ot)[0], 0.0)
-                    self.assertAlmostEqual (abs(np.asarray (mc.ci).flat[0]), ci_ref, delta=1e-5)
-                    self.assertAlmostEqual (np.atleast_1d (mc.e_mcscf)[0], e_mcscf, 9)
+                with self.subTest(part="mcscf", symmetry=symmetry, nroots=nroots):
+                    self.assertEqual(np.atleast_1d(mc.e_tot)[0], 0.0)
+                    self.assertEqual(np.atleast_1d(mc.e_ot)[0], 0.0)
+                    self.assertAlmostEqual(
+                        abs(np.asarray(mc.ci).flat[0]), ci_ref, delta=1e-5
+                    )
+                    self.assertAlmostEqual(np.atleast_1d(mc.e_mcscf)[0], e_mcscf, 9)
                 mc.compute_pdft_energy_()
-                with self.subTest (part='pdft2', symmetry=symmetry, nroots=nroots):
-                    self.assertAlmostEqual (np.atleast_1d (mc.e_tot)[0], e_tot, delta=1e-5)
-                    self.assertAlmostEqual (np.atleast_1d (mc.e_ot)[0], e_ot, delta=1e-5)
+                with self.subTest(part="pdft2", symmetry=symmetry, nroots=nroots):
+                    self.assertAlmostEqual(
+                        np.atleast_1d(mc.e_tot)[0], e_tot, delta=1e-5
+                    )
+                    self.assertAlmostEqual(np.atleast_1d(mc.e_ot)[0], e_ot, delta=1e-5)
 
-    def test_scanner (self):
+    def test_scanner(self):
         # Putting more energy into CASSCF than CASCI scanner because this is
         # necessary for geometry optimization, which isn't available for CASCI
-        mcp1 = auto_setup (xyz='Li 0 0 0\nH 1.55 0 0')[-1]
-        for mol0, mc0, mc1 in zip ([mol_nosym, mol_sym], mcp[0], mcp1[0]):
-            mc_scan = mc1.as_scanner ()
-            with self.subTest (case='SS CASSCF', symm=mol0.symmetry):
-               self.assertAlmostEqual (mc_scan (mol0), mc0.e_tot, delta=1e-6)
-            mc2 = mcpdft.CASCI (mc1, 'tPBE', 5, 2).run (mo_coeff=mc1.mo_coeff)
-            mc_scan = mc2.as_scanner ()
-            mc_scan._scf (mol0) # TODO: fix this in CASCI as_scanner
-                # when you pass mo_coeff on call, it skips updating the _scf
-                # object geometry. This breaks things like CASCI.energy_nuc (),
-                # CASCI.get_hcore (), etc. which refer to the corresponding
-                # _scf fns but don't default to CASCI self.mol
-            e_tot = mc_scan (mol0, mo_coeff=mc0.mo_coeff, ci0=mc0.ci)
-            with self.subTest (case='SS CASCI', symm=mol0.symmetry):
-                 self.assertAlmostEqual (e_tot, mc0.e_tot, delta=1e-6)
-        for ix, (mc0, mc1) in enumerate (zip (mcp[1], mcp1[1])):
-            tms = (0,1,'mixed')[ix]
-            sym = bool (ix//2)
+        mcp1 = auto_setup(xyz="Li 0 0 0\nH 1.55 0 0")[-1]
+        for mol0, mc0, mc1 in zip([mol_nosym, mol_sym], mcp[0], mcp1[0]):
+            mc_scan = mc1.as_scanner()
+            with self.subTest(case="SS CASSCF", symm=mol0.symmetry):
+                self.assertAlmostEqual(mc_scan(mol0), mc0.e_tot, delta=1e-6)
+            mc2 = mcpdft.CASCI(mc1, "tPBE", 5, 2).run(mo_coeff=mc1.mo_coeff)
+            mc_scan = mc2.as_scanner()
+            mc_scan._scf(mol0)  # TODO: fix this in CASCI as_scanner
+            # when you pass mo_coeff on call, it skips updating the _scf
+            # object geometry. This breaks things like CASCI.energy_nuc (),
+            # CASCI.get_hcore (), etc. which refer to the corresponding
+            # _scf fns but don't default to CASCI self.mol
+            e_tot = mc_scan(mol0, mo_coeff=mc0.mo_coeff, ci0=mc0.ci)
+            with self.subTest(case="SS CASCI", symm=mol0.symmetry):
+                self.assertAlmostEqual(e_tot, mc0.e_tot, delta=1e-6)
+        for ix, (mc0, mc1) in enumerate(zip(mcp[1], mcp1[1])):
+            tms = (0, 1, "mixed")[ix]
+            sym = bool(ix // 2)
             mol0 = [mol_nosym, mol_sym][int(sym)]
-            with self.subTest (case='SA CASSCF', symm=mol0.symmetry, triplet_ms=tms):
-                mc_scan = mc1.as_scanner ()
-                e_tot = mc_scan (mol0)
-                e_states_fp = lib.fp (np.sort (mc_scan.e_states))
-                e_states_fp_ref = lib.fp (np.sort (mc0.e_states))
-                self.assertAlmostEqual (e_tot, mc0.e_tot, delta=1e-6)
-                self.assertAlmostEqual (e_states_fp, e_states_fp_ref, delta=5e-6)
-        mc2 = mcpdft.CASCI (mcp1[1][0], 'tPBE', 5, 2)
+            with self.subTest(case="SA CASSCF", symm=mol0.symmetry, triplet_ms=tms):
+                mc_scan = mc1.as_scanner()
+                e_tot = mc_scan(mol0)
+                e_states_fp = lib.fp(np.sort(mc_scan.e_states))
+                e_states_fp_ref = lib.fp(np.sort(mc0.e_states))
+                self.assertAlmostEqual(e_tot, mc0.e_tot, delta=1e-6)
+                self.assertAlmostEqual(e_states_fp, e_states_fp_ref, delta=5e-6)
+        mc2 = mcpdft.CASCI(mcp1[1][0], "tPBE", 5, 2)
         mc2.fcisolver.nroots = 5
-        mc2.run (mo_coeff=mcp[1][0].mo_coeff)
-        mc_scan = mc2.as_scanner ()
-        mc_scan._scf (mol_nosym) # TODO: fix this in CASCI as_scanner
+        mc2.run(mo_coeff=mcp[1][0].mo_coeff)
+        mc_scan = mc2.as_scanner()
+        mc_scan._scf(mol_nosym)  # TODO: fix this in CASCI as_scanner
         # when you pass mo_coeff on call, it skips updating the _scf
         # object geometry. This breaks things like CASCI.energy_nuc (),
         # CASCI.get_hcore (), etc. which refer to the corresponding
         # _scf fns but don't default to CASCI self.mol
-        e_tot = mc_scan (mol_nosym, mo_coeff=mcp[1][0].mo_coeff, ci0=mcp[1][0].ci)
-        e_states_fp = lib.fp (np.sort (e_tot))
-        e_states_fp_ref = lib.fp (np.sort (mcp[1][0].e_states))
-        with self.subTest (case='nroots=5 CASCI'):
-            self.assertAlmostEqual (e_states_fp, e_states_fp_ref, delta=5e-5)
+        e_tot = mc_scan(mol_nosym, mo_coeff=mcp[1][0].mo_coeff, ci0=mcp[1][0].ci)
+        e_states_fp = lib.fp(np.sort(e_tot))
+        e_states_fp_ref = lib.fp(np.sort(mcp[1][0].e_states))
+        with self.subTest(case="nroots=5 CASCI"):
+            self.assertAlmostEqual(e_states_fp, e_states_fp_ref, delta=5e-5)
 
-    def test_tpbe0 (self):
+    def test_tpbe0(self):
         # The most common hybrid functional
         for mc in mcp[0]:
             e_ref = 0.75 * mc.e_tot + 0.25 * mc.e_mcscf
-            e_test = mc.energy_tot (otxc='tPBE0')[0]
-            with self.subTest (case='SS', symm=mc.mol.symmetry):
-                self.assertAlmostEqual (e_test, e_ref, 10)
-        for ix, mc in enumerate (mcp[1]):
-            tms = (0,1,'mixed')[ix]
-            sym = bool (ix//2)
-            e_states = np.array (mc.e_states)
-            e_mcscf = np.array (mc.e_mcscf)
-            e_ref = 0.75*e_states + 0.25*e_mcscf
-            e_test = [mc.energy_tot (otxc='tPBE0', state=i)[0]
-                      for i in range (len (mc.e_states))]
-            with self.subTest (case='SA CASSCF', symm=sym, triplet_ms=tms):
-                e_ref_fp = lib.fp (np.sort (e_ref))
-                e_test_fp = lib.fp (np.sort (e_test))
-                self.assertAlmostEqual (e_test_fp, e_ref_fp, 10)
+            e_test = mc.energy_tot(otxc="tPBE0")[0]
+            with self.subTest(case="SS", symm=mc.mol.symmetry):
+                self.assertAlmostEqual(e_test, e_ref, 10)
+        for ix, mc in enumerate(mcp[1]):
+            tms = (0, 1, "mixed")[ix]
+            sym = bool(ix // 2)
+            e_states = np.array(mc.e_states)
+            e_mcscf = np.array(mc.e_mcscf)
+            e_ref = 0.75 * e_states + 0.25 * e_mcscf
+            e_test = [
+                mc.energy_tot(otxc="tPBE0", state=i)[0] for i in range(len(mc.e_states))
+            ]
+            with self.subTest(case="SA CASSCF", symm=sym, triplet_ms=tms):
+                e_ref_fp = lib.fp(np.sort(e_ref))
+                e_test_fp = lib.fp(np.sort(e_test))
+                self.assertAlmostEqual(e_test_fp, e_ref_fp, 10)
+
+    def test_chkfile(self):
+        for mc in mc_chk:
+            if hasattr(mc, "e_states"):
+                case = "SA CASSCF"
+            else:
+                case = "SS"
+            
+            with self.subTest(case=case):
+                self.assertTrue(h5py.is_hdf5(mc.chkfile))
+                self.assertEqual(lib.fp(mc.mo_coeff), lib.fp(lib.chkfile.load(mc.chkfile, "mcscf/mo_coeff")))
+                self.assertEqual(mc.e_tot, lib.chkfile.load(mc.chkfile, "pdft/e_tot"))
+                self.assertEqual(lib.fp(mc.e_ot), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_ot")))
+                if case=="SA CASSCF":
+                    self.assertEqual(lib.fp(mc.e_states), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_states")))
+            
 
 if __name__ == "__main__":
     print("Full Tests for MC-PDFT energy API")
     unittest.main()
-
-

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -52,7 +52,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
     mcp_ss_nosym = mcpdft.CASSCF(mc_nosym, fnal, 5, 2).run(conv_tol=1e-8)
     mcp_ss_sym = (
         mcpdft.CASSCF(mc_sym, fnal, 5, 2)
-        .set(chkfile=tempfile.NamedTemporaryFile().name, chk_ci=True)
+        .set(chkfile=tempfile.NamedTemporaryFile().name)#, chk_ci=True)
         .run(conv_tol=1e-8)
     )
     mcp_sa_0 = mcp_ss_nosym.state_average(
@@ -85,7 +85,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
             ]
             * 5,
         )
-        .set(ci=None, chkfile=tempfile.NamedTemporaryFile().name, chk_ci=True)
+        .set(ci=None, chkfile=tempfile.NamedTemporaryFile().name)#, chk_ci=True)
         .run(conv_tol=1e-8)
     )
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
@@ -624,9 +624,11 @@ class KnownValues(unittest.TestCase):
                 self.assertEqual(mc.e_tot, lib.chkfile.load(mc.chkfile, "pdft/e_tot"))
                 self.assertEqual(lib.fp(mc.e_ot), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_ot")))
                 self.assertEqual(lib.fp(mc.e_mcscf), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_mcscf")))
-                for state, (c_ref, c) in enumerate(zip(mc.ci, lib.chkfile.load(mc.chkfile, "pdft/ci"))):
-                    with self.subTest(state=state):
-                        self.assertEqual(lib.fp(c_ref), lib.fp(c))
+                
+                # Requires PySCF version > 2.6.2 which is not currently available on pip
+                # for state, (c_ref, c) in enumerate(zip(mc.ci, lib.chkfile.load(mc.chkfile, "pdft/ci"))):
+                    # with self.subTest(state=state):
+                        # self.assertEqual(lib.fp(c_ref), lib.fp(c))
                 
                 if case=="SA CASSCF":
                     self.assertEqual(lib.fp(mc.e_states), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_states")))


### PR DESCRIPTION
Add MC-PDFT and L-PDFT chkfile support under `pdft` key. For certain values, it uses hard links to the corresponding data in the `mcscf` group. Writes the following data to the chkfile:

MC-PDFT:
- `e_tot`
- `e_ot`
- `e_states` (if state-averaged)
- `e_mcscf`
- `mo_coeff` (as a hard link to `mcscf/mo_coeff`)
- `ci` (as a hard link to `mcscf/ci`, if exists)

L-PDFT:
- `e_tot`
- `e_states`
- `e_mcscf`
- `ci` (if `chk_ci=True` and the L-PDFT adiabatic CI vectors)
