### PR TITLE
PySCF #2186 MC-PDFT test fix (#71)

### DIFF
--- a/pyscf/grad/test/test_diatomic_gradients.py
+++ b/pyscf/grad/test/test_diatomic_gradients.py
@@ -15,7 +15,7 @@
 #
 import numpy as np
 from scipy import linalg
-from pyscf import gto, scf, df, mcscf, lib
+from pyscf import gto, scf, df, dft, mcscf, lib
 from pyscf.data.nist import BOHR
 from pyscf import mcpdft
 #from pyscf.fci import csf_solver
@@ -45,9 +45,15 @@ def diatomic (atom1, atom2, r, fnal, basis, ncas, nelecas, nstates,
     mc.kernel (mo)
     return mc.nuc_grad_method ()
 
+def setUpModule():
+    global diatomic, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
+
 def tearDownModule():
-    global diatomic
-    del diatomic
+    global diatomic, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
+    del diatomic, original_grids
 
 # The purpose of these separate test functions is to narrow down an error to specific degrees of
 # freedom. But if the lih_cms2ftpbe and _df cases pass, then almost certainly, they all pass.

--- a/pyscf/grad/test/test_grad_h2co.py
+++ b/pyscf/grad/test/test_grad_h2co.py
@@ -16,7 +16,7 @@
 import os
 import numpy as np
 from scipy import linalg
-from pyscf import gto, scf, df, fci, lib
+from pyscf import gto, scf, df, dft, fci, lib
 from pyscf.fci.addons import fix_spin_
 from pyscf import mcpdft
 #from pyscf.fci import csf_solver
@@ -43,16 +43,19 @@ def get_mc_ref (mol, ri=False, sa2=False, mo0=None):
     return mc.run (mo0)
 
 def setUpModule():
-    global mol_nosymm, mol_symm, mo0
+    global mol_nosymm, mol_symm, mo0, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
     mc_symm = get_mc_ref (mol_symm)
     mo0 = mc_symm.mo_coeff.copy ()
     del mc_symm
 
 def tearDownModule():
-    global mol_nosymm, mol_symm, mo0
+    global mol_nosymm, mol_symm, mo0, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     mol_nosymm.stdout.close ()
     mol_symm.stdout.close ()
-    del mol_nosymm, mol_symm, mo0
+    del mol_nosymm, mol_symm, mo0, original_grids
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/grad/test/test_grad_lpdft.py
+++ b/pyscf/grad/test/test_grad_lpdft.py
@@ -24,7 +24,7 @@
 
 import unittest
 
-from pyscf import scf, gto, df, lib
+from pyscf import scf, gto, df, dft, lib
 from pyscf import mcpdft
 
 
@@ -86,14 +86,16 @@ def diatomic(
 
 
 def setUpModule():
-    global mols
+    global mols, original_grids
     mols = []
-
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
 
 def tearDownModule():
-    global mols, diatomic
+    global mols, diatomic, original_grids
     [m.stdout.close() for m in mols]
-    del mols, diatomic
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
+    del mols, diatomic, original_grids
 
 
 class KnownValues(unittest.TestCase):

--- a/pyscf/grad/test/test_grad_mcpdft.py
+++ b/pyscf/grad/test/test_grad_mcpdft.py
@@ -31,7 +31,7 @@
 # trying to test the API here; we need tight convergence and grids
 # to reproduce well when OMP is on.
 import numpy as np
-from pyscf import gto, scf, mcscf, lib, fci
+from pyscf import gto, scf, mcscf, lib, fci, dft
 from pyscf import mcpdft
 import unittest
 
@@ -66,16 +66,19 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0'):
     return nosym, sym, mcp
 
 def setUpModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
     nosym, sym, mcp = auto_setup ()
     mol_nosym, mf_nosym, mc_nosym = nosym
     mol_sym, mf_sym, mc_sym = sym
 
 def tearDownModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, original_grids
     mol_nosym.stdout.close ()
     mol_sym.stdout.close ()
-    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
+    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, original_grids
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -17,7 +17,7 @@
 
 import tempfile, h5py
 import numpy as np
-from pyscf import gto, scf, fci, lib
+from pyscf import gto, scf, dft, fci, lib
 from pyscf import mcpdft
 import unittest
 
@@ -90,7 +90,9 @@ def get_water_triplet(functional='tPBE', basis="6-31G"):
 
 
 def setUpModule():
-    global lih, lih_4, lih_tpbe, lih_tpbe0, water, t_water
+    global lih, lih_4, lih_tpbe, lih_tpbe0, water, t_water, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
     lih = get_lih(1.5)
     lih_4 = get_lih(1.5, n_states=4, basis="6-31G")
     lih_tpbe = get_lih(1.5, functional="tPBE")
@@ -99,14 +101,15 @@ def setUpModule():
     t_water = get_water_triplet()
 
 def tearDownModule():
-    global lih, lih_4, lih_tpbe0, lih_tpbe, t_water, water
+    global lih, lih_4, lih_tpbe0, lih_tpbe, t_water, water, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     lih.mol.stdout.close()
     lih_4.mol.stdout.close()
     lih_tpbe0.mol.stdout.close()
     lih_tpbe.mol.stdout.close()
     water.mol.stdout.close()
     t_water.mol.stdout.close()
-    del lih, lih_4, lih_tpbe0, lih_tpbe, t_water, water
+    del lih, lih_4, lih_tpbe0, lih_tpbe, t_water, water, original_grids
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -32,7 +32,7 @@
 # to reproduce well when OMP is on.
 import tempfile, h5py
 import numpy as np
-from pyscf import gto, scf, mcscf, lib, fci
+from pyscf import gto, scf, mcscf, lib, fci, dft
 from pyscf import mcpdft
 import unittest
 
@@ -96,17 +96,20 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
 
 
 def setUpModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
     nosym, sym, mcp, mc_chk = auto_setup()
     mol_nosym, mf_nosym, mc_nosym = nosym
     mol_sym, mf_sym, mc_sym = sym
 
 
 def tearDownModule():
-    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+    global mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     mol_nosym.stdout.close()
     mol_sym.stdout.close()
-    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk
+    del mol_nosym, mf_nosym, mc_nosym, mol_sym, mf_sym, mc_sym, mcp, mc_chk, original_grids
 
 
 class KnownValues(unittest.TestCase):

--- a/pyscf/mcpdft/test/test_xmspdft.py
+++ b/pyscf/mcpdft/test/test_xmspdft.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from pyscf import gto, scf, mcpdft
+from pyscf import gto, scf, dft, mcpdft
 from pyscf.mcpdft import xmspdft
 
 import unittest
@@ -16,15 +16,18 @@ def get_lih(r, weights=None):
     return mc
 
 def setUpModule():
-    global mc, mc_unequal
+    global mc, mc_unequal, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
     mc = get_lih(1.5)
     mc_unequal = get_lih(1.5, weights=[0.9, 0.1])
 
 def tearDownModule():
-    global mc, mc_unequal
+    global mc, mc_unequal, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     mc.mol.stdout.close()
     mc_unequal.mol.stdout.close()
-    del mc, mc_unequal
+    del mc, mc_unequal, original_grids
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/prop/dip_moment/test/test_cmspdft_pdm.py
+++ b/pyscf/prop/dip_moment/test/test_cmspdft_pdm.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import numpy as np
-from pyscf import gto, scf, mcscf
+from pyscf import gto, dft, scf, mcscf
 from pyscf import mcpdft
 import unittest
 #from pyscf.fci import csf_solver
@@ -67,11 +67,17 @@ def get_furan_cation(mol,iroots=3):
     mc.kernel(mo)
     return mc
 
+def setUpModule():
+    global mol_h2o, mol_furan_cation, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
+
 def tearDownModule():
-    global mol_h2o, mol_furan_cation
+    global mol_h2o, mol_furan_cation, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     mol_h2o.stdout.close ()
     mol_furan_cation.stdout.close ()
-    del mol_h2o, mol_furan_cation
+    del mol_h2o, mol_furan_cation, original_grids
 
 class KnownValues(unittest.TestCase):
     '''

--- a/pyscf/prop/dip_moment/test/test_sapdft_pdm.py
+++ b/pyscf/prop/dip_moment/test/test_sapdft_pdm.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import numpy as np
-from pyscf import gto, scf, mcscf
+from pyscf import gto, dft, scf, mcscf
 from pyscf import mcpdft
 import unittest
 from pyscf.fci.addons import fix_spin_
@@ -51,11 +51,17 @@ def get_h2o(mol,iroots=3):
     mc.kernel(mo)
     return mc
 
+def setUpModule():
+    global mol_h2o, mol_furan_cation, original_grids
+    original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
+
 def tearDownModule():
-    global mol_h2o, mol_furan_cation
+    global mol_h2o, mol_furan_cation, original_grids
+    dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = original_grids
     mol_h2o.stdout.close ()
     mol_furan_cation.stdout.close ()
-    del mol_h2o, mol_furan_cation
+    del mol_h2o, mol_furan_cation, original_grids
 
 class KnownValues(unittest.TestCase):
     '''


### PR DESCRIPTION
Restore grids of PySCF 2.6.2 for the purpose of matching unittest references.