### PR TITLE
The User can now register its determinant into trexio format

### DIFF
--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -252,9 +252,10 @@ def get_occsa_and_occsb(mcscf, norb, nelec):
 
     return occsa_sorted, occsb_sorted, ci_values_sorted, num_determinants
 
-def det_to_trexio(mcscf, norb, nelec, mo_num, filename, backend='h5', chunk_size=100000):  
+def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', chunk_size=100000):  
     from trexio_tools.group_tools import determinant as trexio_det
 
+    mo_num = norb
     int64_num = int((mo_num - 1) / 64) + 1 
     occsa, occsb, ci_values, num_determinants = get_occsa_and_occsb(mcscf, norb, nelec)
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -299,6 +299,5 @@ def read_det_trexio(filename):
         num_det = trexio.read_determinant_num(tf)
         coeff = trexio.read_determinant_coefficient(tf, offset_file, num_det)
         det = trexio.read_determinant_list(tf, offset_file, num_det)
-  
         return num_det, coeff, det
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -273,6 +273,9 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5'):
       if(trexio.has_determinant(tf)):
         trexio.delete_determinant(tf)
       trexio.write_mo_num(tf, mo_num)
+      trexio.write_electron_up_num(tf, len(a))
+      trexio.write_electron_dn_num(tf, len(b))
+      trexio.write_electron_num(tf, len(a)+len(b))
       trexio.write_determinant_list(tf, offset_file, num_determinants, det_list)
       trexio.write_determinant_coefficient(tf, offset_file, num_determinants, ci_values)
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -16,7 +16,7 @@ import math
 from pyscf import lib
 from pyscf import gto
 from pyscf import scf
-from pyscf import fci 
+from pyscf import fci
 import trexio
 
 def to_trexio(obj, filename, backend='h5'):
@@ -133,7 +133,7 @@ def mol_from_trexio(filename):
     return mol.build()
 
 def scf_from_trexio(filename):
-    mol = mol_from_trexio(filename, backend)
+    mol = mol_from_trexio(filename)
     with trexio.File(filename, 'r', back_end=trexio.TREXIO_AUTO) as tf:
         mo_energy = trexio.read_mo_energy(tf)
         mo        = trexio.read_mo_coefficient(tf)
@@ -256,7 +256,7 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
     from trexio_tools.group_tools import determinant as trexio_det
 
     mo_num = norb
-    int64_num = int((mo_num - 1) / 64) + 1 
+    int64_num = int((mo_num - 1) / 64) + 1
     occsa, occsb, ci_values, num_determinants = get_occsa_and_occsb(mcscf, norb, nelec, ci_threshold)
 
     det_list = []
@@ -271,9 +271,9 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
     if num_determinants > chunk_size:
         n_chunks = math.ceil(num_determinants / chunk_size)
     else:
-        n_chunks = 1 
+        n_chunks = 1
 
-    with trexio.File(filename, 'u', back_end=_mode(backend)) as tf: 
+    with trexio.File(filename, 'u', back_end=_mode(backend)) as tf:
         if trexio.has_determinant(tf):
             trexio.delete_determinant(tf)
         trexio.write_mo_num(tf, mo_num)
@@ -281,7 +281,7 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
         trexio.write_electron_dn_num(tf, len(b))
         trexio.write_electron_num(tf, len(a) + len(b))
 
-        offset_file = 0 
+        offset_file = 0
         for i in range(n_chunks):
             start = i * chunk_size
             end = min((i + 1) * chunk_size, num_determinants)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -260,31 +260,33 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5'):
 
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
-      det_tmp     = []
-      det_tmp    += trexio_det.to_determinant_list(occsa, int64_num)
-      det_tmp    += trexio_det.to_determinant_list(occsb, int64_num)
-      det_list.append(det_tmp)
+        occsa_upshifted = [orb + 1 for orb in a]  
+        occsb_upshifted = [orb + 1 for orb in b]
+        det_tmp     = []
+        det_tmp    += trexio_det.to_determinant_list(occsa_upshifted, int64_num)
+        det_tmp    += trexio_det.to_determinant_list(occsb_upshifted, int64_num)
+        det_list.append(det_tmp)
     
     offset_file = 0
 
     with trexio.File(filename, 'u', back_end=_mode(backend)) as tf:
-      if(trexio.has_determinant(tf)):
-        trexio.delete_determinant(tf)
-      trexio.write_mo_num(tf, mo_num)
-      trexio.write_electron_up_num(tf, len(a))
-      trexio.write_electron_dn_num(tf, len(b))
-      trexio.write_electron_num(tf, len(a)+len(b))
-      trexio.write_determinant_list(tf, offset_file, num_determinants, det_list)
-      trexio.write_determinant_coefficient(tf, offset_file, num_determinants, ci_values)
+        if(trexio.has_determinant(tf)):
+            trexio.delete_determinant(tf)
+        trexio.write_mo_num(tf, mo_num)
+        trexio.write_electron_up_num(tf, len(a))
+        trexio.write_electron_dn_num(tf, len(b))
+        trexio.write_electron_num(tf, len(a)+len(b))
+        trexio.write_determinant_list(tf, offset_file, num_determinants, det_list)
+        trexio.write_determinant_coefficient(tf, offset_file, num_determinants, ci_values)
 
 
 def read_det_trexio(filename, backend='h5'):
     with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
-      offset_file = 0
+        offset_file = 0
 
-      num_det = trexio.read_determinant_num(tf)
-      coeff = trexio.read_determinant_coefficient(tf, offset_file, num_det)
-      det = trexio.read_determinant_list(tf, offset_file, num_det)
+        num_det = trexio.read_determinant_num(tf)
+        coeff = trexio.read_determinant_coefficient(tf, offset_file, num_det)
+        det = trexio.read_determinant_list(tf, offset_file, num_det)
   
-      return num_det, coeff[0], det[0]
+        return num_det, coeff[0], det[0]
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -93,9 +93,10 @@ def _cc_to_trexio(cc_obj, trexio_file):
 def _mcscf_to_trexio(cas_obj, trexio_file):
     raise NotImplementedError
 
-def mol_from_trexio(filename,backend=trexio.TREXIO_AUTO):
+
+def mol_from_trexio(filename, backend='h5'):
     mol = gto.Mole()
-    with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
+    with trexio.File(filename, 'r', backend=trexio.TREXIO_AUTO) as tf:
         assert trexio.read_basis_type(tf) == 'Gaussian'
         if trexio.has_ecp(tf):
             raise NotImplementedError
@@ -132,9 +133,9 @@ def mol_from_trexio(filename,backend=trexio.TREXIO_AUTO):
     mol._basis = basis
     return mol.build()
 
-def scf_from_trexio(filename, backend=trexio.TREXIO_AUTO):
+def scf_from_trexio(filename, backend='h5'):
     mol = mol_from_trexio(filename, backend)
-    with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
+    with trexio.File(filename, 'r', backend=trexio.TREXIO_AUTO) as tf:
         mo_energy = trexio.read_mo_energy(tf)
         mo        = trexio.read_mo_coefficient(tf)
         mo_occ    = trexio.read_mo_occupation(tf)
@@ -174,9 +175,9 @@ def write_eri(eri, filename, backend='h5'):
     with trexio.File(filename, 'w', back_end=_mode(backend)) as tf:
         trexio.write_mo_2e_int_eri(tf, 0, num_integrals, idx, eri.ravel())
 
-def read_eri(filename, backend=trexio.TREXIO_AUTO):
+def read_eri(filename, backend='h5'):
     '''Read ERIs in AO basis, 8-fold symmetry is assumed'''
-    with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
+    with trexio.File(filename, 'r', backend=trexio.TREXIO_AUTO) as tf:
         nmo = trexio.read_mo_num(tf)
         nao_pair = nmo * (nmo+1) // 2
         eri_size = nao_pair * (nao_pair+1) // 2
@@ -280,7 +281,7 @@ def det_to_trexio(mcscf, norb, nelec, ci_threshold_or_filename, filename=None, b
     else:
         n_chunks = 1 
 
-    with trexio.File(filename, 'u', back_end=_mode(backend)) as tf: 
+    with trexio.File(filename, 'w', back_end=_mode(backend)) as tf: 
         if trexio.has_determinant(tf):
             trexio.delete_determinant(tf)
         trexio.write_mo_num(tf, mo_num)
@@ -300,8 +301,8 @@ def det_to_trexio(mcscf, norb, nelec, ci_threshold_or_filename, filename=None, b
                 offset_file += current_chunk_size
 
 
-def read_det_trexio(filename, backend=trexio.TREXIO_AUTO):
-    with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
+def read_det_trexio(filename, backend='h5'):
+    with trexio.File(filename, 'r', backend=trexio.TREXIO_AUTO) as tf:
         offset_file = 0
 
         num_det = trexio.read_determinant_num(tf)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -93,7 +93,7 @@ def _cc_to_trexio(cc_obj, trexio_file):
 def _mcscf_to_trexio(cas_obj, trexio_file):
     raise NotImplementedError
 
-def mol_from_trexio(filename, backend='h5'):
+def mol_from_trexio(filename,backend=trexio.TREXIO_AUTO):
     mol = gto.Mole()
     with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
         assert trexio.read_basis_type(tf) == 'Gaussian'
@@ -132,7 +132,7 @@ def mol_from_trexio(filename, backend='h5'):
     mol._basis = basis
     return mol.build()
 
-def scf_from_trexio(filename, backend='h5'):
+def scf_from_trexio(filename, backend=trexio.TREXIO_AUTO):
     mol = mol_from_trexio(filename, backend)
     with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
         mo_energy = trexio.read_mo_energy(tf)
@@ -174,7 +174,7 @@ def write_eri(eri, filename, backend='h5'):
     with trexio.File(filename, 'w', back_end=_mode(backend)) as tf:
         trexio.write_mo_2e_int_eri(tf, 0, num_integrals, idx, eri.ravel())
 
-def read_eri(filename, backend='h5'):
+def read_eri(filename, backend=trexio.TREXIO_AUTO):
     '''Read ERIs in AO basis, 8-fold symmetry is assumed'''
     with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
         nmo = trexio.read_mo_num(tf)
@@ -300,7 +300,7 @@ def det_to_trexio(mcscf, norb, nelec, ci_threshold_or_filename, filename=None, b
                 offset_file += current_chunk_size
 
 
-def read_det_trexio(filename, backend='h5'):
+def read_det_trexio(filename, backend=trexio.TREXIO_AUTO):
     with trexio.File(filename, 'r', back_end=_mode(backend)) as tf:
         offset_file = 0
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -238,7 +238,7 @@ def get_occsa_and_occsb(mcscf, norb, nelec):
     for i in range(min(len(selected_occslst), mcscf.ci.shape[0])):
         for j in range(min(len(selected_occslst), mcscf.ci.shape[1])):
             ci_coeff = mcscf.ci[i, j]
-            if np.abs(ci_coeff) > 1e-2:  # Check if CI coefficient is significant
+            if np.abs(ci_coeff) > 1e-8:  # Check if CI coefficient is significant
                 occsa.append(selected_occslst[i])
                 occsb.append(selected_occslst[j])
                 ci_values.append(ci_coeff)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -260,8 +260,6 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5'):
 
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
-      occsa_upshifted = [orb + 1 for orb in a]  
-      occsb_upshifted = [orb + 1 for orb in b]
       det_tmp     = []
       det_tmp    += trexio_det.to_determinant_list(occsa_upshifted, int64_num)
       det_tmp    += trexio_det.to_determinant_list(occsb_upshifted, int64_num)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -261,8 +261,8 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5'):
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
       det_tmp     = []
-      det_tmp    += trexio_det.to_determinant_list(occsa_upshifted, int64_num)
-      det_tmp    += trexio_det.to_determinant_list(occsb_upshifted, int64_num)
+      det_tmp    += trexio_det.to_determinant_list(occsa, int64_num)
+      det_tmp    += trexio_det.to_determinant_list(occsb, int64_num)
       det_list.append(det_tmp)
     
     offset_file = 0

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -252,10 +252,9 @@ def get_occsa_and_occsb(mcscf, norb, nelec):
 
     return occsa_sorted, occsb_sorted, ci_values_sorted, num_determinants
 
-def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', chunk_size=100000):  
+def det_to_trexio(mcscf, norb, nelec, mo_num, filename, backend='h5', chunk_size=100000):  
     from trexio_tools.group_tools import determinant as trexio_det
 
-    mo_num = mcscf.mo_energy.size
     int64_num = int((mo_num - 1) / 64) + 1 
     occsa, occsb, ci_values, num_determinants = get_occsa_and_occsb(mcscf, norb, nelec)
 


### PR DESCRIPTION
Hello,

For a specific reason, I needed to register my determinants into TREXIO, so I modified the code to accomplish this.

Since the functions use the MCSCF object and `mcscf_to_trexio` has not been developed yet, it might be beneficial to register the determinants infos into a different TREXIO file compared to the one used for the mf part. Therefore, this final TREXIO file only contains:

- Number of MOs
- Number of alpha electrons
- Number of beta electrons
- Total number of electrons
- Number of determinants
- Coefficients
- Determinants in bitfield format

The user can also set a threshold to register into the TREXIO file only the determinants with coefficients higher than the user-defined value. If no value is provided by the user, the full list of determinants generated by the PySCF object is registered.

As an improvement, one could develop a `mcscf_to_trexio function` (in progress [here](https://github.com/pyscf/pyscf-forge/issues/79#issue-2646546761)) as well as a converter from bitfield to a human-readable format. This would allow users to import a TREXIO file from other software and read it easily.

The different functions from this PR can be called as follow:
```
norb = 10
nelec = 4
ci_threshold = 1e-5
mcscf.kernel()
det_to_trexio(mcscf, norb, nelec, 'my_beautiful_determiants.hdf5', ci_threshold = ci_threshold)
num_det, coeff, det = read_det_trexio('my_beautiful_determiants.hdf5')

print(num_det)
print(coeff)
print(det) #In Bitfiled format
```


Best

Edit: As recommended [here](https://github.com/pyscf/pyscf-forge/pull/80#issuecomment-2468766145),  two files are attached where all new functionalities are working on CASCI/sCI and FCI objects.
[casci.txt](https://github.com/user-attachments/files/17736768/casci.txt)
[fci.txt](https://github.com/user-attachments/files/17736771/fci.txt)


