### PR TITLE
Implemented PBC for Gamma point (real wavefunction)

### DIFF
--- a/pyscf/tools/test/test_trexio.py
+++ b/pyscf/tools/test/test_trexio.py
@@ -28,3 +28,9 @@ def test_mf():
     trexio.write_eri(mf._eri, filename)
     eri = trexio.read_eri(filename)
     assert abs(mf._eri - eri).max() < 1e-12
+
+def test_mf_ecp():
+    filename = 'test2.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='cc-pVQZ', ecp='ccECP')
+    mf = mol.RHF().run()
+    trexio.to_trexio(mf, filename)

--- a/pyscf/tools/test/test_trexio.py
+++ b/pyscf/tools/test/test_trexio.py
@@ -1,15 +1,16 @@
 import pyscf
 from pyscf.tools import trexio
 
-def test_mol():
-    filename = 'test.h5'
-    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g**')
+def test_mol_ae_6_31g():
+    filename = 'test_mol_ae_6_31g_sphe.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g**', cart=False)
     ref = mol.intor('int1e_ovlp')
     trexio.to_trexio(mol, filename)
     mol = trexio.mol_from_trexio(filename)
     s1 = mol.intor('int1e_ovlp')
     assert abs(ref - s1).max() < 1e-12
 
+    filename = 'test_mol_ae_6_31g_cart.h5'
     mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g**', cart=True)
     ref = mol.intor('int1e_ovlp')
     trexio.to_trexio(mol, filename)
@@ -17,20 +18,97 @@ def test_mol():
     s1 = mol.intor('int1e_ovlp')
     assert abs(ref - s1).max() < 1e-12
 
-def test_mf():
-    filename = 'test1.h5'
-    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g*')
+def test_mol_ccecp_ccpvqz():
+    filename = 'test_mol_ccecp_ccpvqz_sphe.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccecp-cc-pVQZ', ecp='ccECP', cart=False)
+    # ref = mol.intor('int1e_ovlp')
+    trexio.to_trexio(mol, filename)
+    ''' Todo: mol_from_trexio for ecp is yet implemented.
+    mol = trexio.mol_from_trexio(filename)
+    s1 = mol.intor('int1e_ovlp')
+    assert abs(ref - s1).max() < 1e-12
+    '''
+
+    filename = 'test_mol_ccecp_ccpvqz_cart.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccecp-cc-pVQZ', ecp='ccECP', cart=True)
+    # ref = mol.intor('int1e_ovlp')
+    trexio.to_trexio(mol, filename)
+    ''' Todo: mol_from_trexio for ecp is yet implemented.
+    mol = trexio.mol_from_trexio(filename)
+    s1 = mol.intor('int1e_ovlp')
+    assert abs(ref - s1).max() < 1e-12
+    '''
+
+''' Todo: it does not work due to the internal contraction in PySCF
+def test_mol_ae_ccpvdz():
+    filename = 'test_mol_ae_ccpvdz_sphe.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccpvdz', cart=False)
+    ref = mol.intor('int1e_ovlp')
+    trexio.to_trexio(mol, filename)
+    mol = trexio.mol_from_trexio(filename)
+    s1 = mol.intor('int1e_ovlp')
+    assert abs(ref - s1).max() < 1e-12
+
+    filename = 'test_mol_ae_ccpvdz_cart.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccpvdz', cart=True)
+    ref = mol.intor('int1e_ovlp')
+    trexio.to_trexio(mol, filename)
+    mol = trexio.mol_from_trexio(filename)
+    s1 = mol.intor('int1e_ovlp')
+    assert abs(ref - s1).max() < 1e-12
+'''
+
+def test_mf_ae_6_31g():
+    filename = 'test_mf_ae_6_31g_sphe.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g*', cart=False)
     mf = mol.RHF().run()
+    print(mf.mo_coeff)
     trexio.to_trexio(mf, filename)
     mf1 = trexio.scf_from_trexio(filename)
     assert abs(mf1.mo_coeff - mf.mo_coeff).max() < 1e-12
-
     trexio.write_eri(mf._eri, filename)
     eri = trexio.read_eri(filename)
     assert abs(mf._eri - eri).max() < 1e-12
 
-def test_mf_ecp():
-    filename = 'test2.h5'
-    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='cc-pVQZ', ecp='ccECP')
+    filename = 'test_mf_ae_6_31g_cart.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='6-31g*', cart=True)
+    mf = mol.RHF().run()
+    print(mf.mo_coeff)
+    trexio.to_trexio(mf, filename)
+    mf1 = trexio.scf_from_trexio(filename)
+    assert abs(mf1.mo_coeff - mf.mo_coeff).max() < 1e-12
+    trexio.write_eri(mf._eri, filename)
+    eri = trexio.read_eri(filename)
+    assert abs(mf._eri - eri).max() < 1e-12
+
+def test_mf_ccecp_ccpvqz():
+    filename = 'test_mf_ccecp_ccpvqz_sphe.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccecp-cc-pVQZ', ecp='ccECP', cart=False)
     mf = mol.RHF().run()
     trexio.to_trexio(mf, filename)
+    ''' Todo: scf_from_trexio for ecp is yet implemented.
+    mf1 = trexio.scf_from_trexio(filename)
+    assert abs(mf1.mo_coeff - mf.mo_coeff).max() < 1e-12
+    trexio.write_eri(mf._eri, filename)
+    eri = trexio.read_eri(filename)
+    assert abs(mf._eri - eri).max() < 1e-12
+    '''
+
+    filename = 'test_mf_ccecp_ccpvqz_cart.h5'
+    mol = pyscf.M(atom='H 0 0 0; F 0 0 1', basis='ccecp-cc-pVQZ', ecp='ccECP', cart=True)
+    mf = mol.RHF().run()
+    trexio.to_trexio(mf, filename)
+    ''' Todo: scf_from_trexio for ecp is yet implemented.
+    mf1 = trexio.scf_from_trexio(filename)
+    assert abs(mf1.mo_coeff - mf.mo_coeff).max() < 1e-12
+    trexio.write_eri(mf._eri, filename)
+    eri = trexio.read_eri(filename)
+    assert abs(mf._eri - eri).max() < 1e-12
+    '''
+
+if __name__ == "__main__":
+    #test_mol_ae_6_31g()
+    #test_mol_ccecp_ccpvqz()
+    #test_mol_ae_ccpvdz()
+    #test_mf_ae_6_31g()
+    test_mf_ccecp_ccpvqz()

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -17,7 +17,6 @@ import pyscf
 from pyscf import lib
 from pyscf import gto
 from pyscf import scf
-from pyscf import pbc
 import trexio
 
 def to_trexio(obj, filename, backend='h5'):
@@ -46,20 +45,15 @@ def _mol_to_trexio(mol, trexio_file):
         trexio.write_nucleus_point_group(trexio_file, mol.groupname)
 
     # 2.3 Periodic boundary calculations
-    if isinstance(mol, pbc.gto.Cell):
-        # 2.3 Periodic boundary calculations (pbc group)
-        trexio.write_pbc_periodic(trexio_file, True)
+    try:
+        mol.a
+        periodic = True
+        raise NotImplementedError('PBC is not supported yet.')
         # 2.2 Cell
-        Bohr = lib.param.BOHR
-        a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
-        b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
-        c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
-        trexio.write_cell_a(trexio_file, a)
-        trexio.write_cell_b(trexio_file, b)
-        trexio.write_cell_c(trexio_file, c)
-    else:
-        # 2.3 Periodic boundary calculations (pbc group)
-        trexio.write_pbc_periodic(trexio_file, False)
+
+    except AttributeError:
+        periodic = False
+        trexio.write_pbc_periodic(trexio_file, periodic)
 
     # 2.4 Electron (electron group)
     electron_up_num, electron_dn_num = mol.nelec
@@ -202,28 +196,9 @@ def _mol_to_trexio(mol, trexio_file):
 
 
 def _scf_to_trexio(mf, trexio_file):
-
+    # 4.2 Molecular orbitals (mo group)
     mol = mf.mol
     _mol_to_trexio(mol, trexio_file)
-
-    # 2.3 Periodic boundary calculations (pbc group)
-    if isinstance(mol, pbc.gto.Cell):
-        try:
-            kpt = mf.kpt
-            kpt = mol.get_scaled_kpts(kpt)
-            if np.all(np.array(kpt) == 0.0):
-                # gamma point PBC. Real wavefunction
-                trexio.write_pbc_k_point_num(trexio_file, 1)
-                trexio.write_pbc_k_point(trexio_file, [kpt])
-                trexio.write_pbc_k_point_weight(trexio_file, [1.0])
-            else:
-                # general point PBC. Complex wavefunction
-                raise NotImplementedError("Complex WF is not yet implemented.")
-        except ValueError:
-            # general points PBC. Complex wavefunctions
-            raise NotImplementedError("Twisted-average is not yet implemented.")
-
-    # 4.2 Molecular orbitals (mo group)
     if isinstance(mf, scf.uhf.UHF):
         mo_energy = np.ravel(mf.mo_energy)
         mo = np.hstack(*mf.mo_coeff)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -36,7 +36,8 @@ def _mol_to_trexio(mol, trexio_file):
 
     # 2 System
     trexio.write_nucleus_num(trexio_file, mol.natm)
-    trexio.write_nucleus_charge(trexio_file, mol.atom_charges())
+    nucleus_charge = [mol.atom_charge(i) for i in range(mol.natm)]
+    trexio.write_nucleus_charge(trexio_file, nucleus_charge)
     trexio.write_nucleus_coord(trexio_file, mol.atom_coords())
     labels = [mol.atom_pure_symbol(i) for i in range(mol.natm)]
     trexio.write_nucleus_label(trexio_file, labels)
@@ -71,7 +72,7 @@ def _mol_to_trexio(mol, trexio_file):
     trexio.write_basis_shell_index(trexio_file, np.hstack(prim2sh))
     trexio.write_basis_exponent(trexio_file, np.hstack(mol.bas_exps()))
     if not all(mol._bas[:,gto.NCTR_OF] == 1):
-        raise NotImplementedError
+        raise NotImplementedError('The generalized contraction is not supported.')
     coef = [mol.bas_ctr_coeff(i).ravel() for i in range(mol.nbas)]
     trexio.write_basis_coefficient(trexio_file, np.hstack(coef))
     prim_norms = [gto.gto_norm(mol.bas_angular(i), mol.bas_exp(i)) for i in range(mol.nbas)]

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -54,10 +54,10 @@ def _mol_to_trexio(mol, trexio_file):
         # 2.3 Periodic boundary calculations (pbc group)
         trexio.write_pbc_periodic(trexio_file, True)
         # 2.2 Cell
-        Bohr = lib.param.BOHR
-        a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
-        b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
-        c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
+        lattice = mol.lattice_vectors()
+        a = lattice[0] # unit is Bohr
+        b = lattice[1] # unit is Bohr
+        c = lattice[2] # unit is Bohr
         trexio.write_cell_a(trexio_file, a)
         trexio.write_cell_b(trexio_file, b)
         trexio.write_cell_c(trexio_file, c)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -17,6 +17,7 @@ import pyscf
 from pyscf import lib
 from pyscf import gto
 from pyscf import scf
+from pyscf import pbc
 import trexio
 
 def to_trexio(obj, filename, backend='h5'):
@@ -45,15 +46,20 @@ def _mol_to_trexio(mol, trexio_file):
         trexio.write_nucleus_point_group(trexio_file, mol.groupname)
 
     # 2.3 Periodic boundary calculations
-    try:
-        mol.a
-        periodic = True
-        raise NotImplementedError('PBC is not supported yet.')
+    if isinstance(mol, pbc.gto.Cell):
+        # 2.3 Periodic boundary calculations (pbc group)
+        trexio.write_pbc_periodic(trexio_file, True)
         # 2.2 Cell
-
-    except AttributeError:
-        periodic = False
-        trexio.write_pbc_periodic(trexio_file, periodic)
+        Bohr = lib.param.BOHR
+        a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
+        b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
+        c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
+        trexio.write_cell_a(trexio_file, a)
+        trexio.write_cell_b(trexio_file, b)
+        trexio.write_cell_c(trexio_file, c)
+    else:
+        # 2.3 Periodic boundary calculations (pbc group)
+        trexio.write_pbc_periodic(trexio_file, False)
 
     # 2.4 Electron (electron group)
     electron_up_num, electron_dn_num = mol.nelec
@@ -196,9 +202,28 @@ def _mol_to_trexio(mol, trexio_file):
 
 
 def _scf_to_trexio(mf, trexio_file):
-    # 4.2 Molecular orbitals (mo group)
+
     mol = mf.mol
     _mol_to_trexio(mol, trexio_file)
+
+    # 2.3 Periodic boundary calculations (pbc group)
+    if isinstance(mol, pbc.gto.Cell):
+        try:
+            kpt = mf.kpt
+            kpt = mol.get_scaled_kpts(kpt)
+            if np.all(np.array(kpt) == 0.0):
+                # gamma point PBC. Real wavefunction
+                trexio.write_pbc_k_point_num(trexio_file, 1)
+                trexio.write_pbc_k_point(trexio_file, [kpt])
+                trexio.write_pbc_k_point_weight(trexio_file, [1.0])
+            else:
+                # general point PBC. Complex wavefunction
+                raise NotImplementedError("Complex WF is not yet implemented.")
+        except ValueError:
+            # general points PBC. Complex wavefunctions
+            raise NotImplementedError("Twisted-average is not yet implemented.")
+
+    # 4.2 Molecular orbitals (mo group)
     if isinstance(mf, scf.uhf.UHF):
         mo_energy = np.ravel(mf.mo_energy)
         mo = np.hstack(*mf.mo_coeff)

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -211,20 +211,16 @@ def _scf_to_trexio(mf, trexio_file):
 
     # 2.3 Periodic boundary calculations (pbc group)
     if isinstance(mol, pbc.gto.Cell):
-        try:
-            kpt = mf.kpt
-            kpt = mol.get_scaled_kpts(kpt)
-            if np.all(np.array(kpt) == 0.0):
-                # gamma point PBC. Real wavefunction
-                trexio.write_pbc_k_point_num(trexio_file, 1)
-                trexio.write_pbc_k_point(trexio_file, [kpt])
-                trexio.write_pbc_k_point_weight(trexio_file, [1.0])
-            else:
-                # general point PBC. Complex wavefunction
-                raise NotImplementedError("Complex WF is not yet implemented.")
-        except ValueError:
-            # general points PBC. Complex wavefunctions
-            raise NotImplementedError("Twisted-average is not yet implemented.")
+        kpt = mf.kpt
+        kpt = mol.get_scaled_kpts(kpt)
+        if np.all(np.array(kpt) == 0.0):
+            # gamma point PBC. Real wavefunction
+            trexio.write_pbc_k_point_num(trexio_file, 1)
+            trexio.write_pbc_k_point(trexio_file, [kpt])
+            trexio.write_pbc_k_point_weight(trexio_file, [1.0])
+        else:
+            # general point PBC. Complex wavefunction
+            raise NotImplementedError("Complex WF is not yet implemented.")
 
     # 4.2 Molecular orbitals (mo group)
     if isinstance(mf, scf.uhf.UHF):


### PR DESCRIPTION
I have implemented PBC for Gamma point (i.e., real wavefunction) in the `trexio` converter.
An example is:

```
# load python packages
import numpy as np
from pyscf.pbc import gto, dft
from pyscf.tools import trexio

# cell info
# cell
cell = gto.M(
    verbose = 4,
    a = np.eye(3)*3.5668,
    atom = '''C     0.      0.      0.    
              C     0.8917  0.8917  0.8917
              C     1.7834  1.7834  0.    
              C     2.6751  2.6751  0.8917
              C     1.7834  0.      1.7834
              C     2.6751  0.8917  2.6751
              C     0.      1.7834  1.7834
              C     0.8917  2.6751  2.6751'''
)
cell.output = pyscf_output
cell.charge = 0
cell.spin = 0
cell.symmetry = False

# basis set
cell.basis = 'ccecp-ccpvdz'
cell.exp_to_discard = 0.2

# define ecp
cell.ecp = 'ccecp'

# cell build
cell.build(cart=False)

# DFT setting
kpt = [0.0, 0.0, 0.0]
mf = dft.rks.RKS(cell, kpt=kpt)
mf.xc = "lda_x,lda_c_pz"
mf.chkfile = "pyscf_diamond.chk"

# run HF/DFT calc.
total_energy = mf.kernel()
print(f"Total HF/DFT energy = {total_energy}")

# dump to TREXIO file
trexio.to_trexio(mf, 'trexio_diamond.hdf5')
```