### PR TITLE
Fix PDFT effective potential numerical instability

### DIFF
--- a/pyscf/mcpdft/otfnal.py
+++ b/pyscf/mcpdft/otfnal.py
@@ -330,8 +330,8 @@ class transfnal (otfnal):
             raise NotImplementedError("derivatives above order 1")
 
         R = np.zeros ((nderiv,ngrids), dtype=Pi.dtype)
-        R[0,:] = 1
-        idx = rho_avg[0] >= (1e-15 / 2)
+        R[0,:] = FT_R1
+        idx = (rho_avg[0] >= (1e-15 / 2)) & (Pi[0] >= (1e-20))
         # Chain rule!
         for ideriv in range (nderiv):
             R[ideriv,idx] = Pi[ideriv,idx] / rho_avg[0,idx] / rho_avg[0,idx]

--- a/pyscf/mcpdft/otfnal.py
+++ b/pyscf/mcpdft/otfnal.py
@@ -331,7 +331,7 @@ class transfnal (otfnal):
 
         R = np.zeros ((nderiv,ngrids), dtype=Pi.dtype)
         R[0,:] = FT_R1
-        idx = (rho_avg[0] >= (1e-15 / 2)) & (Pi[0] >= (1e-20))
+        idx = (rho_avg[0] >= (1e-15 / 2)) & (Pi[0] > 0.0)
         # Chain rule!
         for ideriv in range (nderiv):
             R[ideriv,idx] = Pi[ideriv,idx] / rho_avg[0,idx] / rho_avg[0,idx]

--- a/pyscf/mcpdft/test/test_pdft_veff.py
+++ b/pyscf/mcpdft/test/test_pdft_veff.py
@@ -112,7 +112,7 @@ class KnownValues(unittest.TestCase):
         np.random.seed(1)
         for mol, mf in zip(('H2', 'LiH'), (h2, lih)):
             for state, nel in zip(('Singlet', 'Triplet'), (2, (2, 0))):
-                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE'):
+                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE', 'tN12', 'ftN12'):
                     mc = mcpdft.CASSCF(mf, fnal, 2, nel, grids_level=1).run()
                     with self.subTest(mol=mol, state=state, fnal=fnal):
                         case(self, mc)
@@ -120,7 +120,7 @@ class KnownValues(unittest.TestCase):
     def test_veff_ao2mo(self):
         for mol, mf in zip(('H2', 'LiH'), (h2, lih)):
             for state, nel in zip(('Singlet', 'Triplet'), (2, (2, 0))):
-                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE'):
+                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE', 'tN12', 'ftN12'):
                     mc = mcpdft.CASSCF(mf, fnal, 2, nel, grids_level=1).run()
                     v1_test, v2_test = mc.get_pdft_veff(jk_pc=True)
                     v1_ref, v2_ref = get_veff_ref(mc)


### PR DESCRIPTION
Translated GGA functionals `tN12` and `tGAM` (and other functionals relate to a b97 correlation function) had a numerical instability when calculation the 1- and 2- particle effective potential terms for systems with no beta electrons. This was related to the `idx` in `get_ratio`. This PR fixes the issue and adds tests to the `get_pdft_veff` and `get_pdft_feff` to prevent regression.