### PR TITLE
Repair #108 and add all-spin-up unittest (#112)

### DIFF
--- a/pyscf/mcpdft/otfnal.py
+++ b/pyscf/mcpdft/otfnal.py
@@ -330,8 +330,8 @@ class transfnal (otfnal):
             raise NotImplementedError("derivatives above order 1")
 
         R = np.zeros ((nderiv,ngrids), dtype=Pi.dtype)
-        R[0,:] = FT_R1
-        idx = (rho_avg[0] >= (1e-15 / 2)) & (Pi[0] > 0.0)
+        R[0,:] = 1
+        idx = rho_avg[0] >= (1e-15 / 2)
         # Chain rule!
         for ideriv in range (nderiv):
             R[ideriv,idx] = Pi[ideriv,idx] / rho_avg[0,idx] / rho_avg[0,idx]

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -756,6 +756,16 @@ class KnownValues(unittest.TestCase):
                 if case=="SA CASSCF":
                     self.assertEqual(lib.fp(mc.e_states), lib.fp(lib.chkfile.load(mc.chkfile, "pdft/e_states")))
 
+    def test_h2_triplet(self):
+        mol = gto.M (atom='H 0 0 0; H 1 0 0', basis='sto-3g', spin=2)
+        mf = scf.RHF (mol).run ()
+        mc = mcpdft.CASSCF (mf, 'tPBE', 2, 2).run ()
+        # Reference from OpenMolcas v24.10
+        e_ref = -0.74702903
+        self.assertAlmostEqual (mc.e_tot, e_ref, 6)
+
+
+
 if __name__ == "__main__":
     print("Full Tests for MC-PDFT energy API")
     unittest.main()

--- a/pyscf/mcpdft/test/test_pdft_veff.py
+++ b/pyscf/mcpdft/test/test_pdft_veff.py
@@ -112,7 +112,8 @@ class KnownValues(unittest.TestCase):
         np.random.seed(1)
         for mol, mf in zip(('H2', 'LiH'), (h2, lih)):
             for state, nel in zip(('Singlet', 'Triplet'), (2, (2, 0))):
-                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE', 'tN12', 'ftN12'):
+                # TODO: debug tN12 and ftN12
+                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE'):#, 'tN12', 'ftN12'):
                     mc = mcpdft.CASSCF(mf, fnal, 2, nel, grids_level=1).run()
                     with self.subTest(mol=mol, state=state, fnal=fnal):
                         case(self, mc)

--- a/pyscf/mcpdft/test/test_pdft_veff.py
+++ b/pyscf/mcpdft/test/test_pdft_veff.py
@@ -113,7 +113,7 @@ class KnownValues(unittest.TestCase):
         for mol, mf in zip(('H2', 'LiH'), (h2, lih)):
             for state, nel in zip(('Singlet', 'Triplet'), (2, (2, 0))):
                 # TODO: debug tN12 and ftN12
-                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE'):#, 'tN12', 'ftN12'):
+                for fnal in ('tLDA,VWN3', 'ftLDA,VWN3', 'tPBE', 'ftPBE', 'tN12', 'ftN12'):
                     mc = mcpdft.CASSCF(mf, fnal, 2, nel, grids_level=1).run()
                     with self.subTest(mol=mol, state=state, fnal=fnal):
                         case(self, mc)

--- a/pyscf/mcpdft/tfnal_derivs.py
+++ b/pyscf/mcpdft/tfnal_derivs.py
@@ -436,7 +436,11 @@ def _tGGA_jT_op(x, rho, Pi, R, zeta):
     xmm = (x[2] + x[4] - x[3]) / 4.0
 
     # Gradient-gradient sector
-    jTx[2] = xcc + xcm * zeta[0] + xmm * zeta[0] * zeta[0]
+    idx = (zeta[0]!=1)
+    jTx[2] = x[2]
+    jTx[2,idx] = (xcc + xcm * zeta[0] + xmm * zeta[0] * zeta[0])[idx]
+
+    # Finite-precision safety
 
     # Density-gradient sector
     idx = (rho[0] > 1e-15)


### PR DESCRIPTION
PR #108 inadvertently caused all MC-PDFT calculations of molecules with all spin-up electrons to produce incorrect energies, which was not caught at the time because it turns out we had no actual unit tests of the **values** of the energies in that specific edge case. 