### PR TITLE
Bug fix for register_otfnal

### DIFF
--- a/pyscf/mcpdft/otfnal.py
+++ b/pyscf/mcpdft/otfnal.py
@@ -34,7 +34,7 @@ FT_C = getattr(__config__, 'mcpdft_otfnal_ftransfnal_C', -85.38149682)
 
 OT_ALIAS = {'MC23': 'tMC23'}
 OT_HYB_ALIAS = {'PBE0' : '0.25*HF + 0.75*PBE, 0.25*HF + 0.75*PBE',
-                'MC23' : 'mc23'} # Note: mc23 is hybrid Meta-GGA OT Functional.
+                }
 
 REG_OT_FUNCTIONALS={}
 
@@ -80,7 +80,7 @@ def register_otfnal(xc_code, preset):
             kwargs: dict
                 The additional keyword arguments.
     '''
-    libxc_register_code = xc_code.lower ()
+    libxc_register_code = xc_code.upper ()
     libxc_base_code = preset['xc_base']
     ext_params = preset['ext_params']
     hyb = preset.get('hyb', None)
@@ -100,7 +100,7 @@ def unregister_otfnal(xc_code):
     '''
     try:
         if xc_code.upper() in REG_OT_FUNCTIONALS:
-            libxc_unregister_code = xc_code.lower()
+            libxc_unregister_code = xc_code.upper()
             libxc.unregister_custom_functional_(libxc_unregister_code)
             del REG_OT_FUNCTIONALS[xc_code.upper()]
 

--- a/pyscf/mcpdft/test/test_mgga.py
+++ b/pyscf/mcpdft/test/test_mgga.py
@@ -113,26 +113,44 @@ def get_water_triplet(functional='tM06L', basis='6-31G'):
 def setUpModule():
     global get_lih, lih_tm06l, lih_tmc23, lih_tm06l_sa2, lih_tmc23_sa2,lih_tm06l0
     global get_water_triplet, water_tm06l, water_tmc23
+    global lih_tmc23_2, lih_tmc23_sa2_2, water_tmc23_2
+
+    # register otfnal tMC23_2 which is identical to MC23
+    mc232_preset = mcpdft.otfnal.OT_PRESET['MC23']
+    mcpdft.otfnal.register_otfnal('MC23_2', mc232_preset)
+
     lih_tm06l = get_lih(1.5, functional='tM06L')
     lih_tmc23 = get_lih(1.5, functional='MC23')
+    lih_tmc23_2 = get_lih(1.5, functional='tMC23_2')
     lih_tm06l_sa2 = get_lih(1.5, stateaverage=True, functional='tM06L')
     lih_tmc23_sa2 = get_lih(1.5, stateaverage=True, functional='MC23')
+    lih_tmc23_sa2_2 = get_lih(1.5, stateaverage=True, functional='tmc23_2')
     lih_tm06l0 = get_lih(1.5, functional='tM06L0')
     water_tm06l = get_water_triplet()
     water_tmc23 = get_water_triplet(functional='MC23')
+    water_tmc23_2 = get_water_triplet(functional='TMc23_2')
 
 def tearDownModule():
     global lih_tm06l, lih_tmc23, lih_tm06l_sa2, lih_tmc23_sa2
     global lih_tm06l0, water_tm06l, water_tmc23
+    global lih_tmc23_2, lih_tmc23_sa2_2, water_tmc23_2
+
     lih_tm06l.mol.stdout.close()
     lih_tmc23.mol.stdout.close()
+    lih_tmc23_2.mol.stdout.close()
     lih_tm06l_sa2.mol.stdout.close()
     lih_tmc23_sa2.mol.stdout.close()
+    lih_tmc23_sa2_2.mol.stdout.close()
     lih_tm06l0.mol.stdout.close()
     water_tm06l.mol.stdout.close()
     water_tmc23.mol.stdout.close()
+    water_tmc23_2.mol.stdout.close()
+
+    mcpdft.otfnal.unregister_otfnal('tMC23_2')
+
     del lih_tm06l, lih_tmc23, lih_tm06l_sa2, lih_tmc23_sa2
     del lih_tm06l0, water_tm06l, water_tmc23
+    del lih_tmc23_2, lih_tmc23_sa2_2, water_tmc23_2
 
 class KnownValues(unittest.TestCase):
 
@@ -191,6 +209,25 @@ class KnownValues(unittest.TestCase):
         self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
         self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
 
+    def test_tmc23_2(self):
+        e_mcscf = lih_tmc23_2.e_mcscf
+        epdft = lih_tmc23_2.e_tot
+
+        sa_e_mcscf = lih_tmc23_sa2_2.e_mcscf
+        sa_epdft = lih_tmc23_sa2_2.e_states
+
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -7.88214917
+        E_MCPDFT_EXPECTED = -7.95098727
+        SA_E_CASSCF_EXPECTED = [-7.88205449, -7.74391704]
+        SA_E_MCPDFT_EXPECTED = [-7.95093826, -7.80604012]
+
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
+
     def test_water_triplet_tm06l(self):
         e_mcscf = water_tm06l.e_mcscf
         epdft = water_tm06l.e_tot
@@ -206,6 +243,18 @@ class KnownValues(unittest.TestCase):
     def test_water_triplet_tmc23(self):
         e_mcscf = water_tmc23.e_mcscf
         epdft = water_tmc23.e_tot
+
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -75.72365496
+        E_MCPDFT_EXPECTED = -76.02630019
+
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+
+    def test_water_triplet_tmc23_2(self):
+        e_mcscf = water_tmc23_2.e_mcscf
+        epdft = water_tmc23_2.e_tot
 
         # The CAS and MCPDFT reference values are generated using
         # OpenMolcas v24.10, tag 682-gf74be507d


### PR DESCRIPTION
This pull request fixes a bug in `register_otfnal`. The previous implementation registers the new LibXC functional using lower case `xc_code`, which makes otfnal not able to find the new functional. Changing the LibXC functional code to upper case fixes the issue.

I also added unit tests for registering new otfnals.