### PR TITLE
Handling different types of mean-field bases in MC-PDFT calculations

### DIFF
--- a/pyscf/df/grad/lpdft.py
+++ b/pyscf/df/grad/lpdft.py
@@ -34,11 +34,7 @@ class Gradients (dfsacasscf_grad.Gradients, lpdft_grad.Gradients):
         with lib.temporary_env (lpdft_grad, lpdft_HellmanFeynman_grad=pfn):
             return lpdft_grad.Gradients.get_ham_response (self, **kwargs)
 
-    def kernel (self, **kwargs):
-        if not ('mf_grad' in kwargs):
-            kwargs['mf_grad'] = dfrhf_grad.Gradients (self.base._scf)
-        return lpdft_grad.Gradients.kernel (self, **kwargs)
-
+    kernel = lpdft_grad.Gradients.kernel
     get_wfn_response = lpdft_grad.Gradients.get_wfn_response
     get_init_guess = lpdft_grad.Gradients.get_init_guess
     get_otp_gradient_response = lpdft_grad.Gradients.get_otp_gradient_response

--- a/pyscf/df/grad/mcpdft.py
+++ b/pyscf/df/grad/mcpdft.py
@@ -34,11 +34,7 @@ class Gradients (dfsacasscf_grad.Gradients, mcpdft_grad.Gradients):
         with lib.temporary_env (mcpdft_grad, mcpdft_HellmanFeynman_grad=pfn):
             return mcpdft_grad.Gradients.get_ham_response (self, **kwargs)
 
-    def kernel (self, **kwargs):
-        if not ('mf_grad' in kwargs):
-            kwargs['mf_grad'] = dfrhf_grad.Gradients (self.base._scf)
-        return mcpdft_grad.Gradients.kernel (self, **kwargs)
-
+    kernel = mcpdft_grad.Gradients.kernel
     get_wfn_response = mcpdft_grad.Gradients.get_wfn_response
     get_init_guess = mcpdft_grad.Gradients.get_init_guess
     project_Aop = mcpdft_grad.Gradients.project_Aop

--- a/pyscf/df/grad/mspdft.py
+++ b/pyscf/df/grad/mspdft.py
@@ -29,11 +29,6 @@ class Gradients (mspdft_grad.Gradients):
         self.auxbasis_response = True
         mspdft_grad.Gradients.__init__(self, pdft)
 
-    def kernel (self, **kwargs):
-        if not ('mf_grad' in kwargs):
-            kwargs['mf_grad'] = dfrhf_grad.Gradients (self.base._scf)
-        return mspdft_grad.Gradients.kernel (self, **kwargs)
-
     def make_fcasscf (self, state=None, casscf_attr={}, fcisolver_attr={}):
         fcasscf = sacasscf_grad.Gradients.make_fcasscf (self, state=state,
             casscf_attr=casscf_attr, fcisolver_attr=fcisolver_attr)

--- a/pyscf/grad/cmspdft.py
+++ b/pyscf/grad/cmspdft.py
@@ -237,7 +237,7 @@ def diab_grad (mc_grad, Lis, atmlst=None, mo=None, ci=None, eris=None,
         eris : object of class ERIS (CASSCF or CASCI)
             Contains (true) ERIs in the MO basis
         mf_grad: object of class Gradients (RHF)
-            Defaults to mc_grad.base._scf.nuc_grad_method ()
+            Defaults to mc_grad.base.get_rhf_base ().nuc_grad_method ()
 
     Returns:
         de : ndarray of shape (len (atmlst), 3)
@@ -251,7 +251,7 @@ def diab_grad (mc_grad, Lis, atmlst=None, mo=None, ci=None, eris=None,
     moH = mo.conj ().T
     mo_cas = mo[:,ncore:nocc]
     moH_cas = moH[ncore:nocc,:]
-    if mf_grad is None: mf_grad = mc._scf.nuc_grad_method()
+    if mf_grad is None: mf_grad = mc.get_rhf_base ().nuc_grad_method()
     if atmlst is None: atmlst = list (range(mol.natm))
 
     # CI vector shift
@@ -318,7 +318,7 @@ def diab_grad_o0 (mc_grad, Lis, atmlst=None, mo=None, ci=None, eris=None,
     ''' Monkeypatch version of diab_grad '''
     mc = mc_grad.base
     ncas, nelecas, nroots = mc.ncas, mc.nelecas, mc_grad.nroots
-    if mf_grad is None: mf_grad = mc._scf.nuc_grad_method()
+    if mf_grad is None: mf_grad = mc.get_rhf_base ().nuc_grad_method()
 
     # CI vector shift
     L = np.zeros ((nroots, nroots), dtype=Lis.dtype)

--- a/pyscf/grad/lpdft.py
+++ b/pyscf/grad/lpdft.py
@@ -282,7 +282,7 @@ def lpdft_HellmanFeynman_grad(
     if ci is None:
         ci = mc.ci
     if mf_grad is None:
-        mf_grad = mc._scf.nuc_grad_method()
+        mf_grad = mc.get_rhf_base ().nuc_grad_method()
     if mc.frozen is not None:
         raise NotImplementedError
     mol = mc.mol

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -538,6 +538,8 @@ class Gradients (sacasscf.Gradients):
         if ('veff1' not in kwargs) or ('veff2' not in kwargs):
             kwargs['veff1'], kwargs['veff2'] = self.base.get_pdft_veff (mo,
                 ci, incl_coul=True, paaa_only=True, state=state)
+        if 'mf_grad' not in kwargs:
+            kwargs['mf_grad'] = self.base.get_rhf_base ().nuc_grad_method ()
         return super().kernel (**kwargs)
 
     def project_Aop (self, Aop, ci, state):

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -146,7 +146,7 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     used for the energy response terms. '''
     if mo_coeff is None: mo_coeff = mc.mo_coeff
     if ci is None: ci = mc.ci
-    if mf_grad is None: mf_grad = mc._scf.nuc_grad_method()
+    if mf_grad is None: mf_grad = mc.get_rhf_base ().nuc_grad_method()
     if mc.frozen is not None:
         raise NotImplementedError
     if max_memory is None: max_memory = mc.max_memory

--- a/pyscf/grad/mspdft.py
+++ b/pyscf/grad/mspdft.py
@@ -138,7 +138,7 @@ def mspdft_heff_HellmanFeynman (mc_grad, atmlst=None, mo=None, ci=None,
     if si_bra is None: si_bra = si[:,bra]
     if si_ket is None: si_ket = si[:,ket]
     if eris is None: eris = mc.ao2mo (mo)
-    if mf_grad is None: mf_grad = mc._scf.nuc_grad_method ()
+    if mf_grad is None: mf_grad = mc.get_rhf_base ().nuc_grad_method ()
     if verbose is None: verbose = mc_grad.verbose
     ncore = mc.ncore
     log = logger.new_logger (mc_grad, verbose)
@@ -429,7 +429,7 @@ class Gradients (mcpdft_grad.Gradients):
         ket, bra = _unpack_state (state)
         if si_bra is None: si_bra = si[:,bra]
         if si_ket is None: si_ket = si[:,ket]
-        if mf_grad is None: mf_grad = self.base._scf.nuc_grad_method ()
+        if mf_grad is None: mf_grad = self.base.get_rhf_base ().nuc_grad_method ()
         if verbose is None: verbose = self.verbose
         si_diag = si_bra * si_ket
         log = logger.new_logger (self, verbose)

--- a/pyscf/grad/test/test_diatomic_gradients.py
+++ b/pyscf/grad/test/test_diatomic_gradients.py
@@ -189,22 +189,22 @@ class KnownValues(unittest.TestCase):
     def test_rohf_sanity (self):
         mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
                             cas_irrep={'A1': 4}, spin=2)
-        de_ref = [-0.03980907646529936,-0.0241802481920494] 
-        # Stability checking only
+        de_ref = [-0.039806,-0.024193] 
+        # Numerical from this software
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
-            self.assertAlmostEqual (de, de_ref[i], 5)
+            self.assertAlmostEqual (de, de_ref[i], 4)
 
     def test_dfrohf_sanity (self):
         mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
                             density_fit=True, cas_irrep={'A1': 4}, spin=2)
-        de_ref = [-0.03972386686433475,-0.02412562061211657] 
-        # Stability checking only
+        de_ref = [-0.039721,-0.024139] 
+        # Numerical from this software
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
-            self.assertAlmostEqual (de, de_ref[i], 5)
+            self.assertAlmostEqual (de, de_ref[i], 4)
 
 if __name__ == "__main__":
     print("Full Tests for CMS-PDFT gradients of diatomic molecules")

--- a/pyscf/grad/test/test_diatomic_gradients.py
+++ b/pyscf/grad/test/test_diatomic_gradients.py
@@ -191,6 +191,8 @@ class KnownValues(unittest.TestCase):
                             cas_irrep={'A1': 4}, spin=2)
         de_ref = [-0.039806,-0.024193] 
         # Numerical from this software
+        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
+        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
@@ -201,6 +203,8 @@ class KnownValues(unittest.TestCase):
                             density_fit=True, cas_irrep={'A1': 4}, spin=2)
         de_ref = [-0.039721,-0.024139] 
         # Numerical from this software
+        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
+        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR

--- a/pyscf/grad/test/test_diatomic_gradients.py
+++ b/pyscf/grad/test/test_diatomic_gradients.py
@@ -186,6 +186,26 @@ class KnownValues(unittest.TestCase):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
             self.assertAlmostEqual (de, de_ref[i], 5)
 
+    def test_rohf_sanity (self):
+        mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
+                            cas_irrep={'A1': 4}, spin=2)
+        de_ref = [-0.03980907646529936,-0.0241802481920494] 
+        # Stability checking only
+        for i in range (2):
+         with self.subTest (state=i):
+            de = mc_grad.kernel (state=i) [1,0] / BOHR
+            self.assertAlmostEqual (de, de_ref[i], 5)
+
+    def test_dfrohf_sanity (self):
+        mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
+                            density_fit=True, cas_irrep={'A1': 4}, spin=2)
+        de_ref = [-0.03972386686433475,-0.02412562061211657] 
+        # Stability checking only
+        for i in range (2):
+         with self.subTest (state=i):
+            de = mc_grad.kernel (state=i) [1,0] / BOHR
+            self.assertAlmostEqual (de, de_ref[i], 5)
+
 if __name__ == "__main__":
     print("Full Tests for CMS-PDFT gradients of diatomic molecules")
     unittest.main()

--- a/pyscf/grad/test/test_diatomic_gradients.py
+++ b/pyscf/grad/test/test_diatomic_gradients.py
@@ -16,6 +16,7 @@
 from pyscf import gto, scf, df, dft
 from pyscf.data.nist import BOHR
 from pyscf import mcpdft
+from pyscf.fci.addons import _unpack_nelec
 import unittest
 
 def diatomic (atom1, atom2, r, fnal, basis, ncas, nelecas, nstates,
@@ -34,7 +35,8 @@ def diatomic (atom1, atom2, r, fnal, basis, ncas, nelecas, nstates,
     #if spin is not None: smult = spin+1
     #else: smult = (mol.nelectron % 2) + 1
     #mc.fcisolver = csf_solver (mol, smult=smult)
-    if spin is None: spin = mol.nelectron%2
+    neleca, nelecb = _unpack_nelec (nelecas, spin=spin)
+    spin = neleca-nelecb
     ss=spin*(spin+2)*0.25
     mc = mc.multi_state ([1.0/float(nstates),]*nstates, 'cms')
     mc.fix_spin_(ss=ss, shift=1)
@@ -189,26 +191,34 @@ class KnownValues(unittest.TestCase):
     def test_rohf_sanity (self):
         mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
                             cas_irrep={'A1': 4}, spin=2)
-        de_ref = [-0.039806,-0.024193] 
+        mc_grad_ref = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, (2,0), 2,
+                            symmetry=True, cas_irrep={'A1': 4})
+        de_num_ref = [-0.039806,-0.024193] 
         # Numerical from this software
         # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
         # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
-            self.assertAlmostEqual (de, de_ref[i], 4)
+            self.assertAlmostEqual (de, de_num_ref[i], 4)
+            de_ref = mc_grad_ref.kernel (state=i) [1,0] / BOHR
+            self.assertAlmostEqual (de, de_ref, 6)
 
     def test_dfrohf_sanity (self):
         mc_grad = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, 2, 2, symmetry=True,
                             density_fit=True, cas_irrep={'A1': 4}, spin=2)
-        de_ref = [-0.039721,-0.024139] 
+        mc_grad_ref = diatomic ('Li', 'H', 1.8, 'ftLDA,VWN3', '6-31g', 4, (2,0), 2,
+                                symmetry=True, density_fit=True, cas_irrep={'A1': 4})
+        de_num_ref = [-0.039721,-0.024139] 
         # Numerical from this software
         # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
         # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
         for i in range (2):
          with self.subTest (state=i):
             de = mc_grad.kernel (state=i) [1,0] / BOHR
-            self.assertAlmostEqual (de, de_ref[i], 4)
+            self.assertAlmostEqual (de, de_num_ref[i], 4)
+            de_ref = mc_grad_ref.kernel (state=i) [1,0] / BOHR
+            self.assertAlmostEqual (de, de_ref, 6)
 
 if __name__ == "__main__":
     print("Full Tests for CMS-PDFT gradients of diatomic molecules")

--- a/pyscf/grad/test/test_grad_cmspdft.py
+++ b/pyscf/grad/test/test_grad_cmspdft.py
@@ -107,9 +107,10 @@ class KnownValues(unittest.TestCase):
             else: continue #mc_grad = dfsacasscf.Gradients (mc)
             # TODO: proper DF functionality
             eris = mc.ao2mo (mc.mo_coeff)
+            mf_grad = mc._scf.nuc_grad_method ()
             with self.subTest (symm=stype, solver=atype, eri=itype):
-                dh_test = diab_grad (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris)
-                dh_ref = diab_grad_o0 (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris)
+                dh_test = diab_grad (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris, mf_grad=mf_grad)
+                dh_ref = diab_grad_o0 (mc_grad, Lis, mo=mc.mo_coeff, ci=mc.ci, eris=eris, mf_grad=mf_grad)
                 self.assertAlmostEqual (lib.fp (dh_test), lib.fp (dh_ref), 8)
 
 if __name__ == "__main__":

--- a/pyscf/grad/test/test_grad_lpdft.py
+++ b/pyscf/grad/test/test_grad_lpdft.py
@@ -26,7 +26,7 @@ import unittest
 
 from pyscf import scf, gto, df, dft, lib
 from pyscf import mcpdft
-
+from pyscf.fci.addons import _unpack_nelec
 
 def diatomic(
     atom1,
@@ -62,8 +62,8 @@ def diatomic(
         mf = mf.density_fit(auxbasis=df.aug_etb(mol))
 
     mc = mcpdft.CASSCF(mf.run(), fnal, ncas, nelecas, grids_level=grids_level)
-    if spin is None:
-        spin = mol.nelectron % 2
+    neleca, nelecb = _unpack_nelec (nelecas, spin=spin)
+    spin = neleca-nelecb
 
     ss = spin * (spin + 2) * 0.25
     mc = mc.multi_state(
@@ -267,34 +267,44 @@ class KnownValues(unittest.TestCase):
                 self.assertAlmostEqual(de, NUM_REF[i], 5)
 
     def test_rohf_sanity (self):
-        n_states = 2
+        n_states = 3
         mc_grad = diatomic(
             "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=False, spin=2
         )
-
-        # Numerical from this software
-        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
-        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
-        NUM_REF = [-0.06264161, -0.05843108]
-        for i in range(n_states):
-            with self.subTest(state=i):
-                de = mc_grad.kernel(state=i)[1, 0]
-                self.assertAlmostEqual(de, NUM_REF[i], 4)
-
-    def test_dfrohf_sanity (self):
-        n_states = 2
-        mc_grad = diatomic(
-            "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=True, spin=2
+        mc_grad_ref = diatomic(
+            "Li", "H", 1.4, "ftpbe", "6-31g", 4, (2,0), n_states, density_fit=False
         )
 
         # Numerical from this software
         # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
         # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
-        NUM_REF = [-0.06263842, -0.05846438]
+        NUM_REF = [-0.062533, -0.058472, -0.058472]
         for i in range(n_states):
             with self.subTest(state=i):
                 de = mc_grad.kernel(state=i)[1, 0]
                 self.assertAlmostEqual(de, NUM_REF[i], 4)
+                de_ref = mc_grad_ref.kernel(state=i)[1, 0]
+                self.assertAlmostEqual (de, de_ref, 8)
+
+    def test_dfrohf_sanity (self):
+        n_states = 3
+        mc_grad = diatomic(
+            "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=True, spin=2
+        )
+        mc_grad_ref = diatomic(
+            "Li", "H", 1.4, "ftpbe", "6-31g", 4, (2,0), n_states, density_fit=True,
+        )
+
+        # Numerical from this software
+        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
+        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
+        NUM_REF = [-0.062548, -0.058501, -0.058501]
+        for i in range(n_states):
+            with self.subTest(state=i):
+                de = mc_grad.kernel(state=i)[1, 0]
+                self.assertAlmostEqual(de, NUM_REF[i], 4)
+                de_ref = mc_grad_ref.kernel(state=i)[1, 0]
+                self.assertAlmostEqual (de, de_ref, 6)
 
 
 

--- a/pyscf/grad/test/test_grad_lpdft.py
+++ b/pyscf/grad/test/test_grad_lpdft.py
@@ -266,6 +266,37 @@ class KnownValues(unittest.TestCase):
                 de = mc_grad.kernel(state=i)[1, 0]
                 self.assertAlmostEqual(de, NUM_REF[i], 5)
 
+    def test_rohf_sanity (self):
+        n_states = 2
+        mc_grad = diatomic(
+            "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=False, spin=2
+        )
+
+        # Numerical from this software
+        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
+        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
+        NUM_REF = [-0.06264161, -0.05843108]
+        for i in range(n_states):
+            with self.subTest(state=i):
+                de = mc_grad.kernel(state=i)[1, 0]
+                self.assertAlmostEqual(de, NUM_REF[i], 4)
+
+    def test_dfrohf_sanity (self):
+        n_states = 2
+        mc_grad = diatomic(
+            "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=True, spin=2
+        )
+
+        # Numerical from this software
+        # PySCF commit:         bee0ce288a655105e27fcb0293b203939b7aecc9
+        # PySCF-forge commit:   50bc1da117ced9613948bee14a99a02c7b2c5769
+        NUM_REF = [-0.06263842, -0.05846438]
+        for i in range(n_states):
+            with self.subTest(state=i):
+                de = mc_grad.kernel(state=i)[1, 0]
+                self.assertAlmostEqual(de, NUM_REF[i], 4)
+
+
 
 if __name__ == "__main__":
     print("Full Tests for L-PDFT gradients API")

--- a/pyscf/grad/test/test_grad_mspdft.py
+++ b/pyscf/grad/test/test_grad_mspdft.py
@@ -139,9 +139,10 @@ class KnownValues(unittest.TestCase):
             si_diag = si * si
             de_diag = np.stack ([mc_grad.get_ham_response (state=i, ci=ci) for i in (0,1)], axis=0)
             de_ref -= np.einsum ('sac,sr->rac', de_diag, si_diag)
+            mf_grad = mc._scf.nuc_grad_method ()
             for r in (0,1):
                 de_test = mspdft_heff_HellmanFeynman (mc_grad, ci=ci, state=r,
-                    si_bra=si[:,r], si_ket=si[:,r], eris=eris)
+                    si_bra=si[:,r], si_ket=si[:,r], eris=eris, mf_grad=mf_grad)
                 with self.subTest (symm=stype, solver=atype, eri=itype, root=r):
                     self.assertAlmostEqual (lib.fp (de_test), lib.fp (de_ref[r]), 8)
 

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -462,6 +462,17 @@ class _PDFT:
         self.otfnal.verbose = self.verbose
         self.otfnal.stdout = self.stdout
 
+    def get_rhf_base (self):
+        from pyscf.scf.rhf import RHF
+        from pyscf.scf.rohf import ROHF
+        from pyscf.scf.uhf import UHF
+        scf_cls = mc._scf.__class__
+        if issubclass (scf_cls, ROHF):
+            rhf_cls = lib.drop_class (scf_cls, ROHF)
+        if issubclass (scf_cls, UHF):
+            rhf_cls = lib.replace_class (scf_cls, UHF, RHF)
+        return lib.view (mc._scf, rhf_cls)
+
     @property
     def grids(self):
         return self.otfnal.grids

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -463,15 +463,15 @@ class _PDFT:
         self.otfnal.stdout = self.stdout
 
     def get_rhf_base (self):
-        from pyscf.scf.rhf import RHF
+        from pyscf.scf.hf import RHF
         from pyscf.scf.rohf import ROHF
         from pyscf.scf.uhf import UHF
-        scf_cls = mc._scf.__class__
-        if issubclass (scf_cls, ROHF):
-            rhf_cls = lib.drop_class (scf_cls, ROHF)
-        if issubclass (scf_cls, UHF):
-            rhf_cls = lib.replace_class (scf_cls, UHF, RHF)
-        return lib.view (mc._scf, rhf_cls)
+        rhf_cls = self._scf.__class__
+        if issubclass (rhf_cls, ROHF):
+            rhf_cls = lib.replace_class (rhf_cls, ROHF, RHF)
+        if issubclass (rhf_cls, UHF):
+            rhf_cls = lib.replace_class (rhf_cls, UHF, RHF)
+        return lib.view (self._scf, rhf_cls)
 
     @property
     def grids(self):

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -465,12 +465,13 @@ class _PDFT:
     def get_rhf_base (self):
         from pyscf.scf.hf import RHF
         from pyscf.scf.rohf import ROHF
-        from pyscf.scf.uhf import UHF
+        from pyscf.scf.hf_symm import SymAdaptedRHF
+        from pyscf.scf.hf_symm import SymAdaptedROHF
         rhf_cls = self._scf.__class__
+        if issubclass (rhf_cls, SymAdaptedROHF):
+            rhf_cls = lib.replace_class (rhf_cls, SymAdaptedROHF, SymAdaptedRHF)
         if issubclass (rhf_cls, ROHF):
             rhf_cls = lib.replace_class (rhf_cls, ROHF, RHF)
-        if issubclass (rhf_cls, UHF):
-            rhf_cls = lib.replace_class (rhf_cls, UHF, RHF)
         return lib.view (self._scf, rhf_cls)
 
     @property

--- a/pyscf/nac/mspdft.py
+++ b/pyscf/nac/mspdft.py
@@ -108,7 +108,7 @@ class NonAdiabaticCouplings (mspdft_grad.Gradients):
         if si is None: si = self.base.si
         if si_bra is None: si_bra = si[:,bra]
         if si_ket is None: si_ket = si[:,ket]
-        if mf_grad is None: mf_grad = self.base._scf.nuc_grad_method ()
+        if mf_grad is None: mf_grad = self.base.get_rhf_base ().nuc_grad_method ()
         if atmlst is None: atmlst = self.atmlst
         nac = nac_model (self, mo_coeff=mo_coeff, ci=ci, si_bra=si_bra,
                          si_ket=si_ket, mf_grad=mf_grad, atmlst=atmlst)


### PR DESCRIPTION
Will solve #119 (see thread for workaround in the meantime).

TODO:

- [x] add test coverage for high-spin ROHF-based MC-PDFT calculations
- [x] determine how to handle UHF bases. It's a prerequisite if we ever hope to work with 2-component or 4-component generalizations of MC-PDFT ([such as](https://pubs.acs.org/doi/abs/10.1021/acs.jctc.2c00062)). Is there any version of MC-PDFT for which this currently "just works"?