### PR TITLE
Update CI runner to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   linux-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
From ubuntu-20.04, which is about to be unavailable. See https://github.com/pyscf/pyscf/issues/2721 and https://github.com/actions/runner-images/issues/11101.