### PR TITLE
Loosen too-tight lpdft grad rohf san test tol

### DIFF
--- a/pyscf/grad/test/test_grad_lpdft.py
+++ b/pyscf/grad/test/test_grad_lpdft.py
@@ -284,7 +284,7 @@ class KnownValues(unittest.TestCase):
                 de = mc_grad.kernel(state=i)[1, 0]
                 self.assertAlmostEqual(de, NUM_REF[i], 4)
                 de_ref = mc_grad_ref.kernel(state=i)[1, 0]
-                self.assertAlmostEqual (de, de_ref, 8)
+                self.assertAlmostEqual (de, de_ref, 6)
 
     def test_dfrohf_sanity (self):
         n_states = 3


### PR DESCRIPTION
I think it was a typo because all the other rohf grad san tests had 6 already