### PR TITLE
Hybrid MC-PDFT Nuclear Gradients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # IDEs
 .idea
 .vscode
+
+# MacOS
+.DS_Store

--- a/doc/mcpdft/README.md
+++ b/doc/mcpdft/README.md
@@ -61,11 +61,13 @@ energy calculations for wave functions of various types.
 - Additional properties
   - Decomposition of total electronic energy into core, Coulomb, on-top
   components
-  - Analytical nuclear gradients (non-hybrid functionals only) for:
-    1. Single-state CASSCF wave function: [*JCTC* **2018**, *14*, 126]
-    1. State-averaged CASSCF wave functions: [*JCP* **2020**, *153*, 014106]
-    1. CMS-PDFT: [*Mol Phys* **2022**, 120]
-    1. L-PDFT (no meta-GGA): [*JCTC* **2024**, *20*, 3637]
+  - Analytical nuclear gradients for:
+    - non-hybrid functionals only
+        1. CMS-PDFT: [*Mol Phys* **2022**, 120]
+        1. L-PDFT (no meta-GGA): [*JCTC* **2024**, *20*, 3637]
+    - hybrid and non-hybrid functionals:
+        1. Single-state CASSCF wave function: [*JCTC* **2018**, *14*, 126]
+        1. State-averaged CASSCF wave functions: [*JCP* **2020**, *153*, 014106]
   - Permanent electric dipole moment (non-hybrid functionals only) for:
     1. Single-state CASSCF wave function: [*JCTC* **2021**, *17*, 7586]
     1. State-averaged CASSCF wave functions

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -434,11 +434,14 @@ class Gradients (sacasscf.Gradients):
             raise NotImplementedError("hybrid on-top functional with different exchange,correlation components")
         cas_hyb = hyb[0]
 
-        if cas_hyb > 1e-11:
+        if cas_hyb > 1e-11:# and len(ci) > 1:
+            # For SS-CASSCF, there are no Lagrange multipliers
+            # This is only needed in SA case
             eris = self.base.ao2mo(mo_coeff=mo)
             terms = ["vhf_c", "papa", "ppaa", "j_pc", "k_pc"]
             for term in terms:
-                setattr(eris, term, getattr(veff2, term) + cas_hyb*getattr(eris, term)[:])
+                setattr(eris, term, getattr(veff2, term) + cas_hyb*getattr(eris, term))
+            veff2.vhf_c
             veff2 = eris
 
 

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -168,12 +168,21 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     if abs(omega) > 1e-11:
         raise NotImplementedError("range-separated on-top functionals")
     if abs(hyb[0] - hyb[1]) > 1e-11:
-        raise NotImplementedError("hybrid on-top functionals with different exchange,correlation components")
+        raise NotImplementedError(
+            "hybrid on-top functionals with different exchange,correlation components"
+        )
 
     cas_hyb = hyb[0]
-    ot_hyb = 1.0-cas_hyb
+    ot_hyb = 1.0 - cas_hyb
 
     if cas_hyb > 1e-11:
+        # TODO: actually implement this in a more efficient manner
+        # That is, lets not call grad_elec, but lets actually do this our self maybe?
+        # Can then use get_pdft_veff with drop_mcwfn = False to automatically get
+        # Generalized fock matrix terms, but then have to deal explicitly with the
+        # derivative of eri terms and auxbasis stuff. Also, get_pdft_veff with
+        # drop_mcwfn=False means the get_wfn_response doesn't have to add the
+        # eris to the veff2 since it should just include it already
         if auxbasis_response:
             from pyscf.df.grad import casscf as casscf_grad
         else:

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -382,9 +382,9 @@ class Gradients (sacasscf.Gradients):
         omega, alpha, hyb = ot._numint.rsh_and_hybrid_coeff (
             otxc, spin=spin)
         hyb_x, hyb_c = hyb
-        if hyb_x or hyb_c:
+        if abs(hyb_x - hyb_c) >1e-11:
             raise NotImplementedError (
-                "{} for hybrid MC-PDFT functionals".format (name)
+                "{} for hybrid MC-PDFT functionals with different exchange, correlation".format (name)
             )
         if omega or alpha:
             raise NotImplementedError (

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -594,20 +594,26 @@ class Gradients (sacasscf.Gradients):
         '''Cache the effective Hamiltonian terms so you don't have to
         calculate them twice
         '''
-        state = kwargs['state'] if 'state' in kwargs else self.state
+
+        state = kwargs["state"] if "state" in kwargs else self.state
         if state is None:
-            raise NotImplementedError ('Gradient of PDFT state-average energy')
-        self.state = state # Not the best code hygiene maybe
-        mo = kwargs['mo'] if 'mo' in kwargs else self.base.mo_coeff
-        ci = kwargs['ci'] if 'ci' in kwargs else self.base.ci
-        if isinstance (ci, np.ndarray): ci = [ci] # hack hack hack...
-        kwargs['ci'] = ci
-        if ('veff1' not in kwargs) or ('veff2' not in kwargs):
-            kwargs['veff1'], kwargs['veff2'] = self.base.get_pdft_veff (mo,
-                ci, incl_coul=True, paaa_only=True, state=state, drop_mcwfn=True)
-        
-        if 'mf_grad' not in kwargs:
-            kwargs['mf_grad'] = self.base.get_rhf_base ().nuc_grad_method ()
+            raise NotImplementedError("Gradient of PDFT state-average energy")
+
+        self.state = state  # Not the best code hygiene maybe
+        mo = kwargs["mo"] if "mo" in kwargs else self.base.mo_coeff
+        ci = kwargs["ci"] if "ci" in kwargs else self.base.ci
+        if isinstance(ci, np.ndarray):
+            ci = [ci]  # hack hack hack...
+
+        kwargs["ci"] = ci
+        if ("veff1" not in kwargs) or ("veff2" not in kwargs):
+            kwargs["veff1"], kwargs["veff2"] = self.base.get_pdft_veff(
+                mo, ci, incl_coul=True, paaa_only=True, state=state, drop_mcwfn=True
+            )
+
+        if "mf_grad" not in kwargs:
+            kwargs["mf_grad"] = self.base.get_rhf_base().nuc_grad_method()
+
         return super().kernel (**kwargs)
 
     def project_Aop (self, Aop, ci, state):

--- a/pyscf/grad/mcpdft.py
+++ b/pyscf/grad/mcpdft.py
@@ -200,7 +200,7 @@ def mcpdft_HellmanFeynman_grad (mc, ot, veff1, veff2, mo_coeff=None, ci=None,
     # MRH: vhf1c and vhf1a should be the TRUE vj_c and vj_a (no vk!)
     vj = mf_grad.get_jk (dm=dm1)[0]
     if auxbasis_response:
-        de_aux += np.squeeze (vj.aux[:,:,atmlst,:])
+        de_aux += ot_hyb*np.squeeze (vj.aux[:,:,atmlst,:])
 
     # MRH: Now I have to compute the gradient of the on-top energy
     # This involves derivatives of the orbitals that construct rho and Pi and
@@ -435,10 +435,10 @@ class Gradients (sacasscf.Gradients):
         cas_hyb = hyb[0]
 
         if cas_hyb > 1e-11:
-            eris = self.base.ao2mo()
+            eris = self.base.ao2mo(mo_coeff=mo)
             terms = ["vhf_c", "papa", "ppaa", "j_pc", "k_pc"]
             for term in terms:
-                setattr(eris, term, getattr(veff2, term) + cas_hyb*getattr(eris, term))
+                setattr(eris, term, getattr(veff2, term) + cas_hyb*getattr(eris, term)[:])
             veff2 = eris
 
 

--- a/pyscf/grad/test/test_grad_metagga_mcpdft.py
+++ b/pyscf/grad/test/test_grad_metagga_mcpdft.py
@@ -21,6 +21,7 @@ from pyscf import scf, gto, df, dft, mcscf
 from pyscf.data.nist import BOHR
 from pyscf import mcpdft
 
+from mrh.my_pyscf.fci import csf_solver
 
 def diatomic(
     atom1,
@@ -36,7 +37,7 @@ def diatomic(
     symmetry=False,
     cas_irrep=None,
     density_fit=False,
-    grids_level=9, cas=False
+    grids_level=9
 ):
     """Used for checking diatomic systems to see if the Lagrange Multipliers are working properly."""
     global mols
@@ -55,15 +56,13 @@ def diatomic(
     if density_fit:
         mf = mf.density_fit(auxbasis=df.aug_etb(mol))
 
-    if cas:
-        mc = mcscf.CASSCF(mf.run(), ncas, nelecas)
-    else:
-        mc = mcpdft.CASSCF(mf.run(), fnal, ncas, nelecas, grids_level=grids_level)
+    mc = mcpdft.CASSCF(mf.run(), fnal, ncas, nelecas, grids_level=grids_level)
     if spin is None:
         spin = mol.nelectron % 2
 
-    ss = spin * (spin + 2) * 0.25
-    mc.fix_spin_(ss=ss, shift=2)
+    # ss = spin * (spin + 2) * 0.25
+    # mc.fix_spin_(ss=ss, shift=2)
+    mc.fcisolver = csf_solver(mol, smult=spin+1)
 
     if nstates > 1:
         mc = mc.state_average(
@@ -124,28 +123,47 @@ class KnownValues(unittest.TestCase):
                 de = mc.kernel(state=state)[1, 0] / BOHR
                 self.assertAlmostEqual(de, DE_REF[state], 5)
 
-    def test_grad_lih_sstpbe022_sto3g(self):
-        mc = diatomic("Li", "H", 0.8, "MC23", "STO-3G", 2, 2, 1, grids_level=9)
+    def test_grad_lih_ssmc2322_sto3g(self):
+        mc = diatomic("Li", "H", 0.8, "MC23", "STO-3G", 2, 2, 1, grids_level=1)
+        de = mc.kernel()[1, 0] / BOHR
 
-        de_ana = mc.kernel()[1,0]
+        # Numerical from this software
+        # PySCF commit:         f2c2d3f963916fb64ae77241f1b44f24fa484d96
+        # PySCF-forge commit:   5027df09b644c819439046f9bb34b7efee2ac3e0
+        DE_REF = -1.0641645070
+
+        self.assertAlmostEqual(de, DE_REF, 5)
+
+
+    def test_custom(self):
+        df = False
+        r = 0.8
+        mc = diatomic("Li", "H", r, "MC23", "STO-3G", 2, 2, 1, grids_level=1, density_fit=df)
+
+        de_ana = mc.kernel(state=0)[1,0]/BOHR
 
         mc_scanner = mc.base.as_scanner()
         print(de_ana)
 
         import numpy as np
 
+        deltas = []
+        de_num = []
+
         for i in np.arange(2, 8, 0.1):
             delta = np.exp(-i)
-            mc_scanner(f"Li 0 0 0; H {0.8+delta} 0 0")
+            deltas.append(delta)
+            mc_scanner(f"Li 0 0 0; H {r+delta} 0 0")
             e1 = mc_scanner.e_tot
-            mc_scanner(f"Li 0 0 0; H {0.8-delta} 0 0")
+            mc_scanner(f"Li 0 0 0; H {r-delta} 0 0")
             e2 = mc_scanner.e_tot
-            de_num = (e1-e2)/(2*delta) * BOHR
+            de = (e1-e2)/(2*delta) 
 
-            err = np.abs(de_num - de_ana)
+            de_num.append(de)
+            # print(de-de_ana)
 
-            print(err)
-
+        print(",".join([f"{d:.10f}" for d in deltas]))
+        print(",".join([f"{d:.10f}" for d in de_num]))
 
 
 if __name__ == "__main__":

--- a/pyscf/grad/test/test_grad_metagga_mcpdft.py
+++ b/pyscf/grad/test/test_grad_metagga_mcpdft.py
@@ -21,9 +21,6 @@ from pyscf import scf, gto, df, dft
 from pyscf.data.nist import BOHR
 from pyscf import mcpdft
 
-from mrh.my_pyscf.fci import csf_solver
-
-
 def diatomic(
     atom1,
     atom2,
@@ -61,9 +58,8 @@ def diatomic(
     if spin is None:
         spin = mol.nelectron % 2
 
-    # ss = spin * (spin + 2) * 0.25
-    # mc.fix_spin_(ss=ss, shift=2)
-    mc.fcisolver = csf_solver(mol, smult=spin + 1)
+    ss = spin * (spin + 2) * 0.25
+    mc.fix_spin_(ss=ss, shift=2)
 
     if nstates > 1:
         mc = mc.state_average(

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -136,15 +136,10 @@ def energy_mcwfn(mc, mo_coeff=None, ci=None, ot=None, state=0, casdm1s=None,
     if casdm1s is None: casdm1s = mc.make_one_casdm1s(ci=ci, state=state)
     if casdm2 is None: casdm2 = mc.make_one_casdm2(ci=ci, state=state)
     log = logger.new_logger(mc, verbose=verbose)
-    nelecas = mc.nelecas
     dm1s = _dms.casdm1s_to_dm1s(mc, casdm1s, mo_coeff=mo_coeff)
     cascm2 = _dms.dm2_cumulant(casdm2, casdm1s)
 
-    spin = abs(nelecas[0] - nelecas[1])
-    omega, alpha, hyb = ot._numint.rsh_and_hybrid_coeff(ot.otxc, spin=spin)
-    if abs(omega) > 1e-11:
-        raise NotImplementedError("range-separated on-top functionals")
-    hyb_x, hyb_c = hyb
+    hyb_x, hyb_c = ot._numint.rsh_and_hybrid_coeff(ot.otxc, mc.mol.spin)[2]
 
     Vnn = mc._scf.energy_nuc()
     h = mc._scf.get_hcore()
@@ -636,12 +631,7 @@ class _PDFT:
             pdft_veff1 += ot_hyb*self._scf.get_j(self.mol, dm1s[0] + dm1s[1])
 
         if not drop_mcwfn and cas_hyb > 1e-11:
-            # TODO deal with energy_core???
-            # TODO, have eris be a kwarg???
-            eris = self.ao2mo()
-            terms = ["vhf_c", "papa", "ppaa", "j_pc", "k_pc"]
-            for term in terms:
-                setattr(pdft_veff2, term, getattr(pdft_veff2, term) + cas_hyb*getattr(eris, term))
+            raise NotImplementedError("adding mcwfn response to pdft_veff2")
 
         logger.timer(self, 'get_pdft_veff', *t0)
 

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -604,7 +604,7 @@ class _PDFT:
             casdm1s = self.make_one_casdm1s(ci, state=state)
         if casdm2 is None:
             casdm2 = self.make_one_casdm2(ci, state=state)
-        if ot is None: 
+        if ot is None:
             ot = self.otfnal
 
         ncore, ncas = self.ncore, self.ncas
@@ -623,9 +623,18 @@ class _PDFT:
         cas_hyb = hyb[0]
         ot_hyb = 1.0-cas_hyb
 
-        E_ot, pdft_veff1, pdft_veff2 = pdft_veff.kernel(ot, dm1s,
-                                                        cascm2, mo, ncore, ncas, max_memory=self.max_memory,
-                                                        paaa_only=paaa_only, aaaa_only=aaaa_only, jk_pc=jk_pc) 
+        E_ot, pdft_veff1, pdft_veff2 = pdft_veff.kernel(
+            ot,
+            dm1s,
+            cascm2,
+            mo,
+            ncore,
+            ncas,
+            max_memory=self.max_memory,
+            paaa_only=paaa_only,
+            aaaa_only=aaaa_only,
+            jk_pc=jk_pc,
+        )
 
         if incl_coul:
             pdft_veff1 += ot_hyb*self._scf.get_j(self.mol, dm1s[0] + dm1s[1])

--- a/pyscf/mcpdft/pdft_veff.py
+++ b/pyscf/mcpdft/pdft_veff.py
@@ -42,7 +42,7 @@ import gc
 
 def kernel(ot, dm1s, cascm2, mo_coeff, ncore, ncas,
            max_memory=2000, hermi=1, paaa_only=False, aaaa_only=False,
-           jk_pc=False, drop_mcwfn=False):
+           jk_pc=False):
     '''Get the 1- and 2-body effective potential from MC-PDFT.
 
     Args:
@@ -74,9 +74,6 @@ def kernel(ot, dm1s, cascm2, mo_coeff, ncore, ncas,
         jk_pc : logical
             If true, compute the ppii=pipi elements of veff2
             (otherwise, these are set to zero)
-        drop_mcwfn : logical
-                If true, drops the normal CASSCF wave function
-                contribution (ie the ``Hartree exchange-correlation'') from the response
 
     Returns:
         veff1 : ndarray of shape (nao, nao)
@@ -97,13 +94,10 @@ def kernel(ot, dm1s, cascm2, mo_coeff, ncore, ncas,
     if abs(omega) > 1e-11:
         raise NotImplementedError("range-separated on-top functionals")
 
-    if drop_mcwfn:
-        if abs(hyb_x - hyb_c) > 1e-11:
-            raise NotImplementedError(
-                "effective potential for hybrid functionals with different exchange, correlations components")
+    if abs(hyb_x - hyb_c) > 1e-11:
+        raise NotImplementedError(
+            "effective potential for hybrid functionals with different exchange, correlations components")
 
-    elif abs(hyb_x) > 1e-11 or abs(hyb_c) > 1e-11:
-        raise NotImplementedError("effective potential for hybrid functionals")
 
     E_ot = 0.0
     veff1 = np.zeros((nao, nao), dtype=dm1s.dtype)


### PR DESCRIPTION
Implements hybrid nuclear gradients for:
- SS-MC-PDFT 
- SS-MC-PDFT with density fitting
- SA-MC-PDFT
- SA-MC-PDFT with density fitting

Tests are added for MC23 with and without density fitting.