### PR TITLE
change the davidson solver for spin flip TDDFT

### DIFF
--- a/examples/grad/03-spin_flip_tda_grad.py
+++ b/examples/grad/03-spin_flip_tda_grad.py
@@ -8,7 +8,7 @@ spin flip down.
 Note: pyscf.sftda_grad is implemented under the spin-flip TDDFT framework,
 that can deal with both spin-flip TDA and TDDFT results. However, the Davi-
 dson solver to spin-flip TDDFT hasn't been implemented, and no direct exam-
-ples are displayed here. 
+ples are displayed here.
 '''
 
 import numpy as np

--- a/examples/grad/04-spin_flip_tddft_grad.py
+++ b/examples/grad/04-spin_flip_tddft_grad.py
@@ -1,7 +1,7 @@
 '''
 For spin-flip TDDFT gradient, you can obtain and create a spin-flip TDDFT
-object use sftda.uhf_df.get_ab_sf() function. And transfrom the excited 
-energy \omega and transition vector x,y into the correct form. Then use
+object use sftda.uhf_df.get_ab_sf() function. And transfrom the excited
+energy omega and transition vector x,y into the correct form. Then use
 the gradient module.
 '''
 import numpy as np
@@ -27,7 +27,21 @@ mf = dft.UKS(mol)
 mf.xc = 'svwn' # blyp, b3lyp, tpss
 mf.kernel()
 
-# use get_ab_sf() to get response Matrix
+mftd1 = sftda.TDDFT_SF(mf)
+mftd1.nstates = 5 # the number of excited states
+mftd1.extype = 1  # 1 for spin flip down excited energies
+mftd1.collinear_samples=200
+mftd1.kernel()
+
+# print(mftd1.e)
+
+mftdg1 = mftd1.Gradients()
+g1 = mftdg1.kernel(state=2)
+
+print(g1)
+
+
+# If use get_ab_sf() to get response Matrix:
 a, b = sftda.TDDFT_SF(mf).get_ab_sf()
 A_baba, A_abab = a
 B_baab, B_abba = b

--- a/examples/sftda/00-spin_flip_tddft.py
+++ b/examples/sftda/00-spin_flip_tddft.py
@@ -49,35 +49,34 @@ mftd2.e # to get the excited energies
 mftd2.xy # to get the transition vectors
 
 #
-# 3. get_ab_sf()
+# 3. spin flip up TDDFT, which can not converged.
 #
+mftd3 = sftda.TDDFT_SF(mf) # equal to mftd3 = mf.TDDFT_SF()
+mftd3.nstates = 4
+mftd3.extype = 0
+mftd3.collinear_samples=200
+mftd3.kernel()
+
+mftd3.e
+mftd3.xy
+
+#
+# 4. spin flip down TDDFT, which can not converged.
+#
+mftd4 = sftda.uks_sf.CasidaTDDFT(mf)
+mftd4.nstates = 4
+mftd4.extype = 1
+mftd4.collinear_samples=200
+mftd4.kernel()
+
+mftd4.e
+mftd4.xy
+
+#
+# 5. get_ab_sf()
+# Besides, users can use get_ab_sf() to construct the whole TDDFT matrix
+#          to get all excited energies, if the system is small.
 # a, b = sftda.TDA_SF(mf).get_ab_sf()
 a, b = sftda.TDDFT_SF(mf).get_ab_sf()
 # List a has two items: (A_baba,A_abab) with A[i,a,j,b].
 # List b has two items: (B_baab,B_abba) with B[i,a,j,b].
-
-#
-# 4. spin flip up TDDFT, which can not converged.
-#    Just give an input example here.
-#    Users can use get_ab_sf() to construct the whole TDDFT matrix
-#    to get the excited energies, if the system is small.
-# mftd3 = sftda.TDDFT_SF(mf) # equal to mftd3 = mf.TDDFT_SF()
-# mftd3.nstates = 4
-# mftd3.extype = 0
-# mftd3.collinear_samples=200
-# mftd3.kernel()
-
-# mftd3.e
-# mftd3.xy
-
-#
-# 5. spin flip down TDDFT, which can not converged.
-#    Just give an input example here.
-# mftd4 = sftda.uks_sf.CasidaTDDFT(mf)
-# mftd4.nstates = 4
-# mftd4.extype = 1
-# mftd4.collinear_samples=200
-# mftd4.kernel()
-
-# mftd4.e
-# mftd4.xy

--- a/examples/sftda/01-spin_square.py
+++ b/examples/sftda/01-spin_square.py
@@ -7,8 +7,6 @@ Test the spin_square calculation tool in sftda.tools_td.py.
 from pyscf import gto,dft,sftda,tdscf
 from pyscf.sftda import tools_td
 
-# ToDo : add the spin flip TDDFT parts.
-
 mol = gto.Mole()
 mol.verbose = 3
 mol.output = None
@@ -49,21 +47,43 @@ ssI = tools_td.spin_square(mf,mftd2.xy[0],extype=1,tdtype='TDA')
 print('The spin square of the first excited state is : ' + str(ssI))
 
 #
-# 3. <S^2> for spin conserving TDA.
+# 3. <S^2> for spin flip up TDDFT
 #
-mftd3 = tdscf.TDA(mf)
+mftd3 = sftda.TDDFT_SF(mf)
+mftd3.extype=0
 mftd3.nstates = 5
 mftd3.kernel()
 
-ssI = tools_td.spin_square(mf,mftd3.xy[0],extype=2,tdtype='TDA')
+ssI = tools_td.spin_square(mf,mftd3.xy[0],extype=0,tdtype='TDDFT')
 print('The spin square of the first excited state is : ' + str(ssI))
 
 #
-# 4. <S^2> for spin conserving TDDFT.
+# 4. <S^2> for spin flip down TDDFT
 #
-mftd4 = tdscf.TDDFT(mf)
+mftd4 = sftda.TDDFT_SF(mf)
+mftd4.extype=1
 mftd4.nstates = 5
 mftd4.kernel()
 
-ssI = tools_td.spin_square(mf,mftd4.xy[0],extype=2,tdtype='TDDFT')
+ssI = tools_td.spin_square(mf,mftd4.xy[0],extype=1,tdtype='TDDFT')
+print('The spin square of the first excited state is : ' + str(ssI))
+
+#
+# 5. <S^2> for spin conserving TDA.
+#
+mftd5 = tdscf.TDA(mf)
+mftd5.nstates = 5
+mftd5.kernel()
+
+ssI = tools_td.spin_square(mf,mftd5.xy[0],extype=2,tdtype='TDA')
+print('The spin square of the first excited state is : ' + str(ssI))
+
+#
+# 6. <S^2> for spin conserving TDDFT.
+#
+mftd6 = tdscf.TDDFT(mf)
+mftd6.nstates = 5
+mftd6.kernel()
+
+ssI = tools_td.spin_square(mf,mftd6.xy[0],extype=2,tdtype='TDDFT')
 print('The spin square of the first excited state is : ' + str(ssI))

--- a/examples/sftda/02-test_transition_analyze.py
+++ b/examples/sftda/02-test_transition_analyze.py
@@ -37,7 +37,7 @@ xy = mftd1.xy
 tools_td.transition_analyze(mf, mftd1, e[0], xy[0], tdtype='TDA')
 
 
-mftd2 = sftda.uks_sf.TDA_SF(mf)
+mftd2 = sftda.uks_sf.TDDFT_SF(mf)
 mftd2.nstates = 5
 mftd2.extype = 1
 mftd2.collinear_samples=200
@@ -50,7 +50,7 @@ xy = mftd2.xy
 # 2. Print tansition analyze for the first spin-flip down excited state.
 #
 for i in range(5):
-    tools_td.transition_analyze(mf, mftd2, e[i], xy[i], tdtype='TDA')
+    tools_td.transition_analyze(mf, mftd2, e[i], xy[i], tdtype='TDDFT')
 
 
 #

--- a/pyscf/sftda/__init__.py
+++ b/pyscf/sftda/__init__.py
@@ -29,7 +29,4 @@ def TDA_SF(mf):
     return mf.TDA_SF()
 
 def TDDFT_SF(mf):
-    print('Warning!!! SF-TDDFT ruining in the slow divergence, ' + \
-          'you can choose get_ab_sf() to construct the full matrix ' + \
-          'to obtain the excited energies.')
     return mf.TDDFT_SF()

--- a/pyscf/sftda/numint_sftd.py
+++ b/pyscf/sftda/numint_sftd.py
@@ -29,8 +29,6 @@ def nr_uks_fxc_sf(ni, mol, grids, xc_code, dm0, dms, relativity=0, hermi=0,rho0=
         dtype = dms.dtype
     else:
         dtype = numpy.result_type(*dms)
-    if hermi != 1 and dtype != numpy.double:
-        raise NotImplementedError('complex density matrix')
 
     xctype = ni._xc_type(xc_code)
 

--- a/pyscf/sftda/test/test_uks_sf_tda.py
+++ b/pyscf/sftda/test/test_uks_sf_tda.py
@@ -22,8 +22,6 @@ try:
 except ImportError:
     mcfun = None
 
-# ToDo: Add the SF-TDDFT tests.
-
 def diagonalize(a, b, nroots=4,extype=0):
     a_b2a, a_a2b = a
     b_b2a, b_a2b = b
@@ -257,5 +255,5 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(isinstance(sftda.TDA_SF(ks), sftda.uhf_sf.TDA_SF))
 
 if __name__ == "__main__":
-    print("Full Tests for SF-TD-UKS")
+    print("Full Tests for SF-TDA")
     unittest.main()

--- a/pyscf/sftda/test/test_uks_sf_tddft.py
+++ b/pyscf/sftda/test/test_uks_sf_tddft.py
@@ -1,0 +1,136 @@
+#/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+from pyscf import lib, gto, scf, dft
+from pyscf import sftda
+try:
+    import mcfun
+except ImportError:
+    mcfun = None
+
+def setUpModule():
+    global mol, mf_lda, mf_bp86, mf_b3lyp, mf_tpss
+    mol = gto.Mole()
+    mol.verbose = 5
+    mol.output = '/dev/null'
+    mol.atom = '''
+    O     0.   0.       0.
+    H     0.   -0.757   0.587
+    H     0.   0.757    0.587'''
+    mol.spin = 2
+    mol.basis = '631g'
+    mol.build()
+
+    mf_lda = dft.UKS(mol).set(xc='lda', conv_tol=1e-12)
+    mf_lda.grids.prune = None
+    mf_lda = mf_lda.newton().run()
+    mf_bp86 = dft.UKS(mol).set(xc='b88,p86', conv_tol=1e-12)
+    mf_bp86.grids.prune = None
+    mf_bp86 = mf_bp86.newton().run()
+    mf_b3lyp = dft.UKS(mol).set(xc='b3lyp', conv_tol=1e-12)
+    mf_b3lyp.grids.prune = None
+    mf_b3lyp = mf_b3lyp.newton().run()
+    mf_tpss = dft.UKS(mol).set(xc='tpss', conv_tol=1e-12)
+    mf_tpss.grids.prune = None
+    mf_tpss = mf_tpss.newton().run()
+    
+def tearDownModule():
+    global mol, mf_lda, mf_bp86 , mf_b3lyp, mf_tpss
+    mol.stdout.close()
+    del mol, mf_lda, mf_bp86 , mf_b3lyp, mf_tpss
+
+
+class KnownValues(unittest.TestCase):
+    @unittest.skipIf(mcfun is None, "mcfun library not found.")
+    def test_tddft_lda(self):
+        td = sftda.TDDFT_SF(mf_lda).set(conv_tol=1e-12)
+        td.extype = 0
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 7.948103693468726, 4)
+        ref = [2.90934687e-01, 4.17504148e-01, 5.39294897e-01, 1.00809769e+00]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+        td = sftda.TDDFT_SF(mf_lda).set(conv_tol=1e-12)
+        td.extype = 1
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 0.9727213492347719, 4)
+        ref = [2.48203085e-02, 9.20937945e-02, 9.33131348e-02, 2.42567238e-01]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+    @unittest.skipIf(mcfun is None, "mcfun library not found.")
+    def test_tddft_bp86(self):
+        td = sftda.uks_sf.TDDFT_SF(mf_bp86).set(conv_tol=1e-12)
+        td.extype = 0
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 8.368198437727397, 4)
+        ref = [3.03220029e-01, 4.48165285e-01, 5.71527356e-01, 1.04310453e+00]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+        td = sftda.uks_sf.TDDFT_SF(mf_bp86).set(conv_tol=1e-12)
+        td.extype = 1
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 0.6454471439667748, 4)
+        ref = [1.82489014e-02, 8.23546536e-02, 9.37783834e-02, 2.38795063e-01]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+    @unittest.skipIf(mcfun is None, "mcfun library not found.")
+    def test_tddft_b3lyp(self):
+        td = sftda.TDDFT_SF(mf_b3lyp).set(conv_tol=1e-12)
+        td.extype = 0
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 8.310118087916951, 4)
+        ref = [2.96621765e-01, 4.57522349e-01, 5.72949431e-01, 1.06284181e+00]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+        td = sftda.TDDFT_SF(mf_b3lyp).set(conv_tol=1e-12)
+        td.extype = 1
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 0.7265669784640774, 4)
+        ref = [1.83133171e-02, 8.50138300e-02, 9.02221325e-02, 2.35296638e-01]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+    @unittest.skipIf(mcfun is None, "mcfun library not found.")
+    def test_tddft_tpss(self):
+        td = mf_tpss.TDDFT_SF().set(conv_tol=1e-12)
+        td.extype = 0
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 8.001090007698803, 4)
+        ref = [2.87394817e-01, 4.47824155e-01, 5.65475295e-01, 1.05244100e+00]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+        td = mf_tpss.TDDFT_SF().set(conv_tol=1e-12)
+        td.extype = 1
+        td.collinear_samples = 200
+        es = td.kernel(nstates=6)[0]
+        self.assertAlmostEqual(lib.fp(es[1:4]* 27.2114), 0.6465536096511839, 4)
+        ref = [2.18608622e-02, 8.76824835e-02, 1.09277571e-01, 2.53604876e-01]
+        self.assertAlmostEqual(abs(es[1:5] - ref).max(), 0, 4)
+
+    def test_init(self):
+        ks = scf.UKS(mol)
+        self.assertTrue(isinstance(sftda.TDDFT_SF(ks), sftda.uks_sf.CasidaTDDFT))
+
+if __name__ == "__main__":
+    print("Full Tests for SF-TDDFT")
+    unittest.main()

--- a/pyscf/sftda/uks_sf.py
+++ b/pyscf/sftda/uks_sf.py
@@ -142,18 +142,20 @@ class CasidaTDDFT(TDA_SF):
             x0 = self.init_guess(self._scf, self.nstates)
 
         def pickeig(w, v, nroots, envs):
-            idx = numpy.where(w > 1e-3)[0]
-            return w[idx], v[:,idx], idx
+            realidx = numpy.where((abs(w.imag) < 1e-4) &
+                                  (w.real > -1e-3))[0]
+            return lib.linalg_helper._eigs_cmplx2real(w, v, realidx,
+                                                      real_eigenvectors=True)
 
         # Because the degeneracy has been dealt with by init_guess_sf function.
         nstates_new = x0.shape[0]
         converged, w, x1 = \
-                lib.davidson1(vind, x0, precond,
-                              tol=self.conv_tol,
-                              nroots=nstates_new, lindep=self.lindep,
-                              max_cycle=self.max_cycle,
-                              max_space=self.max_space, pick=pickeig,
-                              verbose=log)
+                lib.davidson_nosym1(vind, x0, precond,
+                                    tol=self.conv_tol,
+                                    nroots=nstates_new,
+                                    max_cycle=self.max_cycle,
+                                    max_space=self.max_space, pick=pickeig,
+                                    verbose=log)
 
         mo_occ = self._scf.mo_occ
         occidxa = numpy.where(mo_occ[0]>0)[0]


### PR DESCRIPTION
Change the davidson solver for spin flip TDDFT, where lib.davidson_nosym1() is used. 
Unlike the case of spin-conserving TDDFT, the matrix in the Casida equation for spin-flip TDDFT (not TDA) is non-Hermitian, so the davidson_nosym1() solver should be used. The following updates have been made:
1. Changed davidson1() to davidson_nosym1() in sftda.uks_sf.kernel();
2. Added unit tests and usage examples for spin-flip TDDFT: (1) sftda.test.test_uks_sf_tddft.py；(2) example.grad.04-spin_flip_tddft_grad.py.