### PR TITLE
Remove physically incorrect debug information in MC-PDFT

### DIFF
--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -147,12 +147,13 @@ def energy_mcwfn(mc, mo_coeff=None, ci=None, ot=None, state=0, casdm1s=None,
     if log.verbose >= logger.DEBUG or abs(hyb_x) > 1e-10:
         vj, vk = mc._scf.get_jk(dm=dm1s)
         vj = vj[0] + vj[1]
+
     else:
         vj = mc._scf.get_j(dm=dm1)
+
     Te_Vne = np.tensordot(h, dm1)
     # (vj_a + vj_b) * (dm_a + dm_b)
     E_j = np.tensordot(vj, dm1) / 2
-    # (vk_a * dm_a) + (vk_b * dm_b) Mind the difference!
     log.debug('CAS energy decomposition:')
     log.debug('Vnn = %s', Vnn)
     log.debug('Te + Vne = %s', Te_Vne)
@@ -160,11 +161,12 @@ def energy_mcwfn(mc, mo_coeff=None, ci=None, ot=None, state=0, casdm1s=None,
 
     if abs(hyb_x - hyb_c) > 1e-10:
         log.warn("exchange and correlation hybridization differ")
-        log.warn("Your energy surfaces may have discontinuities, see https://github.com/pyscf/pyscf-forge/issues/128")
+        log.warn("may lead to unphysical results, see https://github.com/pyscf/pyscf-forge/issues/128")
 
     # Note: this is not the true exchange energy, but just the HF-like exchange
     E_x = 0.0
     if log.verbose >= logger.DEBUG or abs(hyb_x) > 1e-10:
+        # (vk_a * dm_a) + (vk_b * dm_b)
         E_x = -(np.tensordot(vk[0], dm1s[0]) + np.tensordot(vk[1], dm1s[1]))
         E_x /= 2.0
         log.debug("E_x = %s", E_x)

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -158,7 +158,7 @@ def energy_mcwfn(mc, mo_coeff=None, ci=None, ot=None, state=0, casdm1s=None,
     log.debug('Te + Vne = %s', Te_Vne)
     log.debug('E_j = %s', E_j)
 
-    if abs(hyb_x-hyb_c) < 1e-10:
+    if abs(hyb_x - hyb_c) > 1e-10:
         log.warn("exchange and correlation hybridization differ")
         log.warn("Your energy surfaces may have discontinuities, see https://github.com/pyscf/pyscf-forge/issues/128")
 

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -167,15 +167,17 @@ def energy_mcwfn(mc, mo_coeff=None, ci=None, ot=None, state=0, casdm1s=None,
     if log.verbose >= logger.DEBUG or abs(hyb_x) > 1e-10:
         E_x = -(np.tensordot(vk[0], dm1s[0]) + np.tensordot(vk[1], dm1s[1]))
         E_x /= 2.0
-        log.debug('E_x = %s', E_x)
+        log.debug("E_x = %s", E_x)
+        log.debug("Adding (%s) * E_x = %s", hyb_x, hyb_x * E_x)
 
     # This is not correlation, but the 2-body cumulant tensored with the eri's:
     # g_pqrs * l_pqrs / 2
-    E_c = 0
+    E_c = 0.0
     if log.verbose >= logger.DEBUG or abs(hyb_c) > 1e-10:
         aeri = ao2mo.restore(1, mc.get_h2eff(mo_coeff), mc.ncas)
         E_c = np.tensordot(aeri, cascm2, axes=4) / 2
-        log.debug('E_c = %s', E_c)
+        log.debug("E_c = %s", E_c)
+        log.debug("Adding (%s) * E_c = %s", hyb_c, hyb_c * E_c)
 
     e_mcwfn = Vnn + Te_Vne + E_j + (hyb_x * E_x) + (hyb_c * E_c)
     return e_mcwfn


### PR DESCRIPTION
See #128. Removes incorrect debug information that can lead to confusion.

Also warns users and points to the discussion if exchange and correlation are not scaled at the same amount. Perhaps this warning should eventually moved into `otfnal`.