### PR TITLE
Set default MSPDFT to L-PDFT (#138)

### DIFF
--- a/pyscf/mcpdft/__init__.py
+++ b/pyscf/mcpdft/__init__.py
@@ -14,6 +14,20 @@
 # limitations under the License.
 #
 # Lahh dee dah
+'''
+Multi-configuration pair-density functional theory
+==================================================
+
+Simple usage::
+
+    >>> from pyscf import gto, scf, mcpdft
+    >>> mol = gto.M(atom='N 0 0 0; N 0 0 1', basis='def2-tzvp')
+    >>> mf = scf.RHF(mol).run ()
+    >>> mc = mcpdft.CASSCF (mf, 'tPBE', 6, 6)
+    >>> mc.run()
+'''
+
+
 import copy
 from pyscf.mcpdft.mcpdft import get_mcpdft_child_class
 from pyscf.mcpdft.otfnal import make_hybrid_fnal as hyb

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -764,7 +764,7 @@ class _PDFT:
         state_average_mix_(self, fcisolvers, weights)
         return self
 
-    def multi_state_mix(self, fcisolvers=None, weights=(0.5, 0.5), method='CMS'):
+    def multi_state_mix(self, fcisolvers=None, weights=(0.5, 0.5), method='LIN'):
         if method.upper() == "LIN":
             from pyscf.mcpdft.lpdft import linear_multi_state_mix
             return linear_multi_state_mix(self, fcisolvers=fcisolvers, weights=weights)
@@ -772,7 +772,7 @@ class _PDFT:
         else:
             raise NotImplementedError(f"StateAverageMix not available for {method}")
 
-    def multi_state(self, weights=(0.5, 0.5), method='CMS'):
+    def multi_state(self, weights=(0.5, 0.5), method='LIN'):
         if method.upper() == "LIN":
             from pyscf.mcpdft.lpdft import linear_multi_state
             return linear_multi_state(self, weights=weights)

--- a/pyscf/prop/dip_moment/test/test_cmspdft_pdm.py
+++ b/pyscf/prop/dip_moment/test/test_cmspdft_pdm.py
@@ -47,7 +47,7 @@ def get_h2o(mol,iroots=3):
     #mc.fcisolver = csf_solver(mol, smult=1, symm='A1')
     fix_spin_(mc.fcisolver, ss=0)
     mc.fcisolver.wfnsym = 'A1'
-    mc = mc.multi_state(weights)
+    mc = mc.multi_state(weights, 'cms')
     mo = mcscf.sort_mo(mc, mf.mo_coeff, [4,5,8,9])
     mc.conv_tol = 1e-11
     mc.kernel(mo)


### PR DESCRIPTION
Also add a "simple usage" card to the top of `mcpdft/__init__.py` as suggested [here](https://github.com/pyscf/pyscf.github.io?tab=readme-ov-file#how-to-contribute).