### PR TITLE
Rationalize mc.otfnal.verbose (#147)

### DIFF
--- a/pyscf/mcpdft/__init__.py
+++ b/pyscf/mcpdft/__init__.py
@@ -71,6 +71,8 @@ def _MCPDFT (mc_class, mc_or_mf_or_mol, ot, ncas, nelecas, ncore=None, frozen=No
     else: mc1 = mc_class (mf_or_mol, ncas, nelecas, ncore=ncore)
     mc2 = get_mcpdft_child_class (mc1, ot, **kwargs)
     if mc0 is not None:
+        mc2.verbose = mc0.verbose
+        mc2.stdout = mc0.stdout
         mc2.mo_coeff = mc_or_mf_or_mol.mo_coeff.copy ()    
         mc2.ci = copy.deepcopy (mc_or_mf_or_mol.ci)
         mc2.converged = mc0.converged

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -495,7 +495,7 @@ class _PDFT:
         return self.e_mcscf, self.e_cas, self.ci, self.mo_coeff, self.mo_energy
 
     def compute_pdft_energy_(self, mo_coeff=None, ci=None, ot=None, otxc=None,
-                             grids_level=None, grids_attr=None, dump_chk=True, **kwargs):
+                             grids_level=None, grids_attr=None, dump_chk=True, verbose=None, **kwargs):
         '''Compute the MC-PDFT energy(ies) (and update stored data)
         with the MC-SCF wave function fixed. '''
         if mo_coeff is not None: self.mo_coeff = mo_coeff
@@ -505,6 +505,8 @@ class _PDFT:
         if grids_attr is None: grids_attr = {}
         if grids_level is not None: grids_attr['level'] = grids_level
         if len(grids_attr): self.grids.__dict__.update(**grids_attr)
+        if verbose is None: verbose = self.verbose
+        self.verbose = self.otfnal.verbose = verbose
         nroots = getattr(self.fcisolver, 'nroots', 1)
         epdft = [self.energy_tot(mo_coeff=self.mo_coeff, ci=self.ci, state=ix,
                                  logger_tag='MC-PDFT state {}'.format(ix))


### PR DESCRIPTION
1. Set mcpdft verbose from mcscf object when building from mcscf object.
2. Update mcpdft otfnal verbose attribute on `compute_pdft_energy_`