### PR TITLE
Small fix for the LPDFT kernel argument

### DIFF
--- a/pyscf/mcpdft/lpdft.py
+++ b/pyscf/mcpdft/lpdft.py
@@ -432,7 +432,7 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
         """
         return self.lpdft_ham
 
-    def kernel(self, mo_coeff=None, ci0=None, ot=None, verbose=None):
+    def kernel(self, mo_coeff=None, ci0=None, ot=None, verbose=None, dump_chk=True):
         """
         Returns:
             6 elements, they are
@@ -460,7 +460,7 @@ class _LPDFT(mcpdft.MultiStateMCPDFTSolver):
         if ci0 is None and isinstance(getattr(self, "ci", None), list):
             ci0 = [c.copy() for c in self.ci]
 
-        kernel(self, mo_coeff, ci0, ot=ot, verbose=log, dump_chk=True)
+        kernel(self, mo_coeff, ci0, ot=ot, verbose=log, dump_chk=dump_chk)
         self._finalize_lin()
         return (
             self.e_tot,


### PR DESCRIPTION
LPDFT kernel doesn't take the dump_chk argument. 

Although, by default it's true which is a good thing, but in case if I don't want to save the information on chkfile or I am running the LPDFT based on CASCI object then calculations are crashing. They can be run, if I pass the dump_chk as false, that's not the solution, yet the LPDFT kernel should take the dump_chk argument.

mc = mcpdft.CASCI(mf, 'tpbe', 2, 2)
mc_ms = mc.multi_state ([.5, .5], "lin")
mc_ms.kernel(verbose=4, dump_chk=False)

@matthew-hennefarth 