### PR TITLE
Bug fixed in determinants for TREXIO export

### DIFF
--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -421,16 +421,14 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
     from trexio_tools.group_tools import determinant as trexio_det
 
     mo_num = norb
-    int64_num = int((mo_num - 1) / 64) + 1
+    int64_num = trexio.get_int64_num(tf)
     occsa, occsb, ci_values, num_determinants = get_occsa_and_occsb(mcscf, norb, nelec, ci_threshold)
 
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
-        occsa_upshifted = [orb + 1 for orb in a]
-        occsb_upshifted = [orb + 1 for orb in b]
         det_tmp = []
-        det_tmp += trexio_det.to_determinant_list(occsa_upshifted, int64_num)
-        det_tmp += trexio_det.to_determinant_list(occsb_upshifted, int64_num)
+        det_tmp += trexio_det.to_determinant_list(occsa, int64_num)
+        det_tmp += trexio_det.to_determinant_list(occsb, int64_num)
         det_list.append(det_tmp)
 
     if num_determinants > chunk_size:

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -427,8 +427,8 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
         det_tmp = []
-        det_tmp += trexio_det.to_determinant_list(occsa, int64_num)
-        det_tmp += trexio_det.to_determinant_list(occsb, int64_num)
+        det_tmp += trexio_det.to_determinant_list([orb for orb in a], int64_num)
+        det_tmp += trexio_det.to_determinant_list([orb for orb in b], int64_num)
         det_list.append(det_tmp)
 
     if num_determinants > chunk_size:

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -427,8 +427,8 @@ def det_to_trexio(mcscf, norb, nelec, filename, backend='h5', ci_threshold=0., c
     det_list = []
     for a, b, coeff in zip(occsa, occsb, ci_values):
         det_tmp = []
-        det_tmp += trexio_det.to_determinant_list([orb for orb in a], int64_num)
-        det_tmp += trexio_det.to_determinant_list([orb for orb in b], int64_num)
+        det_tmp += trexio_det.to_determinant_list(a, int64_num)
+        det_tmp += trexio_det.to_determinant_list(b, int64_num)
         det_list.append(det_tmp)
 
     if num_determinants > chunk_size:


### PR DESCRIPTION
Hi,
in the current pyscf-forge version, the determinants exported in the TREXIO file are wrong: the orbital indices are shifted by on. This small PR fixes this problem.