### PR TITLE
Small bug fix

### DIFF
--- a/pyscf/prop/dip_moment/mcpdft.py
+++ b/pyscf/prop/dip_moment/mcpdft.py
@@ -34,7 +34,7 @@ def get_guage_origin(mol,origin):
             center = charges.dot(coords)/charges.sum()
         else:
             raise RuntimeError ("Gauge origin is not recognized")
-    elif isinstance(center,str):
+    elif isinstance(origin, tuple):
         center = origin
     else:
         raise RuntimeError ("Gauge origin must be a string or tuple")


### PR DESCRIPTION
The [get_guage_origin](https://github.com/pyscf/pyscf-forge/blob/master/pyscf/prop/dip_moment/mcpdft.py#L24) has a bug. If the origin is passed as a tuple (i.e. coordinate of an atom) then it was breaking.

In this PR i fixed it.

@MatthewRHermes 