### PR TITLE
Disable numpy 2.4 in dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ AUTHOR_EMAIL = None
 DESCRIPTION  = 'Staging ground for PySCF core features'
 SO_EXTENSIONS = {
 }
-DEPENDENCIES = ['pyscf', 'numpy']
+DEPENDENCIES = ['pyscf', 'numpy!=2.4.*']
 VERSION = '1.0.3'
 
 #######################################################################


### PR DESCRIPTION
Due to the change of einsum_path API in numpy 2.4