### PR TITLE
fix broken occri: pyscf.lib.reduce doesn't exist (anymore?)

### DIFF
--- a/pyscf/occri/utils.py
+++ b/pyscf/occri/utils.py
@@ -46,7 +46,7 @@ def make_natural_orbitals(cell, kpts, dms):
     for i, dm in enumerate(dms):
         for k, s in enumerate(sk):
             # Diagonalize the DM in AO basis: S^{1/2} * DM * S^{1/2}
-            A = lib.reduce(numpy.dot, (s, dm[k], s))
+            A = numpy.dot (numpy.dot (s, dm[k]), s)
             w, v = scipy.linalg.eigh(A, b=s)
 
             # Sort eigenvalues/eigenvectors in descending order


### PR DESCRIPTION
This is breaking occri. Just do numpy.dot twice explicitly instead.