### PR TITLE
Refactor spin-flip TDDFT/TDA gradients

### DIFF
--- a/pyscf/grad/tduks_sf.py
+++ b/pyscf/grad/tduks_sf.py
@@ -12,6 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Ref:
+# J. Chem. Theory Comput. 2025, 21, 6, 3010
+#
 
 from functools import reduce
 import numpy as np
@@ -22,20 +26,22 @@ from pyscf.dft import numint
 from pyscf.dft import numint2c
 from pyscf.grad import rks as rks_grad
 from pyscf.grad import tdrhf as tdrhf_grad
-from pyscf.sftda.numint2c_sftd import cache_xc_kernel_sf
+from pyscf.grad import tdrks as tdrks_grad
+from pyscf.grad import tduks as tduks_grad
+from pyscf.sftda.numint2c_sftd import mcfun_eval_xc_adapter_sf
+
 
 def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
-    ''' Spin flip TDDFT gradient in UKS framework. Note: This function supports
-    both TDA or TDDFT results.
+    """
+    Electronic part of spin-flip TDA/TDDFT nuclear gradients.
 
-    Parameters
-    ----------
     Args:
-        td_grad : sftda.TDA_SF object.
+        td_grad : grad.tduks_sf.Gradients object.
 
-    Returns:
-        The gradient of excited states: Ei^{\\xi} = E0^{\\xi} + wi^{\\xi}
-    '''
+        x_y : a two-element list of numpy arrays
+            TDDFT X and Y amplitudes. If Y is set to 0, this function computes
+            TDA energy gradients.
+    """
     log = logger.new_logger(td_grad, verbose)
     time0 = logger.process_clock(), logger.perf_counter()
 
@@ -45,318 +51,208 @@ def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
     mo_coeff = mf.mo_coeff
     mo_energy = mf.mo_energy
     mo_occ = mf.mo_occ
-    occidxa = np.where(mo_occ[0]>0)[0]
-    occidxb = np.where(mo_occ[1]>0)[0]
-    viridxa = np.where(mo_occ[0]==0)[0]
-    viridxb = np.where(mo_occ[1]==0)[0]
+    occidxa = np.where(mo_occ[0] > 0)[0]
+    occidxb = np.where(mo_occ[1] > 0)[0]
+    viridxa = np.where(mo_occ[0] == 0)[0]
+    viridxb = np.where(mo_occ[1] == 0)[0]
     nocca = len(occidxa)
     noccb = len(occidxb)
     nvira = len(viridxa)
     nvirb = len(viridxb)
-    orboa = mo_coeff[0][:,occidxa]
-    orbob = mo_coeff[1][:,occidxb]
-    orbva = mo_coeff[0][:,viridxa]
-    orbvb = mo_coeff[1][:,viridxb]
+    orboa = mo_coeff[0][:, occidxa]
+    orbob = mo_coeff[1][:, occidxb]
+    orbva = mo_coeff[0][:, viridxa]
+    orbvb = mo_coeff[1][:, viridxb]
     nao = mo_coeff[0].shape[0]
-
     nmoa = nocca + nvira
     nmob = noccb + nvirb
 
-    if td_grad.base.extype==0:
-        x_ab, x_ba, y_ab, y_ba = x_y[0], 0, 0, x_y[1]
-        if not isinstance(y_ba, np.ndarray):
-            y_ba = np.zeros((nocca, nvirb))
-    elif td_grad.base.extype==1:
-        x_ab, x_ba, y_ab, y_ba = 0, x_y[0], x_y[1], 0
-        if not isinstance(y_ab, np.ndarray):
-            y_ab = np.zeros((noccb, nvira))
-    xpy_ab = (x_ab + y_ab).T
-    xpy_ba = (x_ba + y_ba).T
-    xmy_ab = (x_ab - y_ab).T
-    xmy_ba = (x_ba - y_ba).T
+    if td_grad.base.extype == 0:
+        y, x = x_y
+        if not isinstance(x, np.ndarray):
+            x = np.zeros((nocca, nvirb))
+    elif td_grad.base.extype == 1:
+        x, y = x_y
+        if not isinstance(y, np.ndarray):
+            y = np.zeros((noccb, nvira))
 
-    dvv_a = np.einsum('ai,bi->ab', xpy_ab, xpy_ab) + np.einsum('ai,bi->ab', xmy_ab, xmy_ab) # T^{ab \alpha \beta}*2
-    dvv_b = np.einsum('ai,bi->ab', xpy_ba, xpy_ba) + np.einsum('ai,bi->ab', xmy_ba, xmy_ba) # T^{ab \beta \alpha}*2
-    doo_b =-np.einsum('ai,aj->ij', xpy_ab, xpy_ab) - np.einsum('ai,aj->ij', xmy_ab, xmy_ab) # T^{ij \alpha \beta}*2
-    doo_a =-np.einsum('ai,aj->ij', xpy_ba, xpy_ba) - np.einsum('ai,aj->ij', xmy_ba, xmy_ba) # T^{ij \beta \alpha}*2
+    dvva = lib.einsum('ia,ib->ab', y, y)
+    dvvb = lib.einsum('ia,ib->ab', x, x)
+    dooa = -lib.einsum('ia,ja->ij', x, x)
+    doob = -lib.einsum('ia,ja->ij', y, y)
 
-    dmxpy_ab = reduce(np.dot, (orbva, xpy_ab, orbob.T)) # ua ai iv -> uv -> (X+Y)_{uv \alpha \beta}
-    dmxpy_ba = reduce(np.dot, (orbvb, xpy_ba, orboa.T)) # ua ai iv -> uv -> (X+Y)_{uv \beta \alpha}
-    dmxmy_ab = reduce(np.dot, (orbva, xmy_ab, orbob.T)) # ua ai iv -> uv -> (X-Y)_{uv \alpha \beta}
-    dmxmy_ba = reduce(np.dot, (orbvb, xmy_ba, orboa.T)) # ua ai iv -> uv -> (X-Y)_{uv \beta \alpha}
+    dmzooa = reduce(np.dot, (orboa, dooa, orboa.T))
+    dmzooa += reduce(np.dot, (orbva, dvva, orbva.T))
+    dmzoob = reduce(np.dot, (orbob, doob, orbob.T))
+    dmzoob += reduce(np.dot, (orbvb, dvvb, orbvb.T))
 
-    dmzoo_a = reduce(np.dot, (orboa, doo_a, orboa.T)) # \sum_{\sigma ab} 2*Tab \sigma C_{au} C_{bu}
-    dmzoo_b = reduce(np.dot, (orbob, doo_b, orbob.T)) # \sum_{\sigma ab} 2*Tij \sigma C_{iu} C_{iu}
-    dmzoo_a+= reduce(np.dot, (orbva, dvv_a, orbva.T))
-    dmzoo_b+= reduce(np.dot, (orbvb, dvv_b, orbvb.T))
+    dmx = reduce(np.dot, (orbvb, x.T, orboa.T))  # ba
+    dmy = reduce(np.dot, (orbob, y, orbva.T))  # ba
+    dmt = dmx + dmy
 
     ni = mf._numint
     ni.libxc.test_deriv_order(mf.xc, 3, raise_error=True)
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
 
-    # used by mcfun.
-    rho0, vxc, fxc = ni.cache_xc_kernel(mf.mol, mf.grids, mf.xc,
-                                    mo_coeff, mo_occ, spin=1)
+    f1vo, f1oo, vxc1, k1ao = _contract_xc_kernel(td_grad, mf.xc, dmt, (dmzooa, dmzoob), True, True, max_memory)
 
-    f1vo, f1oo, vxc1, k1ao = \
-            _contract_xc_kernel(td_grad, mf.xc, ((dmxpy_ab,dmxpy_ba),(dmxmy_ab,dmxmy_ba)),
-                                (dmzoo_a,dmzoo_b), True, True, max_memory)
-    k1ao_xpy, k1ao_xmy = k1ao
+    with_k = ni.libxc.is_hybrid_xc(mf.xc)
+    if with_k:
+        vj0, vk0 = mf.get_jk(mol, (dmzooa, dmzoob), hermi=1)  # (2, nao, nao)
+        vk1 = mf.get_k(mol, dmt, hermi=0) * hyb  # (nao, nao)
+        vk0 = vk0 * hyb
+        if omega != 0:
+            vk0 += mf.get_k(mol, (dmzooa, dmzoob), hermi=1, omega=omega) * (alpha - hyb)
+            vk1 += mf.get_k(mol, dmt, hermi=0, omega=omega) * (alpha - hyb)
 
-    # f1vo, (2,2,4,nao,nao), (X+Y) and (X-Y) with fxc_sf
-    # f1oo, (2,4,nao,nao), 2T with fxc_sc
-    # vxc1, ao with v1^{\sigma}
-    # k1ao_xpy，(2,2,4,nao,nao), (X+Y)(X+Y) and (X-Y)(X-Y) with gxc
+        veff0doo = vj0[0] + vj0[1] - vk0 + f1oo[:, 0] + k1ao[:, 0]
+        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa))
+        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob))
 
-    if abs(hyb) > 1e-10:
-        dm = (dmzoo_a, dmxpy_ba+dmxpy_ab.T, dmxmy_ba-dmxmy_ab.T,
-                dmzoo_b, dmxpy_ab+dmxpy_ba.T, dmxmy_ab-dmxmy_ba.T)
-        vj, vk = mf.get_jk(mol, dm, hermi=0)
-        vk *= hyb
-        if abs(omega) > 1e-10:
-            vk += mf.get_k(mol, dm, hermi=0, omega=omega) * (alpha-hyb)
-        vj = vj.reshape(2,3,nao,nao)
-        vk = vk.reshape(2,3,nao,nao)
-
-        veff0doo = vj[0,0]+vj[1,0] - vk[:,0]+ f1oo[:,0]
-        veff0doo[0] += (k1ao_xpy[0,0,0] + k1ao_xpy[0,1,0] + k1ao_xpy[1,0,0] + k1ao_xpy[1,1,0]
-                        +k1ao_xmy[0,0,0] + k1ao_xmy[0,1,0] + k1ao_xmy[1,0,0] + k1ao_xmy[1,1,0])
-        veff0doo[1] += (k1ao_xpy[0,0,0] + k1ao_xpy[0,1,0] - k1ao_xpy[1,0,0] - k1ao_xpy[1,1,0]
-                        +k1ao_xmy[0,0,0] + k1ao_xmy[0,1,0] - k1ao_xmy[1,0,0] - k1ao_xmy[1,1,0])
-
-        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa)) *2
-        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob)) *2
-
-        veff = - vk[:,1] + f1vo[0,:,0]
-        veff0mop_ba = reduce(np.dot, (mo_coeff[1].T, veff[0], mo_coeff[0]))
-        veff0mop_ab = reduce(np.dot, (mo_coeff[0].T, veff[1], mo_coeff[1]))
-
-        wvoa += np.einsum('ca,ci->ai', veff0mop_ba[noccb:,nocca:], xpy_ba) *2
-        wvob += np.einsum('ca,ci->ai', veff0mop_ab[nocca:,noccb:], xpy_ab) *2
-
-        wvoa -= np.einsum('il,al->ai', veff0mop_ab[:nocca,:noccb], xpy_ab) *2
-        wvob -= np.einsum('il,al->ai', veff0mop_ba[:noccb,:nocca], xpy_ba) *2
-
-        veff = -vk[:,2] + f1vo[1,:,0]
-        veff0mom_ba = reduce(np.dot, (mo_coeff[1].T, veff[0], mo_coeff[0]))
-        veff0mom_ab = reduce(np.dot, (mo_coeff[0].T, veff[1], mo_coeff[1]))
-
-        wvoa += np.einsum('ca,ci->ai', veff0mom_ba[noccb:,nocca:], xmy_ba) *2
-        wvob += np.einsum('ca,ci->ai', veff0mom_ab[nocca:,noccb:], xmy_ab) *2
-
-        wvoa -= np.einsum('il,al->ai', veff0mom_ab[:nocca,:noccb], xmy_ab) *2
-        wvob -= np.einsum('il,al->ai', veff0mom_ba[:noccb,:nocca], xmy_ba) *2
+        veff0mo = reduce(np.dot, (mo_coeff[1].T, f1vo[0] - vk1, mo_coeff[0]))
+        wvoa += lib.einsum('ac,ka->ck', veff0mo[noccb:, nocca:], x)
+        wvoa -= lib.einsum('jk,jc->ck', veff0mo[:noccb, :nocca], y)
+        wvob += lib.einsum('ac,ka->ck', veff0mo.T[nocca:, noccb:], y)
+        wvob -= lib.einsum('jk,jc->ck', veff0mo.T[:nocca, :noccb], x)
 
     else:
-        dm = (dmzoo_a, dmxpy_ba+dmxpy_ab.T, dmxmy_ba-dmxmy_ab.T,
-                dmzoo_b, dmxpy_ab+dmxpy_ba.T, dmxmy_ab-dmxmy_ba.T)
-        vj = mf.get_j(mol, dm, hermi=0).reshape(2,3,nao,nao)
+        vj0 = mf.get_j(mol, (dmzooa, dmzoob), hermi=1)  # (2, nao, nao)
+        veff0doo = vj0[0] + vj0[1] + f1oo[:, 0] + k1ao[:, 0]
+        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa))
+        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob))
 
-        veff0doo = vj[0,0]+vj[1,0] + f1oo[:,0]
-        veff0doo[0] += (k1ao_xpy[0,0,0] + k1ao_xpy[0,1,0] + k1ao_xpy[1,0,0] + k1ao_xpy[1,1,0]
-                        +k1ao_xmy[0,0,0] + k1ao_xmy[0,1,0] + k1ao_xmy[1,0,0] + k1ao_xmy[1,1,0])
-        veff0doo[1] += (k1ao_xpy[0,0,0] + k1ao_xpy[0,1,0] - k1ao_xpy[1,0,0] - k1ao_xpy[1,1,0]
-                        +k1ao_xmy[0,0,0] + k1ao_xmy[0,1,0] - k1ao_xmy[1,0,0] - k1ao_xmy[1,1,0])
-
-        wvoa = reduce(np.dot, (orbva.T, veff0doo[0], orboa)) *2
-        wvob = reduce(np.dot, (orbvb.T, veff0doo[1], orbob)) *2
-
-        veff = f1vo[0,:,0]
-        veff0mop_ba = reduce(np.dot, (mo_coeff[1].T, veff[0], mo_coeff[0]))
-        veff0mop_ab = reduce(np.dot, (mo_coeff[0].T, veff[1], mo_coeff[1]))
-
-        wvoa += np.einsum('ca,ci->ai', veff0mop_ba[noccb:,nocca:], xpy_ba) *2
-        wvob += np.einsum('ca,ci->ai', veff0mop_ab[nocca:,noccb:], xpy_ab) *2
-
-        wvoa -= np.einsum('il,al->ai', veff0mop_ab[:nocca,:noccb], xpy_ab) *2
-        wvob -= np.einsum('il,al->ai', veff0mop_ba[:noccb,:nocca], xpy_ba) *2
-
-        veff = f1vo[1,:,0]
-        veff0mom_ba = reduce(np.dot, (mo_coeff[1].T, veff[0], mo_coeff[0]))
-        veff0mom_ab = reduce(np.dot, (mo_coeff[0].T, veff[1], mo_coeff[1]))
-
-        wvoa += np.einsum('ca,ci->ai', veff0mom_ba[noccb:,nocca:], xmy_ba) *2
-        wvob += np.einsum('ca,ci->ai', veff0mom_ab[nocca:,noccb:], xmy_ab) *2
-
-        wvoa -= np.einsum('il,al->ai', veff0mom_ab[:nocca,:noccb], xmy_ab) *2
-        wvob -= np.einsum('il,al->ai', veff0mom_ba[:noccb,:nocca], xmy_ba) *2
+        veff0mo = reduce(np.dot, (mo_coeff[1].T, f1vo[0], mo_coeff[0]))
+        wvoa += lib.einsum('ac,ka->ck', veff0mo[noccb:, nocca:], x)
+        wvoa -= lib.einsum('jk,jc->ck', veff0mo[:noccb, :nocca], y)
+        wvob += lib.einsum('ac,ka->ck', veff0mo.T[nocca:, noccb:], y)
+        wvob -= lib.einsum('jk,jc->ck', veff0mo.T[:nocca, :noccb], x)
 
     vresp = mf.gen_response(hermi=1)
 
     def fvind(x):
-        dm1 = np.empty((2,nao,nao))
-        x_a = x[0,:nvira*nocca].reshape(nvira,nocca)
-        x_b = x[0,nvira*nocca:].reshape(nvirb,noccb)
-        dm_a = reduce(np.dot, (orbva, x_a, orboa.T))
-        dm_b = reduce(np.dot, (orbvb, x_b, orbob.T))
-        dm1[0] = (dm_a + dm_a.T).real
-        dm1[1] = (dm_b + dm_b.T).real
-
+        xa = x[0, : nvira * nocca].reshape(nvira, nocca)
+        xb = x[0, nvira * nocca :].reshape(nvirb, noccb)
+        dma = reduce(np.dot, (orbva, xa, orboa.T))
+        dmb = reduce(np.dot, (orbvb, xb, orbob.T))
+        dm1 = np.stack((dma + dma.T, dmb + dmb.T))
         v1 = vresp(dm1)
         v1a = reduce(np.dot, (orbva.T, v1[0], orboa))
         v1b = reduce(np.dot, (orbvb.T, v1[1], orbob))
         return np.hstack((v1a.ravel(), v1b.ravel()))
 
-    z1a, z1b = ucphf.solve(fvind, mo_energy, mo_occ, (wvoa,wvob),
-                           max_cycle=td_grad.cphf_max_cycle,
-                           tol=td_grad.cphf_conv_tol)[0]
-
+    z1a, z1b = ucphf.solve(
+        fvind, mo_energy, mo_occ, (wvoa, wvob), max_cycle=td_grad.cphf_max_cycle, tol=td_grad.cphf_conv_tol
+    )[0]
     time1 = log.timer('Z-vector using UCPHF solver', *time0)
 
-    z1ao = np.zeros((2,nao,nao))
-    z1ao[0] += reduce(np.dot, (orbva, z1a, orboa.T))
-    z1ao[1] += reduce(np.dot, (orbvb, z1b, orbob.T))
+    z1ao = np.empty((2, nao, nao))
+    z1ao[0] = reduce(np.dot, (orbva, z1a, orboa.T))
+    z1ao[1] = reduce(np.dot, (orbvb, z1b, orbob.T))
+    veff = vresp((z1ao + z1ao.transpose(0, 2, 1)))
 
-    veff = vresp((z1ao+z1ao.transpose(0,2,1))*0.5)
+    im0a = np.zeros((nmoa, nmoa))
+    im0b = np.zeros((nmob, nmob))
+    im0a[:nocca, :nocca] = reduce(np.dot, (orboa.T, veff0doo[0] + veff[0], orboa))
+    im0b[:noccb, :noccb] = reduce(np.dot, (orbob.T, veff0doo[1] + veff[1], orbob))
+    im0a[:nocca, :nocca] += lib.einsum('al,ka->lk', veff0mo[noccb:, :nocca], x)
+    im0b[:noccb, :noccb] += lib.einsum('al,ka->lk', veff0mo.T[nocca:, :noccb], y)
+    im0a[nocca:, nocca:] = lib.einsum('jd,jc->dc', veff0mo[:noccb, nocca:], y)
+    im0b[noccb:, noccb:] = lib.einsum('jd,jc->dc', veff0mo.T[:nocca, noccb:], x)
+    im0a[:nocca, nocca:] = lib.einsum('jk,jc->kc', veff0mo[:noccb, :nocca], y) * 2
+    im0b[:noccb, noccb:] = lib.einsum('jk,jc->kc', veff0mo.T[:nocca, :noccb], x) * 2
 
-    im0a = np.zeros((nmoa,nmoa))
-    im0b = np.zeros((nmob,nmob))
-
-    im0a[:nocca,:nocca] = reduce(np.dot, (orboa.T, veff0doo[0]+veff[0], orboa)) *.5
-    im0b[:noccb,:noccb] = reduce(np.dot, (orbob.T, veff0doo[1]+veff[1], orbob)) *.5
-    im0a[:nocca,:nocca] += np.einsum('aj,ai->ij', veff0mop_ba[noccb:,:nocca], xpy_ba) *0.5
-    im0b[:noccb,:noccb] += np.einsum('aj,ai->ij', veff0mop_ab[nocca:,:noccb], xpy_ab) *0.5
-    im0a[:nocca,:nocca] += np.einsum('aj,ai->ij', veff0mom_ba[noccb:,:nocca], xmy_ba) *0.5
-    im0b[:noccb,:noccb] += np.einsum('aj,ai->ij', veff0mom_ab[nocca:,:noccb], xmy_ab) *0.5
-
-    im0a[nocca:,nocca:]  = np.einsum('bi,ai->ab', veff0mop_ab[nocca:,:noccb], xpy_ab) *0.5
-    im0b[noccb:,noccb:]  = np.einsum('bi,ai->ab', veff0mop_ba[noccb:,:nocca], xpy_ba) *0.5
-    im0a[nocca:,nocca:] += np.einsum('bi,ai->ab', veff0mom_ab[nocca:,:noccb], xmy_ab) *0.5
-    im0b[noccb:,noccb:] += np.einsum('bi,ai->ab', veff0mom_ba[noccb:,:nocca], xmy_ba) *0.5
-
-    im0a[nocca:,:nocca]  = np.einsum('il,al->ai', veff0mop_ab[:nocca,:noccb], xpy_ab)
-    im0b[noccb:,:noccb]  = np.einsum('il,al->ai', veff0mop_ba[:noccb,:nocca], xpy_ba)
-    im0a[nocca:,:nocca] += np.einsum('il,al->ai', veff0mom_ab[:nocca,:noccb], xmy_ab)
-    im0b[noccb:,:noccb] += np.einsum('il,al->ai', veff0mom_ba[:noccb,:nocca], xmy_ba)
-
-    zeta_a = (mo_energy[0][:,None] + mo_energy[0]) * .5
-    zeta_b = (mo_energy[1][:,None] + mo_energy[1]) * .5
-    zeta_a[nocca:,:nocca] = mo_energy[0][:nocca]
-    zeta_b[noccb:,:noccb] = mo_energy[1][:noccb]
-    zeta_a[:nocca,nocca:] = mo_energy[0][nocca:]
-    zeta_b[:noccb,noccb:] = mo_energy[1][noccb:]
-
-    dm1a = np.zeros((nmoa,nmoa))
-    dm1b = np.zeros((nmob,nmob))
-    dm1a[:nocca,:nocca] = doo_a * .5
-    dm1b[:noccb,:noccb] = doo_b * .5
-    dm1a[nocca:,nocca:] = dvv_a * .5
-    dm1b[noccb:,noccb:] = dvv_b * .5
-
-    dm1a[nocca:,:nocca] = z1a *.5
-    dm1b[noccb:,:noccb] = z1b *.5
-
-    dm1a[:nocca,:nocca] += np.eye(nocca) # for ground state
-    dm1b[:noccb,:noccb] += np.eye(noccb)
-
-    im0a = reduce(np.dot, (mo_coeff[0], im0a+zeta_a*dm1a, mo_coeff[0].T))
-    im0b = reduce(np.dot, (mo_coeff[1], im0b+zeta_b*dm1b, mo_coeff[1].T))
+    zeta_a = (mo_energy[0][:, None] + mo_energy[0]) * 0.5
+    zeta_b = (mo_energy[1][:, None] + mo_energy[1]) * 0.5
+    zeta_a[nocca:, :nocca] = mo_energy[0][:nocca]
+    zeta_b[noccb:, :noccb] = mo_energy[1][:noccb]
+    zeta_a[:nocca, nocca:] = mo_energy[0][nocca:]
+    zeta_b[:noccb, noccb:] = mo_energy[1][noccb:]
+    dm1a = np.zeros((nmoa, nmoa))
+    dm1b = np.zeros((nmob, nmob))
+    dm1a[:nocca, :nocca] = dooa
+    dm1b[:noccb, :noccb] = doob
+    dm1a[nocca:, nocca:] = dvva
+    dm1b[noccb:, noccb:] = dvvb
+    dm1a[nocca:, :nocca] = z1a * 2
+    dm1b[noccb:, :noccb] = z1b * 2
+    dm1a[:nocca, :nocca] += np.eye(nocca)  # for ground state
+    dm1b[:noccb, :noccb] += np.eye(noccb)
+    im0a = reduce(np.dot, (mo_coeff[0], im0a + zeta_a * dm1a, mo_coeff[0].T))
+    im0b = reduce(np.dot, (mo_coeff[1], im0b + zeta_b * dm1b, mo_coeff[1].T))
     im0 = im0a + im0b
 
-    # Initialize hcore_deriv with the underlying SCF object because some
-    # extensions (e.g. QM/MM, solvent) modifies the SCF object only.
-    mf_grad = mf.nuc_grad_method()
+    mf_grad = td_grad.base._scf.nuc_grad_method()
     hcore_deriv = mf_grad.hcore_generator(mol)
-
-    # -mol.intor('int1e_ipovlp', comp=3)
     s1 = mf_grad.get_ovlp(mol)
 
-    dmz1doo_a = z1ao[0] + dmzoo_a
-    dmz1doo_b = z1ao[1] + dmzoo_b
+    dmz1dooa = 4 * z1ao[0] + 2 * dmzooa
+    dmz1doob = 4 * z1ao[1] + 2 * dmzoob
     oo0a = reduce(np.dot, (orboa, orboa.T))
     oo0b = reduce(np.dot, (orbob, orbob.T))
+    as_dm1 = oo0a + oo0b + (dmz1dooa + dmz1doob) * 0.5
 
-    as_dm1 = oo0a + oo0b + (dmz1doo_a + dmz1doo_b) * .5
-
-    if abs(hyb) > 1e-10:
-        dm = (oo0a, dmz1doo_a+dmz1doo_a.T, dmxpy_ba+dmxpy_ab.T, dmxmy_ba-dmxmy_ab.T,
-              oo0b, dmz1doo_b+dmz1doo_b.T, dmxpy_ab+dmxpy_ba.T, dmxmy_ab-dmxmy_ba.T)
-        vj, vk = td_grad.get_jk(mol, dm)
-        vj = vj.reshape(2,4,3,nao,nao)
-        vk = vk.reshape(2,4,3,nao,nao) * hyb
-        vj[:,2:4] *= 0.0
-        if abs(omega) > 1e-10:
-            with mol.with_range_coulomb(omega):
-                vk += td_grad.get_k(mol, dm).reshape(2,4,3,nao,nao) * (alpha-hyb)
-
-        veff1 = np.zeros((2,4,3,nao,nao))
-        veff1[:,:2] = vj[0,:2] + vj[1,:2] - vk[:,:2]
+    if with_k:
+        dm = (oo0a, dmz1dooa + dmz1dooa.T, oo0b, dmz1doob + dmz1doob.T)
+        vj, vk = td_grad.get_jk(mol, dm, hermi=1)
+        vj = vj.reshape(2, 2, 3, nao, nao)
+        vk = vk.reshape(2, 2, 3, nao, nao) * hyb
+        vk1 = -td_grad.get_k(mol, (dmt, dmt.T)) * hyb
+        if omega != 0:
+            vk += td_grad.get_k(mol, dm, omega=omega).reshape(2, 2, 3, nao, nao) * (alpha - hyb)
+            vk1 += -td_grad.get_k(mol, (dmt, dmt.T), omega=omega) * (alpha - hyb)
+        veff1 = vj[0] + vj[1] - vk
     else:
-        dm = (oo0a, dmz1doo_a+dmz1doo_a.T, dmxpy_ba+dmxpy_ab.T,
-              oo0b, dmz1doo_b+dmz1doo_b.T, dmxpy_ab+dmxpy_ba.T)
-        vj = td_grad.get_j(mol, dm).reshape(2,3,3,nao,nao)
-        vj[:,2] *= 0.0
-        veff1 = np.zeros((2,4,3,nao,nao))
-        veff1[:,:3] = vj[0] + vj[1]
+        dm = (oo0a, dmz1dooa + dmz1dooa.T, oo0b, dmz1doob + dmz1doob.T)
+        vj = td_grad.get_j(mol, dm, hermi=1).reshape(2, 2, 3, nao, nao)
+        veff1 = vj[0] + vj[1]
+        veff1 = np.stack((veff1, veff1))
 
-    fxcz1 = _contract_xc_kernel_z(td_grad, mf.xc, z1ao, max_memory)
-
-    veff1[:,0] += vxc1[:,1:]
-    veff1[:,1] += (f1oo[:,1:] + fxcz1[:,1:])*2
-    veff1[0,1] += (k1ao_xpy[0,0,1:] + k1ao_xpy[0,1,1:] + k1ao_xpy[1,0,1:] + k1ao_xpy[1,1,1:]
-                  +k1ao_xmy[0,0,1:] + k1ao_xmy[0,1,1:] + k1ao_xmy[1,0,1:] + k1ao_xmy[1,1,1:])*2
-    veff1[1,1] += (k1ao_xpy[0,0,1:] + k1ao_xpy[0,1,1:] - k1ao_xpy[1,0,1:] - k1ao_xpy[1,1,1:]
-                  +k1ao_xmy[0,0,1:] + k1ao_xmy[0,1,1:] - k1ao_xmy[1,0,1:] - k1ao_xmy[1,1,1:])*2
-
-    veff1[:,2] += f1vo[0,:,1:]
-    veff1[:,3] += f1vo[1,:,1:]
+    fxcz1 = tduks_grad._contract_xc_kernel(td_grad, mf.xc, 2 * z1ao, None, False, False, max_memory)[0]
+    veff1[:, 0] += vxc1[:, 1:]
+    veff1[:, 1] += (f1oo[:, 1:] + fxcz1[:, 1:] + k1ao[:, 1:]) * 4
     veff1a, veff1b = veff1
     time1 = log.timer('2e AO integral derivatives', *time1)
 
     if atmlst is None:
         atmlst = range(mol.natm)
     offsetdic = mol.offset_nr_by_atom()
-    de = np.zeros((len(atmlst),3))
+    de = np.zeros((len(atmlst), 3))
 
     for k, ia in enumerate(atmlst):
         shl0, shl1, p0, p1 = offsetdic[ia]
 
         # Ground state gradients
         h1ao = hcore_deriv(ia)
-        de[k] = np.einsum('xpq,pq->x', h1ao, as_dm1)
-        de[k] += np.einsum('xpq,pq->x', veff1a[0,:,p0:p1], oo0a[p0:p1])
-        de[k] += np.einsum('xpq,pq->x', veff1b[0,:,p0:p1], oo0b[p0:p1])
-        de[k] += np.einsum('xpq,qp->x', veff1a[0,:,p0:p1], oo0a[:,p0:p1])
-        de[k] += np.einsum('xpq,qp->x', veff1b[0,:,p0:p1], oo0b[:,p0:p1])
+        de[k] = lib.einsum('xpq,pq->x', h1ao, as_dm1)
+        de[k] += lib.einsum('xpq,pq->x', veff1a[0, :, p0:p1], oo0a[p0:p1]) * 2
+        de[k] += lib.einsum('xpq,pq->x', veff1b[0, :, p0:p1], oo0b[p0:p1]) * 2
 
-        de[k] += np.einsum('xpq,pq->x', veff1a[0,:,p0:p1], dmz1doo_a[p0:p1]) *.5
-        de[k] += np.einsum('xpq,pq->x', veff1b[0,:,p0:p1], dmz1doo_b[p0:p1]) *.5
-        de[k] += np.einsum('xpq,qp->x', veff1a[0,:,p0:p1], dmz1doo_a[:,p0:p1]) *.5
-        de[k] += np.einsum('xpq,qp->x', veff1b[0,:,p0:p1], dmz1doo_b[:,p0:p1]) *.5
+        # Excitation energy gradients
+        de[k] -= lib.einsum('xpq,pq->x', s1[:, p0:p1], im0[p0:p1])
+        de[k] -= lib.einsum('xqp,pq->x', s1[:, p0:p1], im0[:, p0:p1])
 
-        de[k] -= np.einsum('xpq,pq->x', s1[:,p0:p1], im0[p0:p1])
-        de[k] -= np.einsum('xqp,pq->x', s1[:,p0:p1], im0[:,p0:p1])
+        de[k] += lib.einsum('xpq,pq->x', veff1a[0, :, p0:p1], dmz1dooa[p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,pq->x', veff1b[0, :, p0:p1], dmz1doob[p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,qp->x', veff1a[0, :, p0:p1], dmz1dooa[:, p0:p1]) * 0.5
+        de[k] += lib.einsum('xpq,qp->x', veff1b[0, :, p0:p1], dmz1doob[:, p0:p1]) * 0.5
+        de[k] += lib.einsum('xij,ij->x', veff1a[1, :, p0:p1], oo0a[p0:p1]) * 0.5
+        de[k] += lib.einsum('xij,ij->x', veff1b[1, :, p0:p1], oo0b[p0:p1]) * 0.5
 
-        de[k] += np.einsum('xij,ij->x', veff1a[1,:,p0:p1], oo0a[p0:p1]) *0.5
-        de[k] += np.einsum('xij,ij->x', veff1b[1,:,p0:p1], oo0b[p0:p1]) *0.5
+        if td_grad.base.collinear_samples > 0:
+            de[k] += lib.einsum('xpq,pq->x', f1vo[1:, p0:p1], dmt[p0:p1]) * 2
+            de[k] += lib.einsum('xpq,pq->x', f1vo[1:, p0:p1], dmt.T[p0:p1]) * 2
 
-        de[k] += np.einsum('xij,ij->x', veff1b[2,:,p0:p1], dmxpy_ab[p0:p1,:])
-        de[k] += np.einsum('xij,ij->x', veff1a[2,:,p0:p1], dmxpy_ba[p0:p1,:])
-        de[k] += np.einsum('xji,ij->x', veff1b[2,:,p0:p1], dmxpy_ab[:,p0:p1])
-        de[k] += np.einsum('xji,ij->x', veff1a[2,:,p0:p1], dmxpy_ba[:,p0:p1])
+        if with_k:
+            de[k] += lib.einsum('xpq,pq->x', vk1[0, :, p0:p1], dmt[p0:p1]) * 2
+            de[k] += lib.einsum('xpq,pq->x', vk1[1, :, p0:p1], dmt.T[p0:p1]) * 2
 
-        de[k] += np.einsum('xij,ij->x', veff1b[3,:,p0:p1], dmxmy_ab[p0:p1,:])
-        de[k] += np.einsum('xij,ij->x', veff1a[3,:,p0:p1], dmxmy_ba[p0:p1,:])
-        de[k] += np.einsum('xji,ij->x', veff1b[3,:,p0:p1], dmxmy_ab[:,p0:p1])
-        de[k] += np.einsum('xji,ij->x', veff1a[3,:,p0:p1], dmxmy_ba[:,p0:p1])
+        de[k] += td_grad.extra_force(ia, locals())
 
-        if abs(hyb) > 1e-10:
-            de[k] -= np.einsum('xij,ij->x', vk[1,2,:,p0:p1], dmxpy_ab[p0:p1,:])
-            de[k] -= np.einsum('xij,ij->x', vk[0,2,:,p0:p1], dmxpy_ba[p0:p1,:])
-            de[k] -= np.einsum('xji,ij->x', vk[0,2,:,p0:p1], dmxpy_ab[:,p0:p1])
-            de[k] -= np.einsum('xji,ij->x', vk[1,2,:,p0:p1], dmxpy_ba[:,p0:p1])
-
-            de[k] -= np.einsum('xij,ij->x', vk[1,3,:,p0:p1], dmxmy_ab[p0:p1,:])
-            de[k] -= np.einsum('xij,ij->x', vk[0,3,:,p0:p1], dmxmy_ba[p0:p1,:])
-            de[k] += np.einsum('xji,ij->x', vk[0,3,:,p0:p1], dmxmy_ab[:,p0:p1])
-            de[k] += np.einsum('xji,ij->x', vk[1,3,:,p0:p1], dmxmy_ba[:,p0:p1])
-
-        # de[k] += td_grad.extra_force(ia, locals())
     log.timer('TDUKS nuclear gradients', *time0)
     return de
 
-def _contract_xc_kernel(td_grad, xc_code, dmvo, dmoo=None, with_vxc=True,
-                        with_kxc=True, max_memory=2000):
+
+def _contract_xc_kernel(td_grad, xc_code, dmvo, dmoo=None, with_vxc=True, with_kxc=True, max_memory=2000):
     mol = td_grad.mol
     mf = td_grad.base._scf
     grids = mf.grids
@@ -367,467 +263,111 @@ def _contract_xc_kernel(td_grad, xc_code, dmvo, dmoo=None, with_vxc=True,
     mo_coeff = mf.mo_coeff
     mo_occ = mf.mo_occ
     nao = mo_coeff[0].shape[0]
-
     shls_slice = (0, mol.nbas)
     ao_loc = mol.ao_loc_nr()
 
-    f1vo = np.zeros((2,2,4,nao,nao))
-    deriv = 2
+    dmvo = (dmvo + dmvo.T) * 0.5
 
+    f1vo = np.zeros((4, nao, nao))
+    deriv = 2
     if dmoo is not None:
-        f1oo = np.zeros((2,4,nao,nao))
+        f1oo = np.zeros((2, 4, nao, nao))
     else:
         f1oo = None
     if with_vxc:
-        v1ao = np.zeros((2,4,nao,nao))
+        v1ao = np.zeros((2, 4, nao, nao))
     else:
         v1ao = None
     if with_kxc:
-        k1ao_xpy = np.zeros((2,2,4,nao,nao))
-        k1ao_xmy = np.zeros((2,2,4,nao,nao))
+        k1ao = np.zeros((2, 4, nao, nao))
         deriv = 3
     else:
-        k1ao_xpy = k1ao_xmy = None
+        k1ao = None
 
-    # create a mc object to use mcfun.
-    nimc = numint2c.NumInt2C()
-    nimc.collinear = 'mcol'
-    nimc.collinear_samples=td_grad.base.collinear_samples
+    if td_grad.base.collinear_samples > 0:
+        # create a mc object to use mcfun.
+        nimc = numint2c.NumInt2C()
+        nimc.collinear = 'mcol'
+        nimc.collinear_samples = td_grad.base.collinear_samples
+        eval_xc_eff = mcfun_eval_xc_adapter_sf(nimc, xc_code)
 
-    # calculate the derivatives.
-    if nimc.collinear_samples > 0:
-        fxc_sf,kxc_sf = cache_xc_kernel_sf(nimc,mol,mf.grids,mf.xc,mo_coeff,mo_occ,deriv=3,spin=1)[2:]
-    p0,p1=0,0 # the two parameters are used for counts the batch of grids.
-
-    if xctype == 'LDA':
-        def lda_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[0], wv)
-            for k in range(4):
-                vmat[k] += numint._dot_ao_ao(mol, ao[k], aow, mask, shls_slice, ao_loc)
-
-        ao_deriv = 1
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            p0 = p1
-            p1+= weight.shape[0]
-
-            if nimc.collinear_samples > 0:
-                s_s = fxc_sf[...,p0:p1] * weight
-
-                rho1_ab = ni.eval_rho(mol, ao[0], dmvo[0][0], mask, xctype)
-                rho1_ba = ni.eval_rho(mol, ao[0], dmvo[0][1], mask, xctype)
-                # s_s*2 because of \sigma_x \sigma_x + \sigma_y \sigma_y
-                lda_sum_(f1vo[0][1], ao, (rho1_ab+rho1_ba)*s_s*2, mask)
-                lda_sum_(f1vo[0][0], ao, (rho1_ba+rho1_ab)*s_s*2, mask)
-
-                if with_kxc:
-                    s_s_n = kxc_sf[:,:,0][...,p0:p1] * weight
-                    s_s_s = kxc_sf[:,:,1][...,p0:p1] * weight
-                    lda_sum_(k1ao_xpy[0][0], ao, s_s_n*2*rho1_ab*(rho1_ab+rho1_ba), mask)
-                    lda_sum_(k1ao_xpy[0][1], ao, s_s_n*2*rho1_ba*(rho1_ba+rho1_ab), mask)
-                    lda_sum_(k1ao_xpy[1][0], ao, s_s_s*2*rho1_ab*(rho1_ab+rho1_ba), mask)
-                    lda_sum_(k1ao_xpy[1][1], ao, s_s_s*2*rho1_ba*(rho1_ba+rho1_ab), mask)
-
-                rho1_ab = ni.eval_rho(mol, ao[0], dmvo[1][0], mask, xctype)
-                rho1_ba = ni.eval_rho(mol, ao[0], dmvo[1][1], mask, xctype)
-
-                # py attention to the order of f1vo[1][1] and f1vo[1][0]
-                lda_sum_(f1vo[1][1], ao, (rho1_ab-rho1_ba)*s_s*2, mask)
-                lda_sum_(f1vo[1][0], ao, (rho1_ba-rho1_ab)*s_s*2, mask)
-
-                if with_kxc:
-                    # Note the "-"
-                    lda_sum_(k1ao_xmy[0][0], ao, s_s_n*2*rho1_ab*(rho1_ab-rho1_ba), mask)
-                    lda_sum_(k1ao_xmy[0][1], ao, s_s_n*2*rho1_ba*(rho1_ba-rho1_ab), mask)
-                    lda_sum_(k1ao_xmy[1][0], ao, s_s_s*2*rho1_ab*(rho1_ab-rho1_ba), mask)
-                    lda_sum_(k1ao_xmy[1][1], ao, s_s_s*2*rho1_ba*(rho1_ba-rho1_ab), mask)
-
-            rho = (ni.eval_rho2(mol, ao[0], mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao[0], mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc, kxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:]
-            u_u, u_d, d_d = fxc[0].T * weight
-            if dmoo is not None:
-                rho2a = ni.eval_rho(mol, ao[0], dmoo[0], mask, xctype, hermi=1)
-                rho2b = ni.eval_rho(mol, ao[0], dmoo[1], mask, xctype, hermi=1)
-                lda_sum_(f1oo[0], ao, u_u*rho2a+u_d*rho2b, mask)
-                lda_sum_(f1oo[1], ao, u_d*rho2a+d_d*rho2b, mask)
-            if with_vxc:
-                vrho = vxc[0].T * weight
-                lda_sum_(v1ao[0], ao, vrho[0], mask)
-                lda_sum_(v1ao[1], ao, vrho[1], mask)
-
+    if xctype == 'HF':
+        return f1vo, f1oo, v1ao, k1ao
+    elif xctype == 'LDA':
+        fmat_, ao_deriv = tdrks_grad._lda_eval_mat_, 1
     elif xctype == 'GGA':
-        def gga_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[:4], wv[:4])
-            tmp = numint._dot_ao_ao(mol, ao[0], aow, mask, shls_slice, ao_loc)
-            vmat[0] += tmp + tmp.T
-            rks_grad._gga_grad_sum_(vmat[1:], mol, ao, wv, mask, ao_loc)
-
-        ao_deriv = 2
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            p0 = p1
-            p1+= weight.shape[0]
-
-            if nimc.collinear_samples > 0:
-                rho1_ab = ni.eval_rho(mol, ao, dmvo[0][0], mask, xctype)
-                rho1_ba = ni.eval_rho(mol, ao, dmvo[0][1], mask, xctype)
-
-                wv_sf = uks_sf_gga_wv1((rho1_ab,rho1_ba),fxc_sf[...,p0:p1],weight)
-                gga_sum_(f1vo[0][1], ao, wv_sf[0]+wv_sf[1], mask)
-                gga_sum_(f1vo[0][0], ao, wv_sf[1]+wv_sf[0], mask)
-
-                if with_kxc:
-                    gv_sf = uks_sf_gga_wv2_p((rho1_ab,rho1_ba),kxc_sf[...,p0:p1],weight)
-                    gga_sum_(k1ao_xpy[0][0], ao, gv_sf[0][0], mask)
-                    gga_sum_(k1ao_xpy[0][1], ao, gv_sf[1][0], mask)
-                    gga_sum_(k1ao_xpy[1][0], ao, gv_sf[0][1], mask)
-                    gga_sum_(k1ao_xpy[1][1], ao, gv_sf[1][1], mask)
-
-                rho1_ab = ni.eval_rho(mol, ao, dmvo[1][0], mask, xctype)
-                rho1_ba = ni.eval_rho(mol, ao, dmvo[1][1], mask, xctype)
-
-                wv_sf = uks_sf_gga_wv1((rho1_ab,rho1_ba),fxc_sf[...,p0:p1],weight)
-                gga_sum_(f1vo[1][1], ao, wv_sf[0]-wv_sf[1], mask)
-                gga_sum_(f1vo[1][0], ao, wv_sf[1]-wv_sf[0], mask)
-
-                if with_kxc:
-                    gv_sf = uks_sf_gga_wv2_m((rho1_ab,rho1_ba),kxc_sf[...,p0:p1],weight)
-                    gga_sum_(k1ao_xmy[0][0], ao, gv_sf[0][0], mask)
-                    gga_sum_(k1ao_xmy[0][1], ao, gv_sf[1][0], mask)
-                    gga_sum_(k1ao_xmy[1][0], ao, gv_sf[0][1], mask)
-                    gga_sum_(k1ao_xmy[1][1], ao, gv_sf[1][1], mask)
-
-            rho = (ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc, kxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:]
-
-            if dmoo is not None:
-                rho2 = (ni.eval_rho(mol, ao, dmoo[0], mask, xctype, hermi=1),
-                        ni.eval_rho(mol, ao, dmoo[1], mask, xctype, hermi=1))
-                wv = numint._uks_gga_wv1(rho, rho2, vxc, fxc, weight)
-                gga_sum_(f1oo[0], ao, wv[0], mask)
-                gga_sum_(f1oo[1], ao, wv[1], mask)
-            if with_vxc:
-                wv = numint._uks_gga_wv0(rho, vxc, weight)
-                gga_sum_(v1ao[0], ao, wv[0], mask)
-                gga_sum_(v1ao[1], ao, wv[1], mask)
-
+        fmat_, ao_deriv = tdrks_grad._gga_eval_mat_, 2
     elif xctype == 'MGGA':
-        def mgga_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[:4], wv[:4])
-            tmp = numint._dot_ao_ao(mol, ao[0], aow, mask, shls_slice, ao_loc)
-
-            aow = numint._scale_ao(ao[1], wv[4], aow)
-            tmp += numint._dot_ao_ao(mol, ao[1], aow, mask, shls_slice, ao_loc)
-            aow = numint._scale_ao(ao[2], wv[4], aow)
-            tmp += numint._dot_ao_ao(mol, ao[2], aow, mask, shls_slice, ao_loc)
-            aow = numint._scale_ao(ao[3], wv[4], aow)
-            tmp += numint._dot_ao_ao(mol, ao[3], aow, mask, shls_slice, ao_loc)
-            vmat[0] += tmp + tmp.T
-
-            rks_grad._gga_grad_sum_(vmat[1:], mol, ao, wv[:4], mask, ao_loc)
-            rks_grad._tau_grad_dot_(vmat[1:], mol, ao, wv[4]*2, mask, ao_loc, True)
-
-        ao_deriv = 2
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            p0 = p1
-            p1+= weight.shape[0]
-            ngrid=weight.shape[-1]
-
-            if nimc.collinear_samples > 0:
-                rho1_ab_tmp = ni.eval_rho(mol, ao, dmvo[0][0], mask, xctype)
-                rho1_ba_tmp = ni.eval_rho(mol, ao, dmvo[0][1], mask, xctype)
-                # Padding for laplacian
-                rho1_ab = np.empty((5, ngrid))
-                rho1_ba = np.empty((5, ngrid))
-                rho1_ab[:4] = rho1_ab_tmp[:4]
-                rho1_ba[:4] = rho1_ba_tmp[:4]
-                rho1_ab[4] = rho1_ab_tmp[5]
-                rho1_ba[4] = rho1_ba_tmp[5]
-
-                wv_sf = uks_sf_mgga_wv1((rho1_ab,rho1_ba), fxc_sf[...,p0:p1],weight)
-                mgga_sum_(f1vo[0][1], ao, wv_sf[0]+wv_sf[1], mask)
-                mgga_sum_(f1vo[0][0], ao, wv_sf[1]+wv_sf[0], mask)
-
-                if with_kxc:
-                    gv_sf = uks_sf_mgga_wv2_p((rho1_ab,rho1_ba), kxc_sf[...,p0:p1], weight)
-                    mgga_sum_(k1ao_xpy[0][0], ao, gv_sf[0][0], mask)
-                    mgga_sum_(k1ao_xpy[0][1], ao, gv_sf[1][0], mask)
-                    mgga_sum_(k1ao_xpy[1][0], ao, gv_sf[0][1], mask)
-                    mgga_sum_(k1ao_xpy[1][1], ao, gv_sf[1][1], mask)
-
-                rho1_ab_tmp = ni.eval_rho(mol, ao, dmvo[1][0], mask, xctype)
-                rho1_ba_tmp = ni.eval_rho(mol, ao, dmvo[1][1], mask, xctype)
-                # Padding for laplacian
-                rho1_ab = np.empty((5, ngrid))
-                rho1_ba = np.empty((5, ngrid))
-                rho1_ab[:4] = rho1_ab_tmp[:4]
-                rho1_ba[:4] = rho1_ba_tmp[:4]
-                rho1_ab[4] = rho1_ab_tmp[5]
-                rho1_ba[4] = rho1_ba_tmp[5]
-
-                wv_sf = uks_sf_mgga_wv1((rho1_ab,rho1_ba), fxc_sf[...,p0:p1],weight)
-                mgga_sum_(f1vo[1][1], ao, wv_sf[0]-wv_sf[1], mask)
-                mgga_sum_(f1vo[1][0], ao, wv_sf[1]-wv_sf[0], mask)
-
-                if with_kxc:
-                    gv_sf = uks_sf_mgga_wv2_m((rho1_ab,rho1_ba), kxc_sf[...,p0:p1], weight)
-                    mgga_sum_(k1ao_xmy[0][0], ao, gv_sf[0][0], mask)
-                    mgga_sum_(k1ao_xmy[0][1], ao, gv_sf[1][0], mask)
-                    mgga_sum_(k1ao_xmy[1][0], ao, gv_sf[0][1], mask)
-                    mgga_sum_(k1ao_xmy[1][1], ao, gv_sf[1][1], mask)
-
-            rho = (ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc, kxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:]
-
-            if dmoo is not None:
-                rho2 = (ni.eval_rho(mol, ao, dmoo[0], mask, xctype, hermi=1),
-                        ni.eval_rho(mol, ao, dmoo[1], mask, xctype, hermi=1))
-                wv_tmp = numint._uks_mgga_wv1(rho, rho2, vxc, fxc, weight)
-                # # Padding for laplacian
-                wv = np.empty((2,5,ngrid))
-                wv[0][:4] = wv_tmp[0][:4]
-                wv[0][4]  = wv_tmp[0][5]
-                wv[1][:4] = wv_tmp[1][:4]
-                wv[1][4]  = wv_tmp[1][5]
-
-                mgga_sum_(f1oo[0], ao, wv[0], mask)
-                mgga_sum_(f1oo[1], ao, wv[1], mask)
-
-            if with_vxc:
-                wv_tmp = numint._uks_mgga_wv0(rho, vxc, weight)
-                # # Padding for laplacian
-                wv = np.empty((2,5,ngrid))
-                wv[0][:4] = wv_tmp[0][:4]
-                wv[0][4]  = wv_tmp[0][5]
-                wv[1][:4] = wv_tmp[1][:4]
-                wv[1][4]  = wv_tmp[1][5]
-
-                mgga_sum_(v1ao[0], ao, wv[0], mask)
-                mgga_sum_(v1ao[1], ao, wv[1], mask)
-
-    elif xctype == 'HF':
-        pass
-
+        fmat_, ao_deriv = tdrks_grad._mgga_eval_mat_, 2
+        logger.warn(td_grad, 'TDUKS-MGGA Gradients may be inaccurate due to grids response')
     else:
         raise NotImplementedError(f'td-uks for functional {xc_code}')
 
-    f1vo[:,:,1:] *= -1
-    if f1oo is not None: f1oo[:,1:] *= -1
-    if v1ao is not None: v1ao[:,1:] *= -1
-    if with_kxc:
-        k1ao_xpy[:,:,1:] *= -1
-        k1ao_xmy[:,:,1:] *= -1
-    return f1vo, f1oo, v1ao, (k1ao_xpy,k1ao_xmy)
+    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+        if xctype == 'LDA':
+            ao0 = ao[0]
+        else:
+            ao0 = ao
+        rho = (
+            ni.eval_rho2(mol, ao0, mo_coeff[0], mo_occ[0], mask, xctype, with_lapl=False),
+            ni.eval_rho2(mol, ao0, mo_coeff[1], mo_occ[1], mask, xctype, with_lapl=False),
+        )
+        if td_grad.base.collinear_samples > 0:
+            rho_z = np.array([rho[0] + rho[1], rho[0] - rho[1]])
+            fxc_sf, kxc_sf = eval_xc_eff(xc_code, rho_z, deriv, xctype=xctype)[2:4]
+            kxc_sf = np.stack((kxc_sf[:, :, 0] + kxc_sf[:, :, 1], kxc_sf[:, :, 0] - kxc_sf[:, :, 1]), axis=2)
+            rho1 = ni.eval_rho(mol, ao0, dmvo, mask, xctype, hermi=1, with_lapl=False)
+            if xctype == 'LDA':
+                rho1 = rho1[np.newaxis]
+            wv = lib.einsum('yg,xyg,g->xg', rho1, 2 * fxc_sf, weight)  # 2 for f_xx + f_yy
+            fmat_(mol, f1vo, ao, wv, mask, shls_slice, ao_loc)
 
-def uks_sf_gga_wv1(rho1, fxc_sf,weight):
-    # fxc_sf with a shape (4,4,ngrid), 4 means I, \nabla_x,y,z.
-    rho1_ab,rho1_ba = rho1
-    ngrid = weight.shape[-1]
-    wv_ab, wv_ba = np.empty((2,4,ngrid))
-    wv_ab = np.einsum('yp,xyp->xp',  rho1_ab,fxc_sf)
-    wv_ba = np.einsum('yp,xyp->xp',  rho1_ba,fxc_sf)
-    # wv_ab[0] = wv_ab[0] *2 *.5 # *2 bacause of kernel, *0.5 for the (x + x.T)*0.5
-    # wv_ba[0] = wv_ba[0] *2 *.5
+            if with_kxc:
+                wv = lib.einsum('xg,yg,xyczg,g->czg', rho1, rho1, 2 * kxc_sf, weight)
+                fmat_(mol, k1ao[0], ao, wv[0], mask, shls_slice, ao_loc)
+                fmat_(mol, k1ao[1], ao, wv[1], mask, shls_slice, ao_loc)
 
-    # Don't forget (sigma_x sigma_x + sigma_y sigma_y) needs *2 for kernel term.
-    wv_ab[1:] *=2.0
-    wv_ba[1:] *=2.0
-    return wv_ab*weight, wv_ba*weight
+        if dmoo is not None or with_vxc:
+            vxc, fxc, kxc = ni.eval_xc_eff(xc_code, rho, deriv=2, spin=1)[1:]
 
-def uks_sf_gga_wv2_p(rho1, kxc_sf,weight):
-    # kxc_sf with a shape (4,4,2,4,ngrid), 4 means I,\nabla_x,y,z,
-    # 0: n, \nabla_x,y,z n;  1: s, \nabla_x,y,z s.
-    rho1_ab,rho1_ba = rho1
-    ngrid = weight.shape[-1]
-    gv_ab, gv_ba = np.empty((2,2,4,ngrid))
-    # Note *2 and *0.5 like in function uks_sf_gga_wv1
-    gv_ab = np.einsum('xp,yp,xyvzp->vzp', rho1_ab, rho1_ab+rho1_ba, kxc_sf, optimize=True)
-    gv_ba = np.einsum('xp,yp,xyvzp->vzp', rho1_ba, rho1_ba+rho1_ab, kxc_sf, optimize=True)
+        if dmoo is not None:
+            rho2 = np.asarray(
+                (
+                    ni.eval_rho(mol, ao0, dmoo[0], mask, xctype, hermi=1, with_lapl=False),
+                    ni.eval_rho(mol, ao0, dmoo[1], mask, xctype, hermi=1, with_lapl=False),
+                )
+            )
+            if xctype == 'LDA':
+                rho2 = rho2[:, np.newaxis]
+            wv = lib.einsum('axg,axbyg,g->byg', rho2, fxc, weight)
+            fmat_(mol, f1oo[0], ao, wv[0], mask, shls_slice, ao_loc)
+            fmat_(mol, f1oo[1], ao, wv[1], mask, shls_slice, ao_loc)
 
-    gv_ab[0,1:] *=2.0
-    gv_ab[1,1:] *=2.0
-    gv_ba[0,1:] *=2.0
-    gv_ba[1,1:] *=2.0
-    return gv_ab*weight, gv_ba*weight
+        if with_vxc:
+            wv = vxc * weight
+            fmat_(mol, v1ao[0], ao, wv[0], mask, shls_slice, ao_loc)
+            fmat_(mol, v1ao[1], ao, wv[1], mask, shls_slice, ao_loc)
 
-def uks_sf_gga_wv2_m(rho1, kxc_sf,weight):
-    rho1_ab,rho1_ba = rho1
-    ngrid = weight.shape[-1]
-    gv_ab, gv_ba = np.empty((2,2,5,ngrid))
-    # Note *2 and *0.5 like in function uks_sf_mgga_wv1
-    gv_ab = np.einsum('xp,yp,xyvzp->vzp', rho1_ab, rho1_ab-rho1_ba, kxc_sf , optimize=True)
-    gv_ba = np.einsum('xp,yp,xyvzp->vzp', rho1_ba, rho1_ba-rho1_ab, kxc_sf , optimize=True)
+    f1vo[1:] *= -1
+    if f1oo is not None:
+        f1oo[:, 1:] *= -1
+    if v1ao is not None:
+        v1ao[:, 1:] *= -1
+    if k1ao is not None:
+        k1ao[:, 1:] *= -1
+    return f1vo, f1oo, v1ao, k1ao
 
-    gv_ab[:,1:] *=2.0
-    gv_ba[:,1:] *=2.0
-    return gv_ab*weight, gv_ba*weight
-
-def uks_sf_mgga_wv1(rho1, fxc_sf,weight):
-    rho1_ab,rho1_ba = rho1
-    # fxc_sf with a shape (5,5,ngrid), 5 means I, \nabla_x,y,z s, u
-    # s_s, s_Ns, Ns_s, Ns_Ns, s_u, u_s, u_Ns, Ns_u, u_u
-    ngrid = weight.shape[-1]
-    wv_ab, wv_ba = np.empty((2,5,ngrid))
-    wv_ab = np.einsum('yp,xyp->xp',  rho1_ab,fxc_sf)
-    wv_ba = np.einsum('yp,xyp->xp',  rho1_ba,fxc_sf)
-    # wv_ab[0] = wv_ab[0] *2 *.5 # *2 bacause of kernel, *0.5 for the (x + x.T)*0.5
-    # wv_ba[0] = wv_ba[0] *2 *.5
-
-    # Don't forget (sigma_x sigma_x + sigma_y sigma_y) needs *2 for kernel term.
-    wv_ab[1:4] *=2.0
-    wv_ba[1:4] *=2.0
-    # *0.5 below is for tau->ao
-    wv_ab[4] *= 0.5
-    wv_ba[4] *= 0.5
-    return wv_ab*weight, wv_ba*weight
-
-def uks_sf_mgga_wv2_p(rho1, kxc_sf,weight):
-    rho1_ab,rho1_ba = rho1
-    # kxc_sf with a shape (5,5,2,5,ngrid), 5 means s \nabla_x,y,z s, u
-    # s_s    ->  0: n, \nabla_x,y,z n, tau ;  1: s, \nabla_x,y,z s, u
-    # s_Ns   ->
-    # Ns_s   ->
-    # Ns_Ns  ->
-    # s_u    ->
-    # u_s    ->
-    # u_Ns   ->
-    # Ns_u   ->
-    # u_u    ->
-    ngrid = weight.shape[-1]
-    gv_ab, gv_ba = np.empty((2,2,5,ngrid))
-    # Note *2 and *0.5 like in function uks_sf_mgga_wv1
-    gv_ab = np.einsum('xp,yp,xyvzp->vzp', rho1_ab, rho1_ab+rho1_ba, kxc_sf, optimize=True)
-    gv_ba = np.einsum('xp,yp,xyvzp->vzp', rho1_ba, rho1_ba+rho1_ab, kxc_sf, optimize=True)
-
-    gv_ab[:,1:4] *=2.0
-    gv_ba[:,1:4] *=2.0
-    gv_ab[:,4] *= 0.5
-    gv_ba[:,4] *= 0.5
-    return gv_ab*weight, gv_ba*weight
-
-def uks_sf_mgga_wv2_m(rho1, kxc_sf,weight):
-    rho1_ab,rho1_ba = rho1
-    ngrid = weight.shape[-1]
-    gv_ab, gv_ba = np.empty((2,2,5,ngrid))
-    # Note *2 and *0.5 like in function uks_sf_mgga_wv1
-    gv_ab = np.einsum('xp,yp,xyvzp->vzp', rho1_ab, rho1_ab-rho1_ba, kxc_sf , optimize=True)
-    gv_ba = np.einsum('xp,yp,xyvzp->vzp', rho1_ba, rho1_ba-rho1_ab, kxc_sf , optimize=True)
-
-    gv_ab[:,1:4] *=2.0
-    gv_ba[:,1:4] *=2.0
-    gv_ab[:,4] *= 0.5
-    gv_ba[:,4] *= 0.5
-    return gv_ab*weight, gv_ba*weight
-
-def _contract_xc_kernel_z(td_grad, xc_code, dmvo, max_memory=2000):
-    mol = td_grad.base._scf.mol
-    mf = td_grad.base._scf
-    grids = mf.grids
-
-    ni = mf._numint
-    xctype = ni._xc_type(xc_code)
-
-    mo_coeff = mf.mo_coeff
-    mo_occ = mf.mo_occ
-    nao = mo_coeff[0].shape[0]
-
-    shls_slice = (0, mol.nbas)
-    ao_loc = mol.ao_loc_nr()
-
-    dmvo = [(dmvo[0]+dmvo[0].T)*.5,
-            (dmvo[1]+dmvo[1].T)*.5]
-
-    f1vo = np.zeros((2,4,nao,nao))
-    deriv = 2
-
-    if xctype == 'LDA':
-        def lda_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[0], wv)
-            for k in range(4):
-                vmat[k] += numint._dot_ao_ao(mol, ao[k], aow, mask, shls_slice, ao_loc)
-
-        ao_deriv = 1
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            rho = (ni.eval_rho2(mol, ao[0], mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao[0], mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:3]
-            u_u, u_d, d_d = fxc[0].T * weight
-            rho1a = ni.eval_rho(mol, ao[0], dmvo[0], mask, xctype, hermi=1)
-            rho1b = ni.eval_rho(mol, ao[0], dmvo[1], mask, xctype, hermi=1)
-
-            lda_sum_(f1vo[0], ao, u_u*rho1a+u_d*rho1b, mask)
-            lda_sum_(f1vo[1], ao, u_d*rho1a+d_d*rho1b, mask)
-
-    elif xctype == 'GGA':
-        def gga_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[:4], wv[:4])
-            tmp = numint._dot_ao_ao(mol, ao[0], aow, mask, shls_slice, ao_loc)
-            vmat[0] += tmp + tmp.T
-            rks_grad._gga_grad_sum_(vmat[1:], mol, ao, wv, mask, ao_loc)
-        ao_deriv = 2
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            rho = (ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:3]
-
-            rho1 = (ni.eval_rho(mol, ao, dmvo[0], mask, xctype, hermi=1),
-                    ni.eval_rho(mol, ao, dmvo[1], mask, xctype, hermi=1))
-            wv = numint._uks_gga_wv1(rho, rho1, vxc, fxc, weight)
-            gga_sum_(f1vo[0], ao, wv[0], mask)
-            gga_sum_(f1vo[1], ao, wv[1], mask)
-
-    elif xctype == 'MGGA':
-        def mgga_sum_(vmat, ao, wv, mask):
-            aow = numint._scale_ao(ao[:4], wv[:4])
-            tmp = numint._dot_ao_ao(mol, ao[0], aow, mask, shls_slice, ao_loc)
-
-            aow = numint._scale_ao(ao[1], wv[5], aow)
-            tmp += numint._dot_ao_ao(mol, ao[1], aow, mask, shls_slice, ao_loc)
-            aow = numint._scale_ao(ao[2], wv[5], aow)
-            tmp += numint._dot_ao_ao(mol, ao[2], aow, mask, shls_slice, ao_loc)
-            aow = numint._scale_ao(ao[3], wv[5], aow)
-            tmp += numint._dot_ao_ao(mol, ao[3], aow, mask, shls_slice, ao_loc)
-            vmat[0] += tmp + tmp.T
-
-            rks_grad._gga_grad_sum_(vmat[1:], mol, ao, wv[:4], mask, ao_loc)
-            rks_grad._tau_grad_dot_(vmat[1:], mol, ao, wv[5]*2, mask, ao_loc, True)
-
-        ao_deriv = 2
-        for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
-            rho = (ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype),
-                   ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype))
-            vxc, fxc, kxc = ni.eval_xc(xc_code, rho, 1, deriv=deriv)[1:]
-
-            rho1 = (ni.eval_rho(mol, ao, dmvo[0], mask, xctype, hermi=1),
-                    ni.eval_rho(mol, ao, dmvo[1], mask, xctype, hermi=1))
-            wv = numint._uks_mgga_wv1(rho, rho1, vxc, fxc, weight)
-            mgga_sum_(f1vo[0], ao, wv[0], mask)
-            mgga_sum_(f1vo[1], ao, wv[1], mask)
-
-            vxc = fxc = rho = rho1 = None
-
-    elif xctype == 'HF':
-        pass
-    else:
-        raise NotImplementedError(f'td-uks for functional {xc_code}')
-
-    f1vo[:,1:] *= -1
-    return f1vo
 
 class Gradients(tdrhf_grad.Gradients):
     cphf_max_cycle = tdrhf_grad.Gradients.cphf_max_cycle + 20
+
     @lib.with_doc(grad_elec.__doc__)
     def grad_elec(self, xy, singlet=None, atmlst=None):
         return grad_elec(self, xy, atmlst, self.max_memory, self.verbose)
 
+
 Grad = Gradients
 
 from pyscf import sftda
+
 sftda.uks_sf.TDA_SF.Gradients = sftda.uks_sf.TDDFT_SF.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/test/test_sftda_grad.py
+++ b/pyscf/grad/test/test_sftda_grad.py
@@ -18,16 +18,75 @@ from pyscf import gto
 from pyscf import sftda
 from pyscf.grad import tduks_sf
 
+
+def cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+
+    A_abab_2d = A_abab.reshape((n_occ_a * n_virt_b, n_occ_a * n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a * n_virt_b, n_occ_b * n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b * n_virt_a, n_occ_a * n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b * n_virt_a, n_occ_b * n_virt_a), order='C')
+
+    Casida_matrix = np.block([[A_abab_2d, np.zeros_like(B_abba_2d)], [-np.zeros_like(B_baab_2d), -A_baba_2d]])
+
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+
+    norms = np.linalg.norm(eigenvecs[: n_occ_a * n_virt_b], axis=0) ** 2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b :], axis=0) ** 2
+
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+        eigenvecs = eigenvecs[:, mask].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            y = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, 0)
+    else:
+        mask = norms < -1e-3
+        valid_e = -eigenvals[mask].real
+        idx = np.argsort(valid_e)
+        valid_e = valid_e[::-1]
+        eigenvecs = eigenvecs[:, mask][:, ::-1].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            y = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, 0)
+
+    fake_td = mf.TDA_SF()
+    fake_td.extype = extype
+    fake_td.collinear_samples = collinear_samples
+    fake_td.e = valid_e
+    fake_td.xy = [norm_xy(z) for z in eigenvecs]
+
+    tdg = fake_td.Gradients()
+    return tdg.kernel(state=state)
+
+
 class KnownValues(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         mol = gto.Mole()
         mol.verbose = 0
         mol.output = '/dev/null'
-        mol.atom = '''
+        mol.atom = """
         O     0.   0.       0.
         H     0.   -0.757   0.587
-        H     0.   0.757    0.587'''
+        H     0.   0.757    0.587"""
         mol.spin = 2
         mol.basis = '631g'
         cls.mol = mol.build()
@@ -38,145 +97,201 @@ class KnownValues(unittest.TestCase):
 
     def test_hf_tda(self):
         mf = self.mol.UKS(xc='HF').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-3.0157070982e-18,  3.7144943268e-15,  3.3681971737e-01],
-            [ 8.9129157073e-17,  3.1640695246e-01, -1.6840985868e-01],
-            [-8.6113449975e-17, -3.1640695246e-01, -1.6840985868e-01]]
+            [
+                [-3.9062848726e-17, -3.8312759625e-14, 3.3682079790e-01],
+                [-9.7053273214e-17, 3.1640759776e-01, -1.6841039895e-01],
+                [1.3611612194e-16, -3.1640759776e-01, -1.6841039895e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 9.3014403269e-17,  1.5956923862e-16, -1.6746993353e-02],
-            [ 5.8351890612e-17,  1.4738926078e-02,  8.3734966765e-03],
-            [-1.5136629388e-16, -1.4738926078e-02,  8.3734966765e-03]]
+            [
+                [2.9628379088e-18, 2.9939944619e-15, -1.6746699427e-02],
+                [-3.6072117518e-16, 1.4739029263e-02, 8.3733497137e-03],
+                [3.5775833727e-16, -1.4739029263e-02, 8.3733497137e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_lda_tda(self):
         mf = self.mol.UKS(xc='SVWN').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-9.2546359854e-17, -6.0541677143e-15,  2.8558017756e-01],
-            [-1.2529623683e-16,  2.7449714062e-01, -1.4279559145e-01],
-            [ 1.9188009639e-16, -2.7449714062e-01, -1.4279559145e-01]]
+            [
+                [-1.1347069729e-16, -1.1084528691e-14, 2.8558017754e-01],
+                [-1.1092137160e-16, 2.7449714063e-01, -1.4279559143e-01],
+                [5.9671903444e-17, -2.7449714063e-01, -1.4279559143e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 1.2454225094e-17, -1.7849576353e-14,  3.6816914140e-03],
-            [ 1.2927014603e-16,  1.4522652407e-02, -1.8472200133e-03],
-            [-1.3166296104e-16, -1.4522652407e-02, -1.8472200133e-03]]
+            [
+                [-3.9699882577e-16, 3.2848830357e-14, 3.6816914140e-03],
+                [8.4541133573e-17, 1.4522652407e-02, -1.8472200133e-03],
+                [9.7761986797e-17, -1.4522652407e-02, -1.8472200133e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_b3lyp_tda(self):
         mf = self.mol.UKS(xc='B3LYP').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 3.3755805526e-16,  5.1347236507e-15,  3.0303548147e-01],
-            [-5.7420768990e-17,  2.8716422104e-01, -1.5151852101e-01],
-            [ 5.9375519925e-17, -2.8716422104e-01, -1.5151852101e-01]]
+            [
+                [-1.8081449997e-16, -8.2435367236e-15, 3.0303551390e-01],
+                [-4.0213738471e-17, 2.8716424898e-01, -1.5151853722e-01],
+                [2.0517979988e-16, -2.8716424898e-01, -1.5151853722e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 3.8904964283e-16, -1.6116646615e-15, -2.8870940206e-03],
-            [ 3.0341520419e-17,  1.1221659593e-02,  1.4375770430e-03],
-            [-1.1785487464e-16, -1.1221659593e-02,  1.4375770430e-03]]
+            [
+                [-2.1754590583e-16, 5.1510183861e-15, -2.8870940206e-03],
+                [2.6851737303e-16, 1.1221659593e-02, 1.4375770430e-03],
+                [-1.1021313913e-16, -1.1221659593e-02, 1.4375770429e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_col_b3lyp_tda(self):
         mf = self.mol.UKS(xc='B3LYP').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-3.2259149630e-17,  7.6179452385e-16,  2.9019466200e-01],
-            [-2.5052609688e-16,  2.8359926220e-01, -1.4509830953e-01],
-            [ 1.1342578584e-16, -2.8359926220e-01, -1.4509830953e-01]]
+            [
+                [-2.5468184163e-16, -1.1180009418e-14, 2.9019466200e-01],
+                [-9.0775873947e-17, 2.8359926220e-01, -1.4509830953e-01],
+                [1.1512910412e-16, -2.8359926220e-01, -1.4509830953e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-4.7652535574e-17,  2.7295834367e-17, -7.5626763433e-03],
-            [ 4.6782068927e-17,  8.4214463746e-03,  3.7759834021e-03],
-            [-2.5715216150e-18, -8.4214463746e-03,  3.7759834021e-03]]
+            [
+                [-1.3918149905e-16, 2.8187893403e-15, -7.5626763433e-03],
+                [6.2566519798e-17, 8.4214463746e-03, 3.7759834021e-03],
+                [-1.1867186914e-16, -8.4214463746e-03, 3.7759834021e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_tpss_tda(self):
         mf = self.mol.UKS(xc='TPSS').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-1.0618116650e-16,  8.5065843025e-16,  3.0276587070e-01],
-            [-1.7544086463e-16,  2.8575699030e-01, -1.5139697086e-01],
-            [-2.1559126598e-17, -2.8575699030e-01, -1.5139697086e-01]]
+            [
+                [7.8326284520e-17, -1.3071806385e-14, 3.0276587070e-01],
+                [7.2426310078e-17, 2.8575699030e-01, -1.5139697086e-01],
+                [-1.9546658108e-16, -2.8575699030e-01, -1.5139697086e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[-8.0765155817e-17, -5.4813611036e-15,  8.7167801429e-03],
-            [ 4.8264725316e-17,  1.4280801923e-02, -4.3644887121e-03],
-            [-1.2028615208e-16, -1.4280801923e-02, -4.3644887121e-03]]
+            [
+                [1.4878309854e-16, 1.8283875050e-14, 8.7167801429e-03],
+                [4.6186501645e-17, 1.4280801923e-02, -4.3644887121e-03],
+                [-1.1302550886e-16, -1.4280801923e-02, -4.3644887121e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_cam_tda(self):
         mf = self.mol.UKS(xc='CAM-B3LYP').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-2.4425492658e-16,  7.1480887150e-16,  3.0670229779e-01],
-            [-1.0665896206e-17,  2.9083187407e-01, -1.5335290807e-01],
-            [ 1.4274133369e-17, -2.9083187407e-01, -1.5335290807e-01]]
+            [
+                [-8.0651321211e-17, -2.3767777669e-15, 3.0670229779e-01],
+                [4.1732199809e-18, 2.9083187407e-01, -1.5335290807e-01],
+                [7.9000081855e-18, -2.9083187407e-01, -1.5335290807e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[-3.9676112181e-16, -2.0321658431e-15, -1.0403780070e-02],
-            [ 1.3911348534e-16,  1.1793709730e-02,  5.1952611230e-03],
-            [ 3.4897930373e-18, -1.1793709730e-02,  5.1952611230e-03]]
+            [
+                [1.5152147863e-16, 1.9028098735e-15, -1.0403780070e-02],
+                [-1.0684663896e-16, 1.1793709730e-02, 5.1952611230e-03],
+                [-1.1109928193e-16, -1.1793709730e-02, 5.1952611230e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_col_cam_tda(self):
         mf = self.mol.UKS(xc='CAM-B3LYP').run()
-        td = mf.TDA_SF().set(extype=0, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=0, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=0, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-3.7095391429e-16,  2.3070693682e-15,  2.9440091136e-01],
-            [-1.1663709778e-16,  2.8746882738e-01, -1.4720233631e-01],
-            [-2.3132142127e-18, -2.8746882738e-01, -1.4720233631e-01]]
+            [
+                [-2.3403358733e-16, -8.8750321950e-15, 2.9440091136e-01],
+                [-1.8329779505e-17, 2.8746882738e-01, -1.4720233631e-01],
+                [2.8537278462e-17, -2.8746882738e-01, -1.4720233631e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDA_SF().set(extype=1, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDA_SF(extype=1, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tda_gradient(mf, extype=1, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-4.7123223583e-16,  9.9126039837e-16, -1.5815377851e-02],
-            [ 4.1675117676e-17,  8.5650850136e-03,  7.9015027954e-03],
-            [-7.4950221683e-17, -8.5650850136e-03,  7.9015027954e-03]]
+            [
+                [-7.4172801642e-17, 2.8382044273e-15, -1.5815249811e-02],
+                [-2.2604851938e-16, 8.5651006595e-03, 7.9014387760e-03],
+                [1.0633060174e-16, -8.5651006595e-03, 7.9014387760e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
 
-if __name__ == "__main__":
-    print("Full Tests for spin-flip-TDA analytic gradient with multicollinear functionals and collinear functionals")
+if __name__ == '__main__':
+    print('Full Tests for spin-flip-TDA analytic gradient with multicollinear functionals and collinear functionals')
     unittest.main()

--- a/pyscf/grad/test/test_sftddft_grad.py
+++ b/pyscf/grad/test/test_sftddft_grad.py
@@ -18,16 +18,75 @@ from pyscf import gto
 from pyscf import sftda
 from pyscf.grad import tduks_sf
 
+
+def cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1):
+    a, b = sftda.uhf_sf.get_ab_sf(mf, collinear_samples=collinear_samples)
+    A_baba, A_abab = a
+    B_baab, B_abba = b
+
+    n_occ_a, n_virt_b = A_abab.shape[0], A_abab.shape[1]
+    n_occ_b, n_virt_a = B_abba.shape[2], B_abba.shape[3]
+
+    A_abab_2d = A_abab.reshape((n_occ_a * n_virt_b, n_occ_a * n_virt_b), order='C')
+    B_abba_2d = B_abba.reshape((n_occ_a * n_virt_b, n_occ_b * n_virt_a), order='C')
+    B_baab_2d = B_baab.reshape((n_occ_b * n_virt_a, n_occ_a * n_virt_b), order='C')
+    A_baba_2d = A_baba.reshape((n_occ_b * n_virt_a, n_occ_b * n_virt_a), order='C')
+
+    Casida_matrix = np.block([[A_abab_2d, B_abba_2d], [-B_baab_2d, -A_baba_2d]])
+
+    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    idx = eigenvals.real.argsort()
+    eigenvals = eigenvals[idx]
+    eigenvecs = eigenvecs[:, idx]
+
+    norms = np.linalg.norm(eigenvecs[: n_occ_a * n_virt_b], axis=0) ** 2
+    norms -= np.linalg.norm(eigenvecs[n_occ_a * n_virt_b :], axis=0) ** 2
+
+    if extype == 1:
+        mask = norms > 1e-3
+        valid_e = eigenvals[mask].real
+        eigenvecs = eigenvecs[:, mask].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            y = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, y * norm)
+    else:
+        mask = norms < -1e-3
+        valid_e = -eigenvals[mask].real
+        idx = np.argsort(valid_e)
+        valid_e = valid_e[::-1]
+        eigenvecs = eigenvecs[:, mask][:, ::-1].transpose(1, 0)
+
+        def norm_xy(z):
+            x = z[n_occ_a * n_virt_b :].reshape(n_occ_b, n_virt_a)
+            y = z[: n_occ_a * n_virt_b].reshape(n_occ_a, n_virt_b)
+            norm = np.linalg.norm(x) ** 2 - np.linalg.norm(y) ** 2
+            norm = np.sqrt(1.0 / norm)
+            return (x * norm, y * norm)
+
+    fake_td = mf.TDDFT_SF()
+    fake_td.extype = extype
+    fake_td.collinear_samples = collinear_samples
+    fake_td.e = valid_e
+    fake_td.xy = [norm_xy(z) for z in eigenvecs]
+
+    tdg = fake_td.Gradients()
+    return tdg.kernel(state=state)
+
+
 class KnownValues(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         mol = gto.Mole()
         mol.verbose = 0
         mol.output = '/dev/null'
-        mol.atom = '''
+        mol.atom = """
         O     0.   0.       0.
         H     0.   -0.757   0.587
-        H     0.   0.757    0.587'''
+        H     0.   0.757    0.587"""
         mol.spin = 2
         mol.basis = '631g'
         cls.mol = mol.build()
@@ -38,145 +97,201 @@ class KnownValues(unittest.TestCase):
 
     def test_hf_tddft(self):
         mf = self.mol.UKS(xc='HF').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 9.8635123327e-17, -2.6531978332e-15,  3.5288902041e-01],
-            [-2.0752411168e-16,  3.2334648658e-01, -1.7644451021e-01],
-            [ 1.0888898835e-16, -3.2334648658e-01, -1.7644451021e-01]]
+            [
+                [-2.2719396368e-17, -4.0913995956e-15, 3.5288985123e-01],
+                [-9.8623500302e-17, 3.2334703193e-01, -1.7644492561e-01],
+                [1.2134289667e-16, -3.2334703193e-01, -1.7644492561e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 1.2217345207e-16, -1.4073039905e-15, -1.7603015843e-02],
-            [-3.1381655282e-16,  1.4559153763e-02,  8.8015079214e-03],
-            [ 1.9164310076e-16, -1.4559153763e-02,  8.8015079214e-03]]
+            [
+                [-3.1451899376e-17, 1.2325674955e-15, -1.7602719006e-02],
+                [-1.0377532915e-16, 1.4559257186e-02, 8.8013595029e-03],
+                [1.3522722853e-16, -1.4559257186e-02, 8.8013595029e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_lda_tddft(self):
         mf = self.mol.UKS(xc='SVWN').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-1.2757624379e-16,  1.9190538241e-15,  2.8683262201e-01],
-            [ 3.2461388658e-17,  2.7494365566e-01, -1.4342181386e-01],
-            [-7.3881676371e-17, -2.7494365566e-01, -1.4342181386e-01]]
+            [
+                [-8.4809773264e-16, 8.3401070355e-15, 2.8683261827e-01],
+                [-1.2920607139e-17, 2.7494364759e-01, -1.4342181199e-01],
+                [-1.9612973720e-17, -2.7494364759e-01, -1.4342181199e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[-1.4814561008e-16,  1.5733130704e-14,  3.6572276035e-03],
-            [-1.0110540434e-16,  1.4533618985e-02, -1.8349881981e-03],
-            [ 1.7090139659e-17, -1.4533618985e-02, -1.8349881981e-03]]
+            [
+                [-6.7904482786e-16, 1.2476156342e-14, 3.6571945011e-03],
+                [-9.3757276431e-17, 1.4533596842e-02, -1.8349716472e-03],
+                [4.8848910182e-17, -1.4533596842e-02, -1.8349716472e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_b3lyp_tddft(self):
         mf = self.mol.UKS(xc='B3LYP').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 3.2603455049e-16,  1.7646595764e-16,  3.0669181702e-01],
-            [-9.7156306981e-17,  2.8848085531e-01, -1.5334666701e-01],
-            [ 1.5134230155e-17, -2.8848085531e-01, -1.5334666701e-01]]
+            [
+                [6.3207724582e-17, -3.3299964897e-15, 3.0669181757e-01],
+                [-7.4706674154e-17, 2.8848086768e-01, -1.5334666728e-01],
+                [3.3531102689e-19, -2.8848086768e-01, -1.5334666728e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[ 3.9440438558e-16,  5.8563320419e-15, -2.9490371434e-03],
-            [-1.2116370071e-17,  1.1241921015e-02,  1.4685106244e-03],
-            [-8.3644726181e-17, -1.1241921015e-02,  1.4685106244e-03]]
+            [
+                [8.5327168247e-17, 1.2525864103e-15, -2.9494220961e-03],
+                [2.7815342784e-17, 1.1241681452e-02, 1.4687030974e-03],
+                [-1.7036279713e-17, -1.1241681452e-02, 1.4687030974e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_col_b3lyp_tddft(self):
         mf = self.mol.UKS(xc='B3LYP').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=-50, state=1)
         ref = np.array(
-            [[ 2.5161393249e-16, -2.5218247762e-15,  2.9075065556e-01],
-            [-7.3124160510e-17,  2.8383332799e-01, -1.4537630816e-01],
-            [ 7.0137639062e-17, -2.8383332799e-01, -1.4537630816e-01]]
+            [
+                [-1.5105624594e-16, 1.2602467888e-15, 2.9075066796e-01],
+                [6.5823041051e-18, 2.8383333522e-01, -1.4537631436e-01],
+                [-7.5347051462e-17, -2.8383333522e-01, -1.4537631436e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=-50, state=1)
         ref = np.array(
-            [[ 3.6858848913e-16,  4.0065663116e-15, -7.5967156655e-03],
-            [-2.0596267663e-17,  8.4096408373e-03,  3.7930034810e-03],
-            [-9.5790330150e-18, -8.4096408373e-03,  3.7930034810e-03]]
+            [
+                [-7.5510879830e-17, 1.0627607632e-15, -7.5959284737e-03],
+                [-9.4837014163e-17, 8.4101877276e-03, 3.7926098698e-03],
+                [-1.0223646526e-17, -8.4101877276e-03, 3.7926098698e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_tpss_tddft(self):
         mf = self.mol.UKS(xc='TPSS').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-        [[-3.0513915325e-16, -2.6005974810e-15,  3.0645164672e-01],
-        [ 6.9190185801e-18,  2.8704790411e-01, -1.5324080433e-01],
-        [-1.0512951278e-16, -2.8704790411e-01, -1.5324080433e-01]]
+            [
+                [-2.8308341496e-16, 1.0704054160e-15, 3.0645165527e-01],
+                [-1.1971039167e-16, 2.8704791604e-01, -1.5324080858e-01],
+                [3.3992205735e-17, -2.8704791604e-01, -1.5324080858e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[-3.4214134238e-16, -3.5767789007e-15,  8.8035914294e-03],
-            [-7.8492425982e-18,  1.4360641011e-02, -4.4082258897e-03],
-            [-5.7805037162e-17, -1.4360641011e-02, -4.4082258897e-03]]
+            [
+                [-1.6711533117e-16, 1.0947265850e-14, 8.8032106411e-03],
+                [-1.0451471451e-16, 1.4360403474e-02, -4.4080354878e-03],
+                [-4.7204899979e-20, -1.4360403474e-02, -4.4080354878e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_mcol_cam_tddft(self):
         mf = self.mol.UKS(xc='CAM-B3LYP').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=50, state=1)
         ref = np.array(
-            [[-2.1149902016e-16, -1.2801272120e-15,  3.1103703527e-01],
-            [ 8.8772726516e-18,  2.9247173996e-01, -1.5552026913e-01],
-            [ 8.1548873113e-18, -2.9247173996e-01, -1.5552026913e-01]]
+            [
+                [-3.7538914920e-16, -6.9527321033e-15, 3.1103703156e-01],
+                [-1.4713567467e-16, 2.9247173978e-01, -1.5552026728e-01],
+                [-2.4033397519e-17, -2.9247173978e-01, -1.5552026728e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=50, state=1)
         ref = np.array(
-            [[-1.2850649394e-16,  9.1261102573e-16, -1.0510318371e-02],
-            [-4.1480095616e-17,  1.1801184295e-02,  5.2485041660e-03],
-            [ 8.8065545693e-19, -1.1801184295e-02,  5.2485041660e-03]]
+            [
+                [-4.5098470283e-16, 2.7736173739e-15, -1.0510769880e-02],
+                [-1.9483417972e-16, 1.1800860322e-02, 5.2487299209e-03],
+                [1.1710777201e-16, -1.1800860322e-02, 5.2487299209e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
     def test_col_cam_tddft(self):
         mf = self.mol.UKS(xc='CAM-B3LYP').run()
-        td = mf.TDDFT_SF().set(extype=0, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=0, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=0, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-2.9070712607e-16,  7.8946412672e-16,  2.9529370943e-01],
-            [-1.0423166195e-16,  2.8788636795e-01, -1.4764873898e-01],
-            [-4.6938480146e-17, -2.8788636795e-01, -1.4764873898e-01]]
+            [
+                [1.1028977623e-17, -8.7353942702e-15, 2.9529372572e-01],
+                [-1.3201775114e-16, 2.8788637730e-01, -1.4764874713e-01],
+                [3.1443202277e-17, -2.8788637730e-01, -1.4764874713e-01],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
-        td = mf.TDDFT_SF().set(extype=1, collinear_samples=-50, nstates=2).run()
-        tdg = td.Gradients().run()
+        td = mf.TDDFT_SF(extype=1, collinear_samples=-50).run()
+        grad_iter = td.Gradients().kernel(state=1)
+        grad_exact = cal_exact_sf_tddft_gradient(mf, extype=1, collinear_samples=-50, state=1)
         ref = np.array(
-            [[-3.4311860805e-16,  8.3116047642e-16, -1.5876227600e-02],
-            [ 5.5628047850e-17,  8.5399145588e-03,  7.9319280810e-03],
-            [-1.1167593801e-16, -8.5399145588e-03,  7.9319280810e-03]]
+            [
+                [-2.5925322984e-17, 3.1312811099e-15, -1.5876133062e-02],
+                [4.8403599468e-17, 8.5399089682e-03, 7.9318808125e-03],
+                [-7.8228805841e-17, -8.5399089682e-03, 7.9318808125e-03],
+            ]
         )
-        self.assertAlmostEqual(abs(tdg.de - ref).max(), 0, 4)
+        self.assertAlmostEqual(abs(grad_exact - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(grad_iter - ref).max(), 0, 5)
 
 
-if __name__ == "__main__":
-    print("Full Tests for spin-flip-TDDFT analytic gradient with multicollinear functionals and collinear functionals")
+if __name__ == '__main__':
+    print('Full Tests for spin-flip-TDDFT analytic gradient with multicollinear functionals and collinear functionals')
     unittest.main()

--- a/pyscf/sftda/uhf_sf.py
+++ b/pyscf/sftda/uhf_sf.py
@@ -27,7 +27,6 @@ from pyscf.data import nist
 from pyscf.sftda import uks_sf
 from pyscf.tdscf._lr_eig import eigh as lr_eigh
 
-# import function
 from pyscf.sftda.scf_genrep_sftd import gen_uhf_response_sf
 from pyscf.sftda.numint2c_sftd import cache_xc_kernel_sf
 
@@ -270,7 +269,7 @@ def analyze(tdobj, verbose=None):
                 for o, v in zip(* np.where(abs(x) > 0.1)):
                     log.info('    %4da -> %4db %12.5f', o+MO_BASE, v+MO_BASE+nocc_b, x[o,v])
 
-def get_ab_sf(mf, mo_energy=None, mo_coeff=None, mo_occ=None, collinear_samples=200):
+def get_ab_sf(mf, mo_energy=None, mo_coeff=None, mo_occ=None, collinear_samples=20):
     r'''A and B matrices for TDDFT response function.
 
     A[i,a,j,b] = \delta_{ab}\delta_{ij}(E_a - E_i) + (ia||bj)
@@ -499,16 +498,16 @@ def get_ab_sf(mf, mo_energy=None, mo_coeff=None, mo_occ=None, collinear_samples=
 
 @lib.with_doc(rhf.TDA.__doc__)
 class TDA_SF(TDBase):
-    extype = getattr(__config__, 'tdscf_uhf_sf_SF-TDA_extype', 0)
-    collinear_samples = getattr(__config__, 'tdscf_uhf_sf_SF-TDA_collinear_samples', 200)
+    extype = getattr(__config__, 'tdscf_uhf_sf_SF-TDA_extype', 1)
+    collinear_samples = getattr(__config__, 'tdscf_uhf_sf_SF-TDA_collinear_samples', 20)
 
     _keys = {'extype','collinear_samples'}
 
-    def __init__(self,mf,extype=0,collinear_samples=200):
+    def __init__(self, mf, extype=1, collinear_samples=20):
         TDBase.__init__(self,mf)
         # extype is used to determine which spin flip excitation will be calculated.
         # spin flip up: exytpe=0, spin flip down: exytpe=1.
-        self.extype=extype
+        self.extype = extype
         # collinear_samples controls the 1d spin sample points in TDDFT/TDA.
         self.collinear_samples = collinear_samples
 

--- a/pyscf/sftda/uks_sf.py
+++ b/pyscf/sftda/uks_sf.py
@@ -21,7 +21,6 @@ from pyscf.lib import logger
 from pyscf.sftda import uhf_sf
 from pyscf import __config__
 
-# import function
 from pyscf.sftda.scf_genrep_sftd import gen_uhf_response_sf
 
 from pyscf.lib.parameters import MAX_MEMORY


### PR DESCRIPTION
## Description

This PR refactors the UKS spin-flip TDDFT/TDA analytic gradient implementation. 

### Main changes

- Refactor `pyscf/grad/tduks_sf.py` to simplify and unify gradient evaluation logic, consistent with the methodology in *J. Chem. Theory Comput.* 2025, 21, 6, 3010.
- Modify the contraction between functional derivatives and basis functions to align with the current `tdrks` and `tduks` implementations.
- Improve and expand validation tests for both SF-TDA and SF-TDDFT using exact Casida-matrix gradients as references.

### Interface updates

- Update default SF-TDA settings in `pyscf/sftda/uhf_sf.py`:
    - `extype: 0 -> 1`
    - `collinear_samples: 200 -> 20`
- Keep `TDA_SF.__init__` constructor defaults consistent with the new settings.