### PR TITLE
Add a fast version of ulnoccsd_t.py

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -120,42 +120,42 @@ if(BUILD_OCCRI)
         occri/occri.c
         occri/occri.h
     )
-    
+
     # Check for required dependencies
     set(OCCRI_DEPS_FOUND TRUE)
-    
+
     # Find FFTW
     find_library(FFTW3_LIBRARY fftw3)
     find_library(FFTW3_THREADS_LIBRARY fftw3_threads)
     find_path(FFTW3_INCLUDE_DIR fftw3.h)
-    
+
     if(NOT FFTW3_LIBRARY OR NOT FFTW3_THREADS_LIBRARY OR NOT FFTW3_INCLUDE_DIR)
         message(STATUS "FFTW3 not found - OCCRI C extension will not be built")
         set(OCCRI_DEPS_FOUND FALSE)
     endif()
-    
+
     # Find OpenMP
     find_package(OpenMP)
     if(NOT OPENMP_FOUND)
         message(STATUS "OpenMP not found - OCCRI C extension will not be built")
         set(OCCRI_DEPS_FOUND FALSE)
     endif()
-    
+
     if(OCCRI_DEPS_FOUND)
         message(STATUS "Building OCCRI C extension with FFTW and OpenMP")
         add_library(occri SHARED ${OCCRI_SOURCE_FILES})
-        
+
         # Add include directories
         target_include_directories(occri PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/occri)
         target_include_directories(occri PRIVATE ${FFTW3_INCLUDE_DIR})
-        
+
         # Link against FFTW and OpenMP
         target_link_libraries(occri
             ${OPENMP_C_PROPERTIES}
             ${FFTW3_LIBRARY}
             ${FFTW3_THREADS_LIBRARY}
         )
-        
+
         # Set output directory and name
         set_target_properties(occri PROPERTIES
             CLEAN_DIRECT_OUTPUT 1
@@ -189,14 +189,14 @@ set_target_properties (clib_dsrg PROPERTIES
     OUTPUT_NAME "dsrg")
 
 # Build the LNO library
-set (LNO_SOURCE_FILES "lno/ccsd_t.c")
+set (LNO_SOURCE_FILES "lno/ccsd_t.c" "lno/uccsd_t.c")
 add_library (clib_lno SHARED ${LNO_SOURCE_FILES})
 target_link_libraries (clib_lno cc ao2mo cvhf np_helper ${BLAS_LIBRARIES} ${OPENMP_C_PROPERTIES})
 set_target_properties (clib_lno PROPERTIES
     CLEAN_DIRECT_OUTPUT 1
     LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_NAME "lno")
-    
+
 # Build the CSFstring shared library
 set (CSF_SOURCE_FILES "csf/csfstring.c")
 add_library (clib_csf SHARED ${CSF_SOURCE_FILES})

--- a/pyscf/lib/lno/uccsd_t.c
+++ b/pyscf/lib/lno/uccsd_t.c
@@ -1,0 +1,1221 @@
+/* Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ *
+ * Author: Qiming Sun <osirpt.sun@gmail.com>
+ *         Yu Jin <yjin@flatironinstitute.org>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include "config.h"
+#include "np_helper/np_helper.h"
+#include "vhf/fblas.h"
+
+typedef struct {
+        void *cache[6];
+        short a;
+        short b;
+        short c;
+        short _padding;
+} CacheJob;
+
+size_t _ccsd_t_gen_jobs(CacheJob *jobs, int nocc, int nvir,
+                        int a0, int a1, int b0, int b1,
+                        void *cache_row_a, void *cache_col_a,
+                        void *cache_row_b, void *cache_col_b, size_t stride);
+
+void _make_permute_indices(int *idx, int n);
+
+
+/*
+ * w + w.transpose(1,2,0) + w.transpose(2,0,1)
+ * - w.transpose(2,1,0) - w.transpose(0,2,1) - w.transpose(1,0,2)
+ */
+static void add_and_permute(double *out, double *w, double *v, int n)
+{
+        int nn = n * n;
+        int nnn = nn * n;
+        int i, j, k;
+
+        for (i = 0; i < nnn; i++) {
+                v[i] += w[i];
+        }
+
+        for (i = 0; i < n; i++) {
+        for (j = 0; j < n; j++) {
+        for (k = 0; k < n; k++) {
+                out[i*nn+j*n+k] = v[i*nn+j*n+k] + v[j*nn+k*n+i] + v[k*nn+i*n+j]
+                                - v[k*nn+j*n+i] - v[i*nn+k*n+j] - v[j*nn+i*n+k];
+        } } }
+}
+
+/*
+ * t2T = t2.transpose(2,3,0,1)
+ * ov = vv_op[:,nocc:]
+ * oo = vv_op[:,:nocc]
+ * w = numpy.einsum('if,fjk->ijk', -ov, t2T[c])
+ * w-= numpy.einsum('ijm,mk->ijk', vooo[a], t2T[b,c])
+ * v = numpy.einsum('ij,k->ijk', oo, t1T[c])
+ * v+= w
+ */
+static void get_wv(double *w, double *v, double *cache,
+                   double *fvohalf, double *vooo,
+                   double *vv_op, double *t1T, double *t2T,
+                   int nocc, int nvir, int a, int b, int c, int *idx)
+{
+        const double D0 = 0;
+        const double D1 = 1;
+        const double DN1 =-1;
+        const char TRANS_N = 'N';
+        const char TRANS_T = 'T';
+        const int nmo = nocc + nvir;
+        const int noo = nocc * nocc;
+        const size_t nooo = nocc * noo;
+        const size_t nvoo = nvir * noo;
+        int i, j, k, n;
+        double *pt2T;
+
+        dgemm_(&TRANS_N, &TRANS_N, &noo, &nocc, &nvir,
+               &DN1, t2T+c*nvoo, &noo, vv_op+nocc, &nmo,
+               &D0, cache, &noo);
+        dgemm_(&TRANS_N, &TRANS_T, &nocc, &noo, &nocc,
+               &DN1, t2T+b*nvoo+c*noo, &nocc, vooo+a*nooo, &noo,
+               &D1, cache, &nocc);
+
+        pt2T = t2T + a * nvoo + b * noo;
+        for (n = 0, i = 0; i < nocc; i++) {
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++, n++) {
+                w[idx[n]] += cache[n];
+                v[idx[n]] +=(vv_op[i*nmo+j] * t1T[c*nocc+k]
+                        + pt2T[i*nocc+j] * fvohalf[c*nocc+k]);
+        } } }
+}
+
+static void sym_wv(double *w, double *v, double *cache,
+                   double *fvohalf, double *vooo,
+                   double *vv_op, double *t1T, double *t2T,
+                   int nocc, int nvir, int a, int b, int c, int nirrep,
+                   int *o_ir_loc, int *v_ir_loc, int *oo_ir_loc, int *orbsym,
+                   int *idx)
+{
+        const double D0 = 0;
+        const double D1 = 1;
+        const char TRANS_N = 'N';
+        const int nmo = nocc + nvir;
+        const int noo = nocc * nocc;
+        const int nooo = nocc * noo;
+        const int nvoo = nvir * noo;
+        int a_irrep = orbsym[nocc+a];
+        int b_irrep = orbsym[nocc+b];
+        int c_irrep = orbsym[nocc+c];
+        int ab_irrep = a_irrep ^ b_irrep;
+        int bc_irrep = c_irrep ^ b_irrep;
+        int i, j, k, n;
+        int fr, f0, f1, df, mr, m0, m1, dm, mk0;
+        int ir, i0, i1, di, kr, k0, k1, dk, jr;
+        int ijr, ij0, ij1, dij, jkr, jk0, jk1, djk;
+        double *pt2T;
+
+/* symmetry adapted
+ * w = numpy.einsum('if,fjk->ijk', ov, t2T[c]) */
+        pt2T = t2T + c * nvoo;
+        for (ir = 0; ir < nirrep; ir++) {
+                i0 = o_ir_loc[ir];
+                i1 = o_ir_loc[ir+1];
+                di = i1 - i0;
+                if (di > 0) {
+                        fr = ir ^ ab_irrep;
+                        f0 = v_ir_loc[fr];
+                        f1 = v_ir_loc[fr+1];
+                        df = f1 - f0;
+                        if (df > 0) {
+                                jkr = fr ^ c_irrep;
+                                jk0 = oo_ir_loc[jkr];
+                                jk1 = oo_ir_loc[jkr+1];
+                                djk = jk1 - jk0;
+                                if (djk > 0) {
+
+        dgemm_(&TRANS_N, &TRANS_N, &djk, &di, &df,
+                &D1, pt2T+f0*noo+jk0, &noo, vv_op+i0*nmo+nocc+f0, &nmo,
+                &D0, cache, &djk);
+        for (n = 0, i = o_ir_loc[ir]; i < o_ir_loc[ir+1]; i++) {
+        for (jr = 0; jr < nirrep; jr++) {
+                kr = jkr ^ jr;
+                for (j = o_ir_loc[jr]; j < o_ir_loc[jr+1]; j++) {
+                for (k = o_ir_loc[kr]; k < o_ir_loc[kr+1]; k++, n++) {
+                        w[idx[i*noo+j*nocc+k]] -= cache[n];
+                } }
+        } }
+                                }
+                        }
+                }
+        }
+
+/* symmetry adapted
+ * w-= numpy.einsum('ijm,mk->ijk', eris_vooo[a], t2T[c,b]) */
+        pt2T = t2T + c * nvoo + b * noo;
+        vooo += a * nooo;
+        mk0 = oo_ir_loc[bc_irrep];
+        for (mr = 0; mr < nirrep; mr++) {
+                m0 = o_ir_loc[mr];
+                m1 = o_ir_loc[mr+1];
+                dm = m1 - m0;
+                if (dm > 0) {
+                        kr = mr ^ bc_irrep;
+                        k0 = o_ir_loc[kr];
+                        k1 = o_ir_loc[kr+1];
+                        dk = k1 - k0;
+                        if (dk > 0) {
+                                ijr = mr ^ a_irrep;
+                                ij0 = oo_ir_loc[ijr];
+                                ij1 = oo_ir_loc[ijr+1];
+                                dij = ij1 - ij0;
+                                if (dij > 0) {
+
+        dgemm_(&TRANS_N, &TRANS_N, &dk, &dij, &dm,
+               &D1, pt2T+mk0, &dk, vooo+ij0*nocc+m0, &nocc,
+               &D0, cache, &dk);
+        for (n = 0, ir = 0; ir < nirrep; ir++) {
+                jr = ijr ^ ir;
+                for (i = o_ir_loc[ir]; i < o_ir_loc[ir+1]; i++) {
+                for (j = o_ir_loc[jr]; j < o_ir_loc[jr+1]; j++) {
+                for (k = o_ir_loc[kr]; k < o_ir_loc[kr+1]; k++, n++) {
+                        w[idx[i*noo+j*nocc+k]] -= cache[n];
+                } }
+        } }
+                                }
+                                mk0 += dm * dk;
+                        }
+                }
+        }
+
+        pt2T = t2T + a * nvoo + b * noo;
+        for (n = 0, i = 0; i < nocc; i++) {
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++, n++) {
+                v[idx[n]] +=(vv_op[i*nmo+j] * t1T[c*nocc+k]
+                           + pt2T[i*nocc+j] * fvohalf[c*nocc+k]);
+        } } }
+}
+
+static double _get_energy_aaa_lo(double *w, double *z, double *mo_energy, double *cache,
+                                 double *ulo, int nlo,
+                                 int nocc, int a, int b, int c, double fac)
+{
+        int i, j, k, mu;
+        int nn = nocc * nocc;
+        double abc = mo_energy[nocc+a] + mo_energy[nocc+b] + mo_energy[nocc+c];
+        double *ti = cache;
+        double *zi = ti + nocc;
+        double *tj = zi + nocc;
+        double *zj = tj + nocc;
+        double *tk = zj + nocc;
+        double *zk = tk + nocc;
+        double tlo, zlo;
+        double denom;
+        double et = 0;
+        double *ulo_mu;
+
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++) {
+        for (i = 0; i < nocc; i++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                ti[i] = w[ijk];
+                zi[i] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (i = 0; i < nocc; i++) {
+                        tlo += ti[i] * ulo_mu[i];
+                        zlo += zi[i] * ulo_mu[i];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+
+        for (i = 0; i < nocc; i++) {
+        for (k = 0; k < nocc; k++) {
+        for (j = 0; j < nocc; j++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                tj[j] = w[ijk];
+                zj[j] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (j = 0; j < nocc; j++) {
+                        tlo += tj[j] * ulo_mu[j];
+                        zlo += zj[j] * ulo_mu[j];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+
+        for (i = 0; i < nocc; i++) {
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                tk[k] = w[ijk];
+                zk[k] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (k = 0; k < nocc; k++) {
+                        tlo += tk[k] * ulo_mu[k];
+                        zlo += zk[k] * ulo_mu[k];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+        return et;
+}
+
+static double contract6_aaa(int nocc, int nvir, int a, int b, int c,
+                            double *mo_energy, double *t1T, double *t2T,
+                            int nirrep, int *o_ir_loc, int *v_ir_loc,
+                            int *oo_ir_loc, int *orbsym, double *fvo,
+                            double *vooo,
+                            double *ulo, int nlo,
+                            double *cache1, void **cache, int *permute_idx)
+{
+        int nooo = nocc * nocc * nocc;
+        int *idx0 = permute_idx;
+        int *idx1 = idx0 + nooo;
+        int *idx2 = idx1 + nooo;
+        int *idx3 = idx2 + nooo;
+        int *idx4 = idx3 + nooo;
+        int *idx5 = idx4 + nooo;
+        double *v0 = cache1;
+        double *w0 = v0 + nooo;
+        double *z0 = w0 + nooo;
+        double *cache2 = z0 + nooo;
+        double *wtmp = z0;
+        int i;
+
+        for (i = 0; i < nooo; i++) {
+                w0[i] = 0;
+                v0[i] = 0;
+        }
+
+        if (nirrep == 1) {
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[0], t1T, t2T, nocc, nvir, a, b, c, idx0);
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[1], t1T, t2T, nocc, nvir, a, c, b, idx1);
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[2], t1T, t2T, nocc, nvir, b, a, c, idx2);
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[3], t1T, t2T, nocc, nvir, b, c, a, idx3);
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[4], t1T, t2T, nocc, nvir, c, a, b, idx4);
+                get_wv(w0, v0, wtmp, fvo, vooo, cache[5], t1T, t2T, nocc, nvir, c, b, a, idx5);
+        } else {
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[0], t1T, t2T, nocc, nvir, a, b, c,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx0);
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[1], t1T, t2T, nocc, nvir, a, c, b,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx1);
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[2], t1T, t2T, nocc, nvir, b, a, c,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx2);
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[3], t1T, t2T, nocc, nvir, b, c, a,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx3);
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[4], t1T, t2T, nocc, nvir, c, a, b,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx4);
+                sym_wv(w0, v0, wtmp, fvo, vooo, cache[5], t1T, t2T, nocc, nvir, c, b, a,
+                       nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym, idx5);
+        }
+        add_and_permute(z0, w0, v0, nocc);
+
+        double et;
+        if (a == c) {
+                et = _get_energy_aaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, 1./6);
+        } else if (a == b || b == c) {
+                et = _get_energy_aaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, .5);
+        } else {
+                et = _get_energy_aaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, 1.);
+        }
+        return et;
+}
+
+void CCulnoccsd_t_aaa(double *e_tot,
+                      double *mo_energy, double *t1T, double *t2T,
+                      double *vooo, double *fvo,
+                      double *ulo, int nlo,
+                      int nocc, int nvir, int a0, int a1, int b0, int b1,
+                      int nirrep, int *o_ir_loc, int *v_ir_loc,
+                      int *oo_ir_loc, int *orbsym,
+                      void *cache_row_a, void *cache_col_a,
+                      void *cache_row_b, void *cache_col_b)
+{
+        int da = a1 - a0;
+        int db = b1 - b0;
+        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
+                                        cache_row_a, cache_col_a,
+                                        cache_row_b, cache_col_b, sizeof(double));
+        double *fvohalf = malloc(sizeof(double) * nvir*nocc);
+        int i;
+        for (i = 0; i < nvir*nocc; i++) {
+                fvohalf[i] = fvo[i] * .5;
+        }
+
+        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        _make_permute_indices(permute_idx, nocc);
+
+#pragma omp parallel default(none) \
+        shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
+               v_ir_loc, oo_ir_loc, orbsym, vooo, fvohalf, jobs, e_tot, \
+               permute_idx, stderr, nlo, ulo)
+{
+        int a, b, c;
+        size_t k;
+        double *cache1 = malloc(sizeof(double) * (nocc*nocc*nocc*3+2+6*nocc));
+        if (cache1 == NULL) {
+                fprintf(stderr, "malloc(%zu) failed in CCulnoccsd_t_aaa\n",
+                        sizeof(double) * (nocc*nocc*nocc*3+6*nocc));
+                exit(1);
+        }
+        double e = 0;
+#pragma omp for schedule (dynamic, 4)
+        for (k = 0; k < njobs; k++) {
+                a = jobs[k].a;
+                b = jobs[k].b;
+                c = jobs[k].c;
+                e += contract6_aaa(nocc, nvir, a, b, c, mo_energy, t1T, t2T,
+                                  nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym,
+                                  fvohalf, vooo, ulo, nlo, cache1, jobs[k].cache,
+                                  permute_idx);
+        }
+        free(cache1);
+#pragma omp critical
+        *e_tot += e;
+}
+        free(permute_idx);
+        free(fvohalf);
+        free(jobs);
+}
+
+
+/*************************************************
+ *
+ * UCCSD(T) beta-alpha-alpha
+ *
+ *************************************************/
+static void get_wv_baa(double *w, double *v, double **vs_ts, double **cache,
+                       int nocca, int noccb, int nvira, int nvirb,
+                       int a, int b, int c, double *cache1)
+{
+        double *fvo = vs_ts[2];
+        double *fVO = vs_ts[3];
+        double *vooo = vs_ts[4];
+        double *vOoO = vs_ts[5];
+        double *VoOo = vs_ts[6];
+        double *t1aT = vs_ts[7];
+        double *t1bT = vs_ts[8];
+        double *t2aaT = vs_ts[9];
+        double *t2abT = vs_ts[10];
+        double *vvop = cache[0];
+        double *vVoP = cache[1];
+        double *VvOp = cache[2];
+        const double D0 = 0;
+        const double D1 = 1;
+        const double D2 = 2;
+        const char TRANS_T = 'T';
+        const char TRANS_N = 'N';
+        const int nmoa = nocca + nvira;
+        const int nmob = noccb + nvirb;
+        const int noo = nocca * nocca;
+        const int nOo = noccb * nocca;
+        const size_t nooo = nocca * noo;
+        const size_t noOo = nocca * nOo;
+        const size_t nOoO = noccb * nOo;
+        const size_t nvoo = nvira * noo;
+        const int nVoO = nvirb * nOo;
+        int i, j, k, n;
+
+        /*
+ * t2aaT = t2aa.transpose(2,3,0,1)
+ * w  = numpy.einsum('ejI,ke->Ijk', t2abT[:,a], vvov) * 2
+ * w += numpy.einsum('EjI,kE->Ijk', t2abT[b,:], vVoV) * 2
+ * w += numpy.einsum('mj,mIk->Ijk', t2aaT[b,c], VoOo[a,:])
+ * w += numpy.einsum('kM,MjI->Ijk', t2abT[b,a], vOoO[c,:]) * 2
+ * w += numpy.einsum('ejk,Ie->Ijk', t2aaT[b,:], VvOv)
+ * w += numpy.einsum('mI,mjk->Ijk', t2abT[b,a], vooo[c,:]) * 2
+ * v  = numpy.einsum('kj,I->Ijk', vvoo, t1bT[a])
+ * v += numpy.einsum('Ik,j->Ijk', VvOo, t1aT[b]) * 2
+ * v += numpy.einsum('jk,I->Ijk', t2aaT[b,c], fVO[a]) * .5
+ * v += numpy.einsum('kI,j->Ijk', t2abT[c,a], fvo[b]) * 2
+ * v += w
+ */
+        dgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &nvira,
+               &D2, vvop+nocca, &nmoa, t2abT+a*nOo, &nVoO,
+               &D0, v, &nocca);
+        dgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &nvirb,
+               &D2, vVoP+noccb, &nmob, t2abT+b*(size_t)nVoO, &nOo,
+               &D1, v, &nocca);
+        dgemm_(&TRANS_N, &TRANS_T, &nOo, &nocca, &nocca,
+               &D1, VoOo+a*noOo, &nOo, t2aaT+b*nvoo+c*noo, &nocca,
+               &D1, v, &nOo);
+        dgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &noccb,
+               &D2, t2abT+b*(size_t)nVoO+a*nOo, &noccb, vOoO+c*nOoO, &nOo,
+               &D1, v, &nocca);
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                w[n] = v[j*nOo+i*nocca+k];
+        } } }
+        dgemm_(&TRANS_N, &TRANS_N, &noo, &noccb, &nvira,
+               &D1, t2aaT+b*nvoo, &noo, VvOp+nocca, &nmoa,
+               &D1, w, &noo);
+        dgemm_(&TRANS_N, &TRANS_T, &noo, &noccb, &nocca,
+               &D2, vooo+c*nooo, &noo, t2abT+b*(size_t)nVoO+a*nOo, &noccb,
+               &D1, w, &noo);
+
+        double *t1aT2 = cache1;
+        double *fvo2 = t1aT2 + nocca;
+        double *fVOhalf = fvo2 + nocca;
+        for (i = 0; i < nocca; i++) {
+                t1aT2[i] = t1aT[b*nocca+i] * 2;
+                fvo2[i] = fvo[b*nocca+i] * 2;
+        }
+        for (i = 0; i < noccb; i++) {
+                fVOhalf[i] = fVO[a*noccb+i] * .5;
+        }
+        double *pt2aaT = t2aaT + b * nvoo + c * noo;
+        double *pt2abT = t2abT + (c*nvirb+a) * nOo;
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                v[n] = (w[n] + vvop[k*nmoa+j] * t1bT[a*noccb+i]
+                        + VvOp[i*nmoa+k] * t1aT2[j]
+                        + pt2aaT[j*nocca+k] * fVOhalf[i]
+                        + pt2abT[k*noccb+i] * fvo2[j]);
+        } } }
+}
+
+/*
+ * w - w.transpose(0,2,1)
+ */
+static void permute_baa(double *out, double *w, int nocca, int noccb)
+{
+        int noo = nocca * nocca;
+        int n;
+        int i, j, k;
+
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                out[n] = w[i*noo+j*nocca+k] - w[i*noo+k*nocca+j];
+        } } }
+}
+
+static double _get_energy_baa_lo(double *z0, double *z1, double *w0, double *w1,
+                                 double *mo_ea, double *mo_eb,
+                                 double *uloa, int nloa, double *ulob, int nlob,
+                                 double *cache, int nocca, int noccb,
+                                 int a, int b, int c, double fac)
+{
+        int noo = nocca * nocca;
+        int i, j, k, mu;
+        double abc = mo_eb[noccb+a] + mo_ea[nocca+b] + mo_ea[nocca+c];
+        double *tb = cache;
+        double *zb = tb + noccb;
+        double *ta = zb + noccb;
+        double *za = ta + nocca;
+        double et = 0;
+        double denom;
+        double tlo, zlo;
+        double *ulo_mu;
+
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++) {
+        for (i = 0; i < noccb; i++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                tb[i] = w0[idx0] + w1[idx1];
+                zb[i] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nlob; mu++) {
+                ulo_mu = ulob + mu * noccb;
+                tlo = 0;
+                zlo = 0;
+                for (i = 0; i < noccb; i++) {
+                        tlo += tb[i] * ulo_mu[i];
+                        zlo += zb[i] * ulo_mu[i];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+
+        for (i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                ta[k] = w0[idx0] + w1[idx1];
+                za[k] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nloa; mu++) {
+                ulo_mu = uloa + mu * nocca;
+                tlo = 0;
+                zlo = 0;
+                for (k = 0; k < nocca; k++) {
+                        tlo += ta[k] * ulo_mu[k];
+                        zlo += za[k] * ulo_mu[k];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+
+        for (i = 0; i < noccb; i++) {
+        for (k = 0; k < nocca; k++) {
+        for (j = 0; j < nocca; j++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                ta[j] = w0[idx0] + w1[idx1];
+                za[j] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nloa; mu++) {
+                ulo_mu = uloa + mu * nocca;
+                tlo = 0;
+                zlo = 0;
+                for (j = 0; j < nocca; j++) {
+                        tlo += ta[j] * ulo_mu[j];
+                        zlo += za[j] * ulo_mu[j];
+                }
+                et -= fac / 3. * tlo * zlo;
+        } } }
+        return et;
+}
+
+static double contract6_baa(int nocca, int noccb, int nvira, int nvirb,
+                            int a, int b, int c,
+                            double **vs_ts, void **cache, double *cache1,
+                            double *uloa, int nloa, double *ulob, int nlob)
+{
+        int nOoo = noccb * nocca * nocca;
+        double *v0 = cache1;
+        double *v1 = v0 + nOoo;
+        double *w0 = v1 + nOoo;
+        double *w1 = w0 + nOoo;
+        double *z0 = w1 + nOoo;
+        double *z1 = v0;
+        cache1 += nOoo * 5;
+
+        get_wv_baa(w0, v0, vs_ts, ((double **)cache)  , nocca, noccb, nvira, nvirb, a, b, c, cache1);
+        get_wv_baa(w1, v1, vs_ts, ((double **)cache)+3, nocca, noccb, nvira, nvirb, a, c, b, cache1);
+        permute_baa(z0, v0, nocca, noccb);
+        permute_baa(z1, v1, nocca, noccb);
+
+        double *mo_ea = vs_ts[0];
+        double *mo_eb = vs_ts[1];
+        double et;
+        if (b == c) {
+                et = _get_energy_baa_lo(z0, z1, w0, w1, mo_ea, mo_eb, uloa, nloa, ulob, nlob, cache1, nocca, noccb, a, b, c, .5);
+        } else {
+                et = _get_energy_baa_lo(z0, z1, w0, w1, mo_ea, mo_eb, uloa, nloa, ulob, nlob, cache1, nocca, noccb, a, b, c, 1.);
+        }
+        return et;
+}
+
+
+static size_t gen_baa_jobs(CacheJob *jobs,
+                           int nocca, int noccb, int nvira, int nvirb,
+                           int a0, int a1, int b0, int b1,
+                           void *cache_row_a, void *cache_col_a,
+                           void *cache_row_b, void *cache_col_b, size_t stride)
+{
+        size_t nov = nocca * (nocca+nvira) * stride;
+        size_t noV = nocca * (noccb+nvirb) * stride;
+        size_t nOv = noccb * (nocca+nvira) * stride;
+        int da = a1 - a0;
+        int db = b1 - b0;
+        int a, b, c;
+
+        size_t m = 0;
+        for (a = a0; a < a1; a++) {
+        for (b = b0; b < b1; b++) {
+        for (c = 0; c <= b; c++, m++) {
+                jobs[m].a = a;
+                jobs[m].b = b;
+                jobs[m].c = c;
+                if (c < b0) {
+                        jobs[m].cache[0] = cache_col_b + nov*(db*(c   )+b-b0);
+                } else {
+                        jobs[m].cache[0] = cache_row_b + nov*(b1*(c-b0)+b   );
+                }
+                jobs[m].cache[1] = cache_col_a + noV*(da   *(c   )+a-a0);
+                jobs[m].cache[2] = cache_row_a + nOv*(nvira*(a-a0)+c   );
+                jobs[m].cache[3] = cache_row_b + nov*(b1   *(b-b0)+c   );
+                jobs[m].cache[4] = cache_col_a + noV*(da   *(b   )+a-a0);
+                jobs[m].cache[5] = cache_row_a + nOv*(nvira*(a-a0)+b   );
+        } } }
+        return m;
+}
+
+void CCulnoccsd_t_baa(double *e_tot,
+                      double *mo_ea, double *mo_eb,
+                      double *t1aT, double *t1bT, double *t2aaT, double *t2abT,
+                      double *vooo, double *vOoO, double *VoOo,
+                      double *fvo, double *fVO,
+                      double *uloa, int nloa, double *ulob, int nlob,
+                      int nocca, int noccb, int nvira, int nvirb,
+                      int a0, int a1, int b0, int b1,
+                      void *cache_row_a, void *cache_col_a,
+                      void *cache_row_b, void *cache_col_b)
+{
+        int da = a1 - a0;
+        int db = b1 - b0;
+        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        size_t njobs = gen_baa_jobs(jobs, nocca, noccb, nvira, nvirb,
+                                    a0, a1, b0, b1,
+                                    cache_row_a, cache_col_a,
+                                    cache_row_b, cache_col_b, sizeof(double));
+        double *vs_ts[] = {mo_ea, mo_eb, fvo, fVO, vooo, vOoO, VoOo,
+                t1aT, t1bT, t2aaT, t2abT};
+
+#pragma omp parallel default(none) \
+        shared(njobs, nocca, noccb, nvira, nvirb, vs_ts, jobs, e_tot, stderr, nloa, nlob, uloa, ulob)
+        {
+        int a, b, c;
+        size_t k;
+        double *cache1 = malloc(sizeof(double) * (noccb*nocca*nocca*5+1 +
+                                                        nocca*2+noccb*2));
+        if (cache1 == NULL) {
+                fprintf(stderr, "malloc(%zu) failed in CCulnoccsd_t_baa\n",
+                        sizeof(double) * noccb*nocca*nocca*5);
+                exit(1);
+        }
+        double e = 0;
+#pragma omp for schedule (dynamic, 4)
+        for (k = 0; k < njobs; k++) {
+                a = jobs[k].a;
+                b = jobs[k].b;
+                c = jobs[k].c;
+                e += contract6_baa(nocca, noccb, nvira, nvirb, a, b, c, vs_ts,
+                                   jobs[k].cache, cache1, uloa, nloa, ulob, nlob);
+        }
+        free(cache1);
+#pragma omp critical
+        *e_tot += e;
+        }
+        free(jobs);
+}
+
+
+
+/*
+ * Complex version of all functions
+ */
+static void zadd_and_permute(double complex *out, double complex *w,
+                             double complex *v, int n)
+{
+        int nn = n * n;
+        int nnn = nn * n;
+        int i, j, k;
+
+        for (i = 0; i < nnn; i++) {
+                v[i] += w[i];
+        }
+
+        for (i = 0; i < n; i++) {
+        for (j = 0; j < n; j++) {
+        for (k = 0; k < n; k++) {
+                out[i*nn+j*n+k] = v[i*nn+j*n+k] + v[j*nn+k*n+i] + v[k*nn+i*n+j]
+                                - v[k*nn+j*n+i] - v[i*nn+k*n+j] - v[j*nn+i*n+k];
+        } } }
+}
+
+static void zget_wv(double complex *w, double complex *v, double complex *cache,
+                    double complex *fvohalf, double complex *vooo,
+                    double complex *vv_op, double complex *t1T, double complex *t2T,
+                    int nocc, int nvir, int a, int b, int c, int *idx)
+{
+        const double complex D0 = 0;
+        const double complex D1 = 1;
+        const double complex DN1 =-1;
+        const char TRANS_N = 'N';
+        const char TRANS_T = 'T';
+        const int nmo = nocc + nvir;
+        const int noo = nocc * nocc;
+        const size_t nooo = nocc * noo;
+        const size_t nvoo = nvir * noo;
+        int i, j, k, n;
+        double complex *pt2T;
+
+        zgemm_(&TRANS_N, &TRANS_N, &noo, &nocc, &nvir,
+               &DN1, t2T+c*nvoo, &noo, vv_op+nocc, &nmo,
+               &D0, cache, &noo);
+        zgemm_(&TRANS_N, &TRANS_T, &nocc, &noo, &nocc,
+               &DN1, t2T+b*nvoo+c*noo, &nocc, vooo+a*nooo, &noo,
+               &D1, cache, &nocc);
+
+        pt2T = t2T + a * nvoo + b * noo;
+        for (n = 0, i = 0; i < nocc; i++) {
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++, n++) {
+                w[idx[n]] += cache[n];
+                v[idx[n]] +=(vv_op[i*nmo+j] * t1T[c*nocc+k]
+                           + pt2T[i*nocc+j] * fvohalf[c*nocc+k]);
+        } } }
+}
+
+static double
+_get_energy_zaaa_lo(double complex *w, double complex *z, double *mo_energy, double complex *cache,
+                    double complex *ulo, int nlo,
+                    int nocc, int a, int b, int c, double fac)
+{
+        int i, j, k, mu;
+        int nn = nocc * nocc;
+        double abc = mo_energy[nocc+a] + mo_energy[nocc+b] + mo_energy[nocc+c];
+        double complex *ti = cache;
+        double complex *zi = ti + nocc;
+        double complex *tj = zi + nocc;
+        double complex *zj = tj + nocc;
+        double complex *tk = zj + nocc;
+        double complex *zk = tk + nocc;
+        double complex tlo, zlo;
+        double denom;
+        double et = 0;
+        double complex *ulo_mu;
+
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++) {
+        for (i = 0; i < nocc; i++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                ti[i] = w[ijk];
+                zi[i] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (i = 0; i < nocc; i++) {
+                        tlo += ti[i] * conj(ulo_mu[i]);
+                        zlo += zi[i] * conj(ulo_mu[i]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+
+        for (i = 0; i < nocc; i++) {
+        for (k = 0; k < nocc; k++) {
+        for (j = 0; j < nocc; j++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                tj[j] = w[ijk];
+                zj[j] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (j = 0; j < nocc; j++) {
+                        tlo += tj[j] * conj(ulo_mu[j]);
+                        zlo += zj[j] * conj(ulo_mu[j]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+
+        for (i = 0; i < nocc; i++) {
+        for (j = 0; j < nocc; j++) {
+        for (k = 0; k < nocc; k++) {
+                int ijk = i * nn + j * nocc + k;
+                denom = abc - (mo_energy[i] + mo_energy[j] + mo_energy[k]);
+                tk[k] = w[ijk];
+                zk[k] = z[ijk] / denom;
+        } for (mu = 0; mu < nlo; mu++) {
+                ulo_mu = ulo + mu * nocc;
+                tlo = 0;
+                zlo = 0;
+                for (k = 0; k < nocc; k++) {
+                        tlo += tk[k] * conj(ulo_mu[k]);
+                        zlo += zk[k] * conj(ulo_mu[k]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+        return et;
+}
+
+static double complex
+zcontract6_aaa(int nocc, int nvir, int a, int b, int c,
+               double *mo_energy, double complex *t1T, double complex *t2T,
+               int nirrep, int *o_ir_loc, int *v_ir_loc,
+               int *oo_ir_loc, int *orbsym,
+               double complex *ulo, int nlo,
+               double complex *fvo,
+               double complex *vooo, double complex *cache1, void **cache,
+               int *permute_idx)
+{
+        int nooo = nocc * nocc * nocc;
+        int *idx0 = permute_idx;
+        int *idx1 = idx0 + nooo;
+        int *idx2 = idx1 + nooo;
+        int *idx3 = idx2 + nooo;
+        int *idx4 = idx3 + nooo;
+        int *idx5 = idx4 + nooo;
+        double complex *v0 = cache1;
+        double complex *w0 = v0 + nooo;
+        double complex *z0 = w0 + nooo;
+        double complex *cache2 = z0 + nooo;
+        double complex *wtmp = z0;
+        int i;
+
+        for (i = 0; i < nooo; i++) {
+                w0[i] = 0;
+                v0[i] = 0;
+        }
+
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[0], t1T, t2T, nocc, nvir, a, b, c, idx0);
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[1], t1T, t2T, nocc, nvir, a, c, b, idx1);
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[2], t1T, t2T, nocc, nvir, b, a, c, idx2);
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[3], t1T, t2T, nocc, nvir, b, c, a, idx3);
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[4], t1T, t2T, nocc, nvir, c, a, b, idx4);
+        zget_wv(w0, v0, wtmp, fvo, vooo, cache[5], t1T, t2T, nocc, nvir, c, b, a, idx5);
+        zadd_and_permute(z0, w0, v0, nocc);
+
+        double complex et;
+        if (a == c) {
+                et = _get_energy_zaaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, 1./6);
+        } else if (a == b || b == c) {
+                et = _get_energy_zaaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, .5);
+        } else {
+                et = _get_energy_zaaa_lo(w0, z0, mo_energy, cache2, ulo, nlo, nocc, a, b, c, 1.);
+        }
+        return et;
+}
+
+void CCulnoccsd_t_zaaa(double complex *e_tot,
+                       double *mo_energy, double complex *t1T, double complex *t2T,
+                       double complex *vooo, double complex *fvo,
+                       double complex *ulo, int nlo,
+                       int nocc, int nvir, int a0, int a1, int b0, int b1,
+                       int nirrep, int *o_ir_loc, int *v_ir_loc,
+                       int *oo_ir_loc, int *orbsym,
+                       void *cache_row_a, void *cache_col_a,
+                       void *cache_row_b, void *cache_col_b)
+{
+        int da = a1 - a0;
+        int db = b1 - b0;
+        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
+                                        cache_row_a, cache_col_a,
+                                        cache_row_b, cache_col_b,
+                                        sizeof(double complex));
+        double complex *fvohalf = malloc(sizeof(double complex) * nvir*nocc);
+        int i;
+        for (i = 0; i < nvir*nocc; i++) {
+                fvohalf[i] = fvo[i] * .5;
+        }
+
+        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        _make_permute_indices(permute_idx, nocc);
+
+#pragma omp parallel default(none) \
+        shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
+               v_ir_loc, oo_ir_loc, orbsym, vooo, fvohalf, jobs, e_tot, \
+               permute_idx, stderr, nlo, ulo)
+{
+        int a, b, c;
+        size_t k;
+        double complex *cache1 = malloc(sizeof(double complex) *
+                                        (nocc*nocc*nocc*3+2+6*nocc));
+        if (cache1 == NULL) {
+                fprintf(stderr, "malloc(%zu) failed in CCulnoccsd_t_zaaa\n",
+                        sizeof(double complex) * (nocc*nocc*nocc*3+6*nocc));
+                exit(1);
+        }
+        double complex e = 0;
+#pragma omp for schedule (dynamic, 4)
+        for (k = 0; k < njobs; k++) {
+                a = jobs[k].a;
+                b = jobs[k].b;
+                c = jobs[k].c;
+                e += zcontract6_aaa(nocc, nvir, a, b, c, mo_energy, t1T, t2T,
+                                    nirrep, o_ir_loc, v_ir_loc, oo_ir_loc, orbsym,
+                                    ulo, nlo,
+                                    fvohalf, vooo, cache1, jobs[k].cache,
+                                    permute_idx);
+        }
+        free(cache1);
+#pragma omp critical
+        *e_tot += e;
+}
+        free(permute_idx);
+        free(fvohalf);
+        free(jobs);
+}
+
+
+/*************************************************
+ *
+ * UCCSD(T) beta-alpha-alpha
+ *
+ *************************************************/
+static void zget_wv_baa(double complex *w, double complex *v,
+                        double complex **vs_ts, double complex **cache,
+                        int nocca, int noccb, int nvira, int nvirb,
+                        int a, int b, int c, double complex *cache1)
+{
+        double complex *fvo = vs_ts[2];
+        double complex *fVO = vs_ts[3];
+        double complex *vooo = vs_ts[4];
+        double complex *vOoO = vs_ts[5];
+        double complex *VoOo = vs_ts[6];
+        double complex *t1aT = vs_ts[7];
+        double complex *t1bT = vs_ts[8];
+        double complex *t2aaT = vs_ts[9];
+        double complex *t2abT = vs_ts[10];
+        double complex *vvop = cache[0];
+        double complex *vVoP = cache[1];
+        double complex *VvOp = cache[2];
+        const double complex D0 = 0;
+        const double complex D1 = 1;
+        const double complex D2 = 2;
+        const char TRANS_T = 'T';
+        const char TRANS_N = 'N';
+        const int nmoa = nocca + nvira;
+        const int nmob = noccb + nvirb;
+        const int noo = nocca * nocca;
+        const int nOo = noccb * nocca;
+        const size_t nooo = nocca * noo;
+        const size_t noOo = nocca * nOo;
+        const size_t nOoO = noccb * nOo;
+        const size_t nvoo = nvira * noo;
+        const int nVoO = nvirb * nOo;
+        int i, j, k, n;
+
+        zgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &nvira,
+               &D2, vvop+nocca, &nmoa, t2abT+a*nOo, &nVoO,
+               &D0, v, &nocca);
+        zgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &nvirb,
+               &D2, vVoP+noccb, &nmob, t2abT+b*(size_t)nVoO, &nOo,
+               &D1, v, &nocca);
+        zgemm_(&TRANS_N, &TRANS_T, &nOo, &nocca, &nocca,
+               &D1, VoOo+a*noOo, &nOo, t2aaT+b*nvoo+c*noo, &nocca,
+               &D1, v, &nOo);
+        zgemm_(&TRANS_T, &TRANS_T, &nocca, &nOo, &noccb,
+               &D2, t2abT+b*(size_t)nVoO+a*nOo, &noccb, vOoO+c*nOoO, &nOo,
+               &D1, v, &nocca);
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                w[n] = v[j*nOo+i*nocca+k];
+        } } }
+        zgemm_(&TRANS_N, &TRANS_N, &noo, &noccb, &nvira,
+               &D1, t2aaT+b*nvoo, &noo, VvOp+nocca, &nmoa,
+               &D1, w, &noo);
+        zgemm_(&TRANS_N, &TRANS_T, &noo, &noccb, &nocca,
+               &D2, vooo+c*nooo, &noo, t2abT+b*(size_t)nVoO+a*nOo, &noccb,
+               &D1, w, &noo);
+
+        double complex *t1aT2 = cache1;
+        double complex *fvo2 = t1aT2 + nocca;
+        double complex *fVOhalf = fvo2 + nocca;
+        for (i = 0; i < nocca; i++) {
+                t1aT2[i] = t1aT[b*nocca+i] * 2;
+                fvo2[i] = fvo[b*nocca+i] * 2;
+        }
+        for (i = 0; i < noccb; i++) {
+                fVOhalf[i] = fVO[a*noccb+i] * .5;
+        }
+        double complex *pt2aaT = t2aaT + b * nvoo + c * noo;
+        double complex *pt2abT = t2abT + (c*nvirb+a) * nOo;
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                v[n] = (w[n] + vvop[k*nmoa+j] * t1bT[a*noccb+i]
+                        + VvOp[i*nmoa+k] * t1aT2[j]
+                        + pt2aaT[j*nocca+k] * fVOhalf[i]
+                        + pt2abT[k*noccb+i] * fvo2[j]);
+        } } }
+}
+
+/*
+ * w - w.transpose(0,2,1)
+ */
+static void zpermute_baa(double complex *out, double complex *w, int nocca, int noccb)
+{
+        int noo = nocca * nocca;
+        int n;
+        int i, j, k;
+
+        for (n = 0, i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++, n++) {
+                out[n] = w[i*noo+j*nocca+k] - w[i*noo+k*nocca+j];
+        } } }
+}
+
+static double
+_get_energy_zbaa_lo(double complex *z0, double complex *z1,
+                    double complex *w0, double complex *w1,
+                    double *mo_ea, double *mo_eb,
+                    double complex *uloa, int nloa, double complex *ulob, int nlob,
+                    double complex *cache, int nocca, int noccb,
+                    int a, int b, int c, double fac)
+{
+        int noo = nocca * nocca;
+        int i, j, k, mu;
+        double abc = mo_eb[noccb+a] + mo_ea[nocca+b] + mo_ea[nocca+c];
+        double complex *tb = cache;
+        double complex *zb = tb + noccb;
+        double complex *ta = zb + noccb;
+        double complex *za = ta + nocca;
+        double et = 0;
+        double denom;
+        double complex tlo, zlo;
+        double complex *ulo_mu;
+
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++) {
+        for (i = 0; i < noccb; i++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                tb[i] = w0[idx0] + w1[idx1];
+                zb[i] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nlob; mu++) {
+                ulo_mu = ulob + mu * noccb;
+                tlo = 0;
+                zlo = 0;
+                for (i = 0; i < noccb; i++)
+                {
+                        tlo += tb[i] * conj(ulo_mu[i]);
+                        zlo += zb[i] * conj(ulo_mu[i]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+
+        for (i = 0; i < noccb; i++) {
+        for (j = 0; j < nocca; j++) {
+        for (k = 0; k < nocca; k++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                ta[k] = w0[idx0] + w1[idx1];
+                za[k] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nloa; mu++) {
+                ulo_mu = uloa + mu * nocca;
+                tlo = 0;
+                zlo = 0;
+                for (k = 0; k < nocca; k++)
+                {
+                        tlo += ta[k] * conj(ulo_mu[k]);
+                        zlo += za[k] * conj(ulo_mu[k]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+
+        for (i = 0; i < noccb; i++) {
+        for (k = 0; k < nocca; k++) {
+        for (j = 0; j < nocca; j++) {
+                int idx0 = i * noo + j * nocca + k;
+                int idx1 = i * noo + k * nocca + j;
+                denom = abc - (mo_eb[i] + mo_ea[j] + mo_ea[k]);
+                ta[j] = w0[idx0] + w1[idx1];
+                za[j] = (z0[idx0] + z1[idx1]) / denom;
+        } for (mu = 0; mu < nloa; mu++) {
+                ulo_mu = uloa + mu * nocca;
+                tlo = 0;
+                zlo = 0;
+                for (j = 0; j < nocca; j++)
+                {
+                        tlo += ta[j] * conj(ulo_mu[j]);
+                        zlo += za[j] * conj(ulo_mu[j]);
+                }
+                et -= fac / 3. * creal(tlo * conj(zlo));
+        } } }
+        return et;
+}
+
+static double complex
+zcontract6_baa(int nocca, int noccb, int nvira, int nvirb,
+               int a, int b, int c,
+               double complex **vs_ts, void **cache, double complex *cache1,
+               double complex *uloa, int nloa, double complex *ulob, int nlob)
+{
+        int nOoo = noccb * nocca * nocca;
+        double complex *v0 = cache1;
+        double complex *v1 = v0 + nOoo;
+        double complex *w0 = v1 + nOoo;
+        double complex *w1 = w0 + nOoo;
+        double complex *z0 = w1 + nOoo;
+        double complex *z1 = v0;
+        cache1 += nOoo * 5;
+
+        zget_wv_baa(w0, v0, vs_ts, ((double complex **)cache)  , nocca, noccb, nvira, nvirb, a, b, c, cache1);
+        zget_wv_baa(w1, v1, vs_ts, ((double complex **)cache)+3, nocca, noccb, nvira, nvirb, a, c, b, cache1);
+        zpermute_baa(z0, v0, nocca, noccb);
+        zpermute_baa(z1, v1, nocca, noccb);
+
+        double *mo_ea = (double *)vs_ts[0];
+        double *mo_eb = (double *)vs_ts[1];
+        double complex et;
+        if (b == c) {
+                et = _get_energy_zbaa_lo(z0, z1, w0, w1, mo_ea, mo_eb, uloa, nloa, ulob, nlob, cache1, nocca, noccb, a, b, c, .5);
+        } else {
+                et = _get_energy_zbaa_lo(z0, z1, w0, w1, mo_ea, mo_eb, uloa, nloa, ulob, nlob, cache1, nocca, noccb, a, b, c, 1.);
+        }
+        return et;
+}
+
+
+void CCulnoccsd_t_zbaa(double complex *e_tot,
+                       double *mo_ea, double *mo_eb,
+                       double complex *t1aT, double complex *t1bT,
+                       double complex *t2aaT, double complex *t2abT,
+                       double complex *vooo, double complex *vOoO, double complex *VoOo,
+                       double complex *fvo, double complex *fVO,
+                       double complex *uloa, int nloa, double complex *ulob, int nlob,
+                       int nocca, int noccb, int nvira, int nvirb,
+                       int a0, int a1, int b0, int b1,
+                       void *cache_row_a, void *cache_col_a,
+                       void *cache_row_b, void *cache_col_b)
+{
+        int da = a1 - a0;
+        int db = b1 - b0;
+        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        size_t njobs = gen_baa_jobs(jobs, nocca, noccb, nvira, nvirb,
+                                    a0, a1, b0, b1,
+                                    cache_row_a, cache_col_a,
+                                    cache_row_b, cache_col_b,
+                                    sizeof(double complex));
+        double complex *vs_ts[] = {(double complex *)mo_ea,
+                (double complex *)mo_eb, fvo, fVO, vooo, vOoO, VoOo,
+                t1aT, t1bT, t2aaT, t2abT};
+
+#pragma omp parallel default(none) \
+        shared(njobs, nocca, noccb, nvira, nvirb, vs_ts, jobs, e_tot, stderr, nloa, nlob, uloa, ulob)
+{
+        int a, b, c;
+        size_t k;
+        double complex *cache1 = malloc(sizeof(double complex) *
+                                        (noccb*nocca*nocca*5+1 +
+                                        nocca*2+noccb*2));
+        if (cache1 == NULL) {
+                fprintf(stderr, "malloc(%zu) failed in CCulnoccsd_t_zbaa\n",
+                        sizeof(double complex) * noccb*nocca*nocca*5);
+                exit(1);
+        }
+        double complex e = 0;
+#pragma omp for schedule (dynamic, 4)
+        for (k = 0; k < njobs; k++) {
+                a = jobs[k].a;
+                b = jobs[k].b;
+                c = jobs[k].c;
+                e += zcontract6_baa(nocca, noccb, nvira, nvirb, a, b, c, vs_ts,
+                                    jobs[k].cache, cache1, uloa, nloa, ulob, nlob);
+        }
+        free(cache1);
+#pragma omp critical
+        *e_tot += e;
+        }
+        free(jobs);
+}
+

--- a/pyscf/lno/lnoccsd_t.py
+++ b/pyscf/lno/lnoccsd_t.py
@@ -46,7 +46,7 @@ def kernel(mycc, eris, ulo, t1=None, t2=None, verbose=logger.NOTE):
     r''' (T) energy correction normalized to LOs.
 
     Args:
-        ulo[mu,i] = <mu|i> is the overlap between the mu-th LO and the i-th occ MO.
+        ulo[i,mu] = <i|mu> is the overlap between the i-th occ MO and the mu-th LO.
     '''
     cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mycc, verbose)

--- a/pyscf/lno/test/test_ulnoccsd_t.py
+++ b/pyscf/lno/test/test_ulnoccsd_t.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from functools import reduce
+import unittest
+import numpy as np
+from pyscf import gto, scf, cc, lo
+from pyscf.lno.ulnoccsd_t import kernel as ULNOCCSD_T_kernel
+from pyscf.lno.ulnoccsd_t_slow import kernel as ULNOCCSD_T_slow_kernel
+
+
+class WaterDimer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 4
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O   -1.485163346097   -0.114724564047    0.000000000000
+        H   -1.868415346097    0.762298435953    0.000000000000
+        H   -0.533833346097    0.040507435953    0.000000000000
+        O    1.416468653903    0.111264435953    0.000000000000
+        H    1.746241653903   -0.373945564047   -0.758561000000
+        H    1.746241653903   -0.373945564047    0.758561000000
+        '''
+        mol.spin = 2
+        mol.basis = '631g'
+        mol.build()
+        mf = scf.UHF(mol).density_fit().run()
+
+        frozen = 2
+
+        cls.mol = mol
+        cls.mf = mf
+        cls.frozen = frozen
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+        del cls.mol, cls.mf, cls.frozen
+
+    def test_ulno_t(self):
+        mol = self.mol
+        mf = self.mf
+        frozen = self.frozen
+
+        # PM localization
+        orbocc = list()
+        lo_coeff = list()
+        for s in range(2):
+            orbocc.append(mf.mo_coeff[s][:,frozen:np.count_nonzero(mf.mo_occ[s])])
+            mlo = lo.PipekMezey(mol, orbocc[s])
+            lo_coeff_s = mlo.kernel()
+            for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
+                stable, lo_coeff1_s = mlo.stability_jacobi()
+                if stable:
+                    break
+                mlo = lo.PipekMezey(mf.mol, lo_coeff1_s).set(verbose=4)
+                mlo.init_guess = None
+                lo_coeff_s = mlo.kernel()
+            lo_coeff.append(lo_coeff_s)
+
+        s1e = mf.get_ovlp()
+        uocc_loc = (reduce(np.dot, (orbocc[0].T.conj(), s1e, lo_coeff[0])),
+                    reduce(np.dot, (orbocc[1].T.conj(), s1e, lo_coeff[1])))
+
+        # Fragment list: for PM, every orbital corresponds to a fragment
+        oa = [[[i],[]] for i in range(orbocc[0].shape[1])]
+        ob = [[[],[i]] for i in range(orbocc[1].shape[1])]
+        frag_lolist = oa + ob
+
+        mcc = cc.CCSD(mf, frozen=frozen)
+        eris = mcc.ao2mo()
+        _, t1, t2 = mcc.kernel(eris=eris)
+
+        for frag in frag_lolist:
+            prjlo = uocc_loc[0][:, frag[0]].T.conj(), uocc_loc[1][:, frag[1]].T.conj()
+            slow_et = ULNOCCSD_T_slow_kernel(mcc, eris, prjlo, t1=t1, t2=t2)
+            fast_et = ULNOCCSD_T_kernel(mcc, eris, prjlo, t1=t1, t2=t2)
+            self.assertAlmostEqual(slow_et, fast_et, 10)
+
+if __name__ == "__main__":
+    print("Full Tests for LNO-CCSD(T)")
+    unittest.main()

--- a/pyscf/lno/ulnoccsd.py
+++ b/pyscf/lno/ulnoccsd.py
@@ -373,8 +373,8 @@ def impurity_solve(mcc, mo_coeff, uocc_loc, mo_occ, maskact, eris,
         elcorr_cc = get_fragment_energy(imp_eris, t1, t2, prjlo)
         cput1 = log.timer_debug1('imp sol - cc  ene', *cput1)
         if ccsd_t:
-            from pyscf.lno.ulnoccsd_t_slow import kernel as UCCSD_T
-            elcorr_cc_t = UCCSD_T(mcc, imp_eris, prjlo, t1=t1, t2=t2)
+            from pyscf.lno.ulnoccsd_t import kernel as UCCSD_T
+            elcorr_cc_t = UCCSD_T(mcc, imp_eris, prjlo, t1=t1, t2=t2, verbose=verbose_imp)
             cput1 = log.timer_debug1('imp sol - cc  (T)', *cput1)
         else:
             elcorr_cc_t = 0.

--- a/pyscf/lno/ulnoccsd_t.py
+++ b/pyscf/lno/ulnoccsd_t.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#         Yu Jin <yjin@flatironinstitute.org>
+#
+
+'''
+ULNO-UCCSD(T)
+'''
+
+
+import ctypes
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.cc.uccsd_t import _sort_eri
+
+
+libcc = lib.load_library('liblno')
+CCulnoccsd_t_aaa  = libcc.CCulnoccsd_t_aaa
+CCulnoccsd_t_zaaa = libcc.CCulnoccsd_t_zaaa
+CCulnoccsd_t_baa  = libcc.CCulnoccsd_t_baa
+CCulnoccsd_t_zbaa = libcc.CCulnoccsd_t_zbaa
+
+
+def kernel(mycc, eris, prjlo, t1=None, t2=None, verbose=logger.NOTE):
+    '''
+    adapted from pyscf.cc.uccsd_t
+
+    Args:
+       prjlo[mu,i] = <mu|i> is the overlap between the mu-th LO and the i-th occ MO.
+    '''
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
+    log = logger.new_logger(mycc, verbose)
+    if t1 is None: t1 = mycc.t1
+    if t2 is None: t2 = mycc.t2
+    t1a, t1b = t1
+    t2aa, t2ab, t2bb = t2
+    prjloa, prjlob = prjlo
+
+    nocca, noccb = mycc.nocc
+    nmoa = eris.focka.shape[0]
+    nmob = eris.fockb.shape[0]
+    nvira = nmoa - nocca
+    nvirb = nmob - noccb
+
+    if prjloa.shape[1] != nocca:
+        raise ValueError(f'Alpha projector shape {prjloa.shape} does not match nocca={nocca}')
+    if prjlob.shape[1] != noccb:
+        raise ValueError(f'Beta projector shape {prjlob.shape} does not match noccb={noccb}')
+
+    dtype = numpy.result_type(t1a, t1b, t2aa, t2ab, t2bb, eris.ovoo.dtype)
+    prjloa = numpy.asarray(prjloa, dtype=dtype, order='C')
+    prjlob = numpy.asarray(prjlob, dtype=dtype, order='C')
+
+    et_sum = numpy.zeros(1, dtype=dtype)
+    if mycc.incore_complete:
+        ftmp = None
+    else:
+        ftmp = lib.H5TmpFile()
+    t1aT = t1a.T.copy()
+    t1bT = t1b.T.copy()
+    t2aaT = t2aa.transpose(2,3,0,1).copy()
+    t2bbT = t2bb.transpose(2,3,0,1).copy()
+
+    eris_vooo = numpy.asarray(eris.ovoo).transpose(1,3,0,2).conj().copy()
+    eris_VOOO = numpy.asarray(eris.OVOO).transpose(1,3,0,2).conj().copy()
+    eris_vOoO = numpy.asarray(eris.ovOO).transpose(1,3,0,2).conj().copy()
+    eris_VoOo = numpy.asarray(eris.OVoo).transpose(1,3,0,2).conj().copy()
+
+    eris_vvop, eris_VVOP, eris_vVoP, eris_VvOp = _sort_eri(mycc, eris, ftmp, log)
+    cpu1 = log.timer_debug1('UCCSD(T) sort_eri', *cpu1)
+
+    mem_now = lib.current_memory()[0]
+    max_memory = max(0, mycc.max_memory - mem_now)
+    # aaa
+    bufsize = max(8, int((max_memory*.5e6/8-nocca**3*3*lib.num_threads())*.4/max(1,nocca*nmoa)))
+    log.debug('max_memory %d MB (%d MB in use)', max_memory, mem_now)
+    orbsym = numpy.zeros(nocca, dtype=int)
+    contract = _gen_contract_aaa(t1aT, t2aaT, eris_vooo, eris.focka,
+                                 eris.mo_energy[0], prjloa, orbsym, log)
+    with lib.call_in_background(contract, sync=not mycc.async_io) as ctr:
+        for a0, a1 in reversed(list(lib.prange_tril(0, nvira, bufsize))):
+            cache_row_a = numpy.asarray(eris_vvop[a0:a1,:a1], order='C')
+            if a0 == 0:
+                cache_col_a = cache_row_a
+            else:
+                cache_col_a = numpy.asarray(eris_vvop[:a0,a0:a1], order='C')
+            ctr(et_sum, a0, a1, a0, a1, (cache_row_a,cache_col_a,
+                                         cache_row_a,cache_col_a))
+
+            for b0, b1 in lib.prange_tril(0, a0, max(1, bufsize//8)):
+                cache_row_b = numpy.asarray(eris_vvop[b0:b1,:b1], order='C')
+                if b0 == 0:
+                    cache_col_b = cache_row_b
+                else:
+                    cache_col_b = numpy.asarray(eris_vvop[:b0,b0:b1], order='C')
+                ctr(et_sum, a0, a1, b0, b1, (cache_row_a,cache_col_a,
+                                             cache_row_b,cache_col_b))
+    cpu1 = log.timer_debug1('contract_aaa', *cpu1)
+
+    # bbb
+    bufsize = max(8, int((max_memory*.5e6/8-noccb**3*3*lib.num_threads())*.4/max(1,noccb*nmob)))
+    log.debug('max_memory %d MB (%d MB in use)', max_memory, mem_now)
+    orbsym = numpy.zeros(noccb, dtype=int)
+    contract = _gen_contract_aaa(t1bT, t2bbT, eris_VOOO, eris.fockb,
+                                 eris.mo_energy[1], prjlob, orbsym, log)
+    with lib.call_in_background(contract, sync=not mycc.async_io) as ctr:
+        for a0, a1 in reversed(list(lib.prange_tril(0, nvirb, bufsize))):
+            cache_row_a = numpy.asarray(eris_VVOP[a0:a1,:a1], order='C')
+            if a0 == 0:
+                cache_col_a = cache_row_a
+            else:
+                cache_col_a = numpy.asarray(eris_VVOP[:a0,a0:a1], order='C')
+            ctr(et_sum, a0, a1, a0, a1, (cache_row_a,cache_col_a,
+                                         cache_row_a,cache_col_a))
+
+            for b0, b1 in lib.prange_tril(0, a0, max(1, bufsize//8)):
+                cache_row_b = numpy.asarray(eris_VVOP[b0:b1,:b1], order='C')
+                if b0 == 0:
+                    cache_col_b = cache_row_b
+                else:
+                    cache_col_b = numpy.asarray(eris_VVOP[:b0,b0:b1], order='C')
+                ctr(et_sum, a0, a1, b0, b1, (cache_row_a,cache_col_a,
+                                             cache_row_b,cache_col_b))
+    cpu1 = log.timer_debug1('contract_bbb', *cpu1)
+
+    # Premature termination for fully spin-polarized systems
+    if nocca*noccb == 0:
+        et_sum *= .25
+        if abs(et_sum[0].imag) > 1e-4:
+            logger.warn(mycc, 'Non-zero imaginary part of UCCSD(T) energy was found %s',
+                        et_sum[0])
+        et = et_sum[0].real
+        log.timer('UCCSD(T)', *cpu0)
+        log.note('UCCSD(T) correction = %.15g', et)
+        return et
+
+    # Cache t2abT in t2ab to reduce memory footprint
+    assert (t2ab.flags.c_contiguous)
+    t2abT = lib.transpose(t2ab.copy().reshape(nocca*noccb,nvira*nvirb), out=t2ab)
+    t2abT = t2abT.reshape(nvira,nvirb,nocca,noccb)
+    # baa
+    bufsize = int(max(12, (max_memory*.5e6/8-noccb*nocca**2*5)*.7/max(1,nocca*nmob)))
+    ts = t1aT, t1bT, t2aaT, t2abT
+    fock = (eris.focka, eris.fockb)
+    vooo = (eris_vooo, eris_vOoO, eris_VoOo)
+    contract = _gen_contract_baa(ts, vooo, fock, eris.mo_energy, (prjloa, prjlob), log)
+    with lib.call_in_background(contract, sync=not mycc.async_io) as ctr:
+        for a0, a1 in lib.prange(0, nvirb, int(bufsize/nvira+1)):
+            cache_row_a = numpy.asarray(eris_VvOp[a0:a1,:], order='C')
+            cache_col_a = numpy.asarray(eris_vVoP[:,a0:a1], order='C')
+            for b0, b1 in lib.prange_tril(0, nvira, max(1, bufsize//12)):
+                cache_row_b = numpy.asarray(eris_vvop[b0:b1,:b1], order='C')
+                cache_col_b = numpy.asarray(eris_vvop[:b0,b0:b1], order='C')
+                ctr(et_sum, a0, a1, b0, b1, (cache_row_a,cache_col_a,
+                                             cache_row_b,cache_col_b))
+    cpu1 = log.timer_debug1('contract_baa', *cpu1)
+
+    t2baT = numpy.ndarray((nvirb,nvira,noccb,nocca), buffer=t2abT,
+                          dtype=t2abT.dtype)
+    t2baT[:] = t2abT.copy().transpose(1,0,3,2)
+    # abb
+    ts = t1bT, t1aT, t2bbT, t2baT
+    fock = (eris.fockb, eris.focka)
+    mo_energy = (eris.mo_energy[1], eris.mo_energy[0])
+    vooo = (eris_VOOO, eris_VoOo, eris_vOoO)
+    contract = _gen_contract_baa(ts, vooo, fock, mo_energy, (prjlob, prjloa), log)
+    for a0, a1 in lib.prange(0, nvira, int(bufsize/nvirb+1)):
+        with lib.call_in_background(contract, sync=not mycc.async_io) as ctr:
+            cache_row_a = numpy.asarray(eris_vVoP[a0:a1,:], order='C')
+            cache_col_a = numpy.asarray(eris_VvOp[:,a0:a1], order='C')
+            for b0, b1 in lib.prange_tril(0, nvirb, max(1, bufsize//12)):
+                cache_row_b = numpy.asarray(eris_VVOP[b0:b1,:b1], order='C')
+                cache_col_b = numpy.asarray(eris_VVOP[:b0,b0:b1], order='C')
+                ctr(et_sum, a0, a1, b0, b1, (cache_row_a,cache_col_a,
+                                             cache_row_b,cache_col_b))
+    cpu1 = log.timer_debug1('contract_abb', *cpu1)
+
+    # Restore t2ab
+    lib.transpose(t2baT.transpose(1,0,3,2).copy().reshape(nvira*nvirb,nocca*noccb),
+                  out=t2ab)
+    et_sum *= .25
+    if abs(et_sum[0].imag) > 1e-4:
+        logger.warn(mycc, 'Non-zero imaginary part of UCCSD(T) energy was found %s',
+                    et_sum[0])
+    et = et_sum[0].real
+    log.timer('UCCSD(T)', *cpu0)
+    log.note('UCCSD(T) correction = %.15g', et)
+    return et
+
+
+def _gen_contract_aaa(t1T, t2T, vooo, fock, mo_energy, prjlo, orbsym, log):
+    nvir, nocc = t1T.shape
+    nlo = prjlo.shape[0]
+    mo_energy = numpy.asarray(mo_energy, order='C')
+    fvo = numpy.asarray(fock[nocc:, :nocc], dtype=t1T.dtype, order='C')
+    prjlo = numpy.asarray(prjlo, dtype=t1T.dtype, order='C')
+
+    cpu2 = [logger.process_clock(), logger.perf_counter()]
+    orbsym = numpy.hstack((numpy.sort(orbsym[:nocc]), numpy.sort(orbsym[nocc:])))
+    o_ir_loc = numpy.append(0, numpy.cumsum(numpy.bincount(orbsym[:nocc], minlength=8)))
+    v_ir_loc = numpy.append(0, numpy.cumsum(numpy.bincount(orbsym[nocc:], minlength=8)))
+    o_sym = orbsym[:nocc]
+    oo_sym = (o_sym[:, None] ^ o_sym).ravel()
+    oo_ir_loc = numpy.append(0, numpy.cumsum(numpy.bincount(oo_sym, minlength=8)))
+    if len(oo_sym) == 0:
+        nirrep = 0
+    else:
+        nirrep = max(oo_sym) + 1
+
+    orbsym = orbsym.astype(numpy.int32)
+    o_ir_loc = o_ir_loc.astype(numpy.int32)
+    v_ir_loc = v_ir_loc.astype(numpy.int32)
+    oo_ir_loc = oo_ir_loc.astype(numpy.int32)
+    dtype = numpy.result_type(t2T.dtype, vooo.dtype, fock.dtype)
+    if dtype == numpy.complex128:
+        drv = CCulnoccsd_t_zaaa
+    else:
+        drv = CCulnoccsd_t_aaa
+
+    def contract(et_sum, a0, a1, b0, b1, cache):
+        cache_row_a, cache_col_a, cache_row_b, cache_col_b = cache
+        drv(et_sum.ctypes.data_as(ctypes.c_void_p),
+            mo_energy.ctypes.data_as(ctypes.c_void_p),
+            t1T.ctypes.data_as(ctypes.c_void_p),
+            t2T.ctypes.data_as(ctypes.c_void_p),
+            vooo.ctypes.data_as(ctypes.c_void_p),
+            fvo.ctypes.data_as(ctypes.c_void_p),
+            prjlo.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nlo),
+            ctypes.c_int(nocc), ctypes.c_int(nvir),
+            ctypes.c_int(a0), ctypes.c_int(a1),
+            ctypes.c_int(b0), ctypes.c_int(b1),
+            ctypes.c_int(nirrep),
+            o_ir_loc.ctypes.data_as(ctypes.c_void_p),
+            v_ir_loc.ctypes.data_as(ctypes.c_void_p),
+            oo_ir_loc.ctypes.data_as(ctypes.c_void_p),
+            orbsym.ctypes.data_as(ctypes.c_void_p),
+            cache_row_a.ctypes.data_as(ctypes.c_void_p),
+            cache_col_a.ctypes.data_as(ctypes.c_void_p),
+            cache_row_b.ctypes.data_as(ctypes.c_void_p),
+            cache_col_b.ctypes.data_as(ctypes.c_void_p))
+        cpu2[:] = log.timer_debug1('contract %d:%d,%d:%d' % (a0, a1, b0, b1), *cpu2)
+    return contract
+
+def _gen_contract_baa(ts, vooo, fock, mo_energy, prjlo, log):
+    t1aT, t1bT, t2aaT, t2abT = ts
+    focka, fockb = fock
+    vooo, vOoO, VoOo = vooo
+    prjloa, prjlob = prjlo
+    nvira, nocca = t1aT.shape
+    nvirb, noccb = t1bT.shape
+    nloa = prjloa.shape[0]
+    nlob = prjlob.shape[0]
+    mo_ea = numpy.asarray(mo_energy[0], order='C')
+    mo_eb = numpy.asarray(mo_energy[1], order='C')
+    fvo = numpy.asarray(focka[nocca:, :nocca], dtype=t1aT.dtype, order='C')
+    fVO = numpy.asarray(fockb[noccb:, :noccb], dtype=t1bT.dtype, order='C')
+    prjloa = numpy.asarray(prjloa, dtype=t1aT.dtype, order='C')
+    prjlob = numpy.asarray(prjlob, dtype=t1aT.dtype, order='C')
+
+    cpu2 = [logger.process_clock(), logger.perf_counter()]
+    dtype = numpy.result_type(t2aaT.dtype, vooo.dtype, prjloa.dtype, prjlob.dtype)
+    if dtype == numpy.complex128:
+        drv = CCulnoccsd_t_zbaa
+    else:
+        drv = CCulnoccsd_t_baa
+    def contract(et_sum, a0, a1, b0, b1, cache):
+        cache_row_a, cache_col_a, cache_row_b, cache_col_b = cache
+        drv(et_sum.ctypes.data_as(ctypes.c_void_p),
+            mo_ea.ctypes.data_as(ctypes.c_void_p),
+            mo_eb.ctypes.data_as(ctypes.c_void_p),
+            t1aT.ctypes.data_as(ctypes.c_void_p),
+            t1bT.ctypes.data_as(ctypes.c_void_p),
+            t2aaT.ctypes.data_as(ctypes.c_void_p),
+            t2abT.ctypes.data_as(ctypes.c_void_p),
+            vooo.ctypes.data_as(ctypes.c_void_p),
+            vOoO.ctypes.data_as(ctypes.c_void_p),
+            VoOo.ctypes.data_as(ctypes.c_void_p),
+            fvo.ctypes.data_as(ctypes.c_void_p),
+            fVO.ctypes.data_as(ctypes.c_void_p),
+            prjloa.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nloa),
+            prjlob.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nlob),
+            ctypes.c_int(nocca), ctypes.c_int(noccb),
+            ctypes.c_int(nvira), ctypes.c_int(nvirb),
+            ctypes.c_int(a0), ctypes.c_int(a1),
+            ctypes.c_int(b0), ctypes.c_int(b1),
+            cache_row_a.ctypes.data_as(ctypes.c_void_p),
+            cache_col_a.ctypes.data_as(ctypes.c_void_p),
+            cache_row_b.ctypes.data_as(ctypes.c_void_p),
+            cache_col_b.ctypes.data_as(ctypes.c_void_p))
+        cpu2[:] = log.timer_debug1('contract %d:%d,%d:%d' % (a0, a1, b0, b1), *cpu2)
+    return contract


### PR DESCRIPTION
This PR introduces a fast implementation of `ulnoccsd_t.py`, based on `pyscf.cc.uccsd_t.py`.

- Switches `ULNOCCSD_T` to use the fast implementation by default (replacing `ulnoccsd_t_slow.py`)
- Adds unit tests to validate correctness