### PR TITLE
Debug PySCF 2.13.0 (#191)

### DIFF
--- a/pyscf/csf_fci/csf.py
+++ b/pyscf/csf_fci/csf.py
@@ -566,6 +566,9 @@ class FCISolver (CSFFCISolver, direct_spin1.FCISolver):
         return get_init_guess (norb, nelec, nroots, hdiag_csf, self.transformer)
 
     def kernel(self, h1e, eri, norb, nelec, ci0=None, **kwargs):
+        # Assume we are passed "remaining memory" if max_memory is a kwarg
+        if 'max_memory' in kwargs:
+            kwargs['max_memory'] += lib.current_memory ()[0]
         self.norb = norb
         self.nelec = nelec
         if 'smult' in kwargs:

--- a/pyscf/csf_fci/csf_symm.py
+++ b/pyscf/csf_fci/csf_symm.py
@@ -34,6 +34,10 @@ class FCISolver (CSFFCISolver, direct_spin1_symm.FCISolver):
         ''' Over the top of the existing kernel, I just need to set the parameters and cache values related to spin.
 
         ...and electron configuration point group '''
+
+        # Assume we are passed "remaining memory" if max_memory is a kwarg
+        if 'max_memory' in kwargs:
+            kwargs['max_memory'] += lib.current_memory ()[0]
         log = logger.new_logger (self, self.verbose)
         gpname = getattr (self.mol, 'groupname', None)
         if gpname in ('Dooh', 'Coov'):

--- a/pyscf/csf_fci/csf_symm.py
+++ b/pyscf/csf_fci/csf_symm.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy
-from pyscf import symm, __config__
+from pyscf import symm, __config__, lib
 from pyscf.lib import logger, davidson1
 from pyscf.fci import direct_spin1_symm, cistring, direct_uhf
 from pyscf.lib.numpy_helper import tag_array

--- a/pyscf/csf_fci/csfstring.py
+++ b/pyscf/csf_fci/csfstring.py
@@ -938,9 +938,6 @@ def get_spin_evecs (nspin, neleca, nelecb, smult, max_memory=param.MAX_MEMORY):
     mem_reqd = ndet * ncsf * np.dtype (np.float64).itemsize / 1e6
     if max_memory < 0:
         warnings.warn ("Negative max_memory ({} MB)".format (max_memory), RuntimeWarning)
-    elif mem_rem < 0:
-        warnings.warn ("Negative available memory ({} - {} = {} MB)".format (
-            mem_current, max_memory, mem_rem), RuntimeWarning)
     elif mem_reqd > mem_rem:
         memstr = ('CSF unitary matrix for {} unpaired of {} total electrons w/ s={:.1f} is too big'
                   " ({} MB req'd of {} MB remaining; {} MB total available)").format (

--- a/pyscf/csf_fci/csfstring.py
+++ b/pyscf/csf_fci/csfstring.py
@@ -941,7 +941,7 @@ def get_spin_evecs (nspin, neleca, nelecb, smult, max_memory=param.MAX_MEMORY):
     elif mem_rem < 0:
         warnings.warn ("Negative available memory ({} - {} = {} MB)".format (
             mem_current, max_memory, mem_rem), RuntimeWarning)
-    if mem_reqd > mem_rem:
+    elif mem_reqd > mem_rem:
         memstr = ('CSF unitary matrix for {} unpaired of {} total electrons w/ s={:.1f} is too big'
                   " ({} MB req'd of {} MB remaining; {} MB total available)").format (
             nspin, neleca+nelecb, s, mem_reqd, mem_rem, max_memory)

--- a/pyscf/csf_fci/csfstring.py
+++ b/pyscf/csf_fci/csfstring.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sys, os, time
 import ctypes
+import warnings
 from pyscf.csf_fci import csdstring
 from pyscf.fci import cistring
 from pyscf.fci.spin_op import spin_square0
@@ -935,6 +936,11 @@ def get_spin_evecs (nspin, neleca, nelecb, smult, max_memory=param.MAX_MEMORY):
     mem_current = lib.current_memory ()[0]
     mem_rem = max_memory - mem_current
     mem_reqd = ndet * ncsf * np.dtype (np.float64).itemsize / 1e6
+    if max_memory < 0:
+        warnings.warn ("Negative max_memory ({} MB)".format (max_memory), RuntimeWarning)
+    elif mem_rem < 0:
+        warnings.warn ("Negative available memory ({} - {} = {} MB)".format (
+            mem_current, max_memory, mem_rem), RuntimeWarning)
     if mem_reqd > mem_rem:
         memstr = ('CSF unitary matrix for {} unpaired of {} total electrons w/ s={:.1f} is too big'
                   " ({} MB req'd of {} MB remaining; {} MB total available)").format (

--- a/pyscf/csf_fci/test/test_csfstring.py
+++ b/pyscf/csf_fci/test/test_csfstring.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from scipy import special
 from pyscf.csf_fci.csfstring import *
+from pyscf import lib
 
 def case_spin_evecs (ks, nspin, ms):
     neleca = int (round (nspin/2 + ms))

--- a/pyscf/occri/__init__.py
+++ b/pyscf/occri/__init__.py
@@ -229,15 +229,17 @@ class OCCRI(pyscf.pbc.df.fft.FFTDF):
         dm_shape = dm.shape
         nk = self.kpts.shape[0]
         nao = cell.nao
+        ndm = dm.reshape (-1, nk, nao, nao).shape[0]
         if with_k:
             if self.scf_iter == 0:
                 dm = numpy.asarray(dm)
             if getattr(dm, 'mo_coeff', None) is None:
                 dm = self.make_natural_orbitals(dm.reshape(-1, nk, nao, nao))
             else:
-                mo_coeff = numpy.asarray(dm.mo_coeff).reshape(-1, nk, nao, nao)
-                mo_occ = numpy.asarray(dm.mo_occ).reshape(-1, nk, nao)
-                dm = lib.tag_array(dm.reshape(-1, nk, nao, nao), mo_coeff=mo_coeff, mo_occ=mo_occ)
+                mo_occ = numpy.asarray(dm.mo_occ).reshape(ndm, nk, -1)
+                nmo = mo_occ.shape[2]
+                mo_coeff = numpy.asarray(dm.mo_coeff).reshape(ndm, nk, nao, nmo)
+                dm = lib.tag_array(dm.reshape(ndm, nk, nao, nao), mo_coeff=mo_coeff, mo_occ=mo_occ)
 
         if with_j:
             vj = self.get_j(self, dm, kpts=self.kpts)

--- a/pyscf/occri/test/test_isdfx_energy.py
+++ b/pyscf/occri/test/test_isdfx_energy.py
@@ -45,7 +45,7 @@ class TestISdfxEnergyComparison(unittest.TestCase):
         self.cell_h2.basis = "gth-szv"
         self.cell_h2.pseudo = "gth-pbe"
         self.cell_h2.a = numpy.eye(3) * 6.0
-        self.cell_h2.mesh = [11] * 3
+        self.cell_h2.mesh = [21] * 3
         self.cell_h2.verbose = 0
         self.cell_h2.build()
 

--- a/pyscf/occri/test/test_occri.py
+++ b/pyscf/occri/test/test_occri.py
@@ -34,7 +34,7 @@ def setUpModule():
     cell.basis = "gth-szv"
     cell.pseudo = "gth-pbe"
     cell.a = numpy.eye(3) * 3.5607
-    cell.mesh = [17] * 3
+    cell.mesh = [21] * 3
     cell.build()
 
     # Setup proper k-point mesh

--- a/pyscf/pbc/lno/test/test_makeklnordm1.py
+++ b/pyscf/pbc/lno/test/test_makeklnordm1.py
@@ -232,29 +232,32 @@ class Water_COMPLEX(unittest.TestCase):
                               verbose=cell.verbose,stdout=cell.stdout)
         eris.build()
 
+        occ_ref = -0.06419439687135728+4.973277156424204e-05j
+        vir_ref = -0.010792752484758372-0.014791758114215927j
+
         arr = make_lo_rdm1_occ_1h_complex(eris, moeocc, moevir, uocc_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.06422719794290856+2.5105071595401036e-05j, 7)
+        self.assertAlmostEqual(fp, occ_ref, 7)
 
         arr = make_lo_rdm1_occ_1p_complex(eris, moeocc, moevir, uvir_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.06422719794290856+2.5105071595401036e-05j, 7)
+        self.assertAlmostEqual(fp, occ_ref, 7)
 
         arr = make_lo_rdm1_occ_2p_complex(eris, moeocc, moevir, uvir_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.06422719794290856+2.5105071595401036e-05j, 7)
+        self.assertAlmostEqual(fp, occ_ref, 7)
 
         arr = make_lo_rdm1_vir_1h_complex(eris, moeocc, moevir, uocc_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.002766848360192287-0.034349212190162834j, 7)
+        self.assertAlmostEqual(fp, vir_ref, 7)
 
         arr = make_lo_rdm1_vir_1p_complex(eris, moeocc, moevir, uvir_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.002766848360192287-0.034349212190162834j, 7)
+        self.assertAlmostEqual(fp, vir_ref, 7)
 
         arr = make_lo_rdm1_vir_2h_complex(eris, moeocc, moevir, uocc_loc)
         fp = lib.fp(arr)
-        self.assertAlmostEqual(fp, -0.002766848360192287-0.034349212190162834j, 7)
+        self.assertAlmostEqual(fp, vir_ref, 7)
 
 
 

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -726,8 +726,7 @@ def _scf_to_trexio(mf, trexio_file):
             if _trexio_is_uhf_uks_mf(mf):
                 mo_type = "UHF"
                 # Check for split structure (common in KUKS/KDF): ([up...], [dn...])
-                # FIXME: this is now an ndarray rather than a tuple in PySCF 2.13.0
-                is_split_spin = isinstance(mf.mo_coeff, tuple) and len(mf.mo_coeff) == 2
+                is_split_spin = (mf.mo_coeff.ndim==4) and (mf.mo_coeff.shape[0]==2)
 
                 for i_k, _ in enumerate(kpts):
                     if is_split_spin:

--- a/pyscf/tools/trexio.py
+++ b/pyscf/tools/trexio.py
@@ -726,6 +726,7 @@ def _scf_to_trexio(mf, trexio_file):
             if _trexio_is_uhf_uks_mf(mf):
                 mo_type = "UHF"
                 # Check for split structure (common in KUKS/KDF): ([up...], [dn...])
+                # FIXME: this is now an ndarray rather than a tuple in PySCF 2.13.0
                 is_split_spin = isinstance(mf.mo_coeff, tuple) and len(mf.mo_coeff) == 2
 
                 for i_k, _ in enumerate(kpts):


### PR DESCRIPTION
- Fix memory passing in `csf_fci` (again)
- Update data format of `mo_coeff` in `trexio`
- Account for potential rank reduction in `occri`
- Finer mesh in some unit tests to restore agreement between different forms of density fitting
- Update test references in `pbc/lno` for density matrix elements that differ between versions by scientifically irrelevant phases

~There are still two unit tests that I cannot make pass without changing either the tolerance of the check or the reference value itself, in `pbc/lno` and `pbc/pwscf`. I wonder if anyone else has a commentary on those.~