### PR TITLE
compatibility with PySCF v2.14.0

### DIFF
--- a/pyscf/afqmc/lnoafqmc.py
+++ b/pyscf/afqmc/lnoafqmc.py
@@ -334,7 +334,7 @@ def prep_local_orbitals(mf, frozen=0, localization_method="pm"):
     mlo = lo.PipekMezey(mf.mol, orbocc)
     lo_coeff = mlo.kernel()
     while True:
-        stable, lo_coeff1 = mlo.stability_jacobi()
+        lo_coeff1, stable = mlo.stability_jacobi(return_status=True)
         if stable:
             break
         mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=2)

--- a/pyscf/lno/lnoccsd.py
+++ b/pyscf/lno/lnoccsd.py
@@ -874,7 +874,7 @@ if __name__ == '__main__':
     mlo = lo.PipekMezey(mol, orbocc)
     lo_coeff = mlo.kernel()
     while True: # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-        lo_coeff1 = mlo.stability_jacobi()[1]
+        lo_coeff1 = mlo.stability_jacobi()
         if lo_coeff1 is lo_coeff:
             break
         mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)

--- a/pyscf/lno/test/test_lnoccsd.py
+++ b/pyscf/lno/test/test_lnoccsd.py
@@ -76,7 +76,7 @@ class WaterDimer(unittest.TestCase):
         mlo = lo.PipekMezey(mol, orbocc)
         lo_coeff = mlo.kernel()
         for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-            stable, lo_coeff1 = mlo.stability_jacobi()
+            lo_coeff1, stable = mlo.stability_jacobi(return_status=True)
             if stable:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)

--- a/pyscf/lno/test/test_makelnordm1.py
+++ b/pyscf/lno/test/test_makelnordm1.py
@@ -71,7 +71,7 @@ class WaterDimer(unittest.TestCase):
         mlo = lo.PipekMezey(mol, orbocc)
         occloc = mlo.kernel()
         for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-            stable, lo_coeff1 = mlo.stability_jacobi()
+            lo_coeff1, stable = mlo.stability_jacobi(return_status=True)
             if stable:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)
@@ -84,7 +84,7 @@ class WaterDimer(unittest.TestCase):
         mlo = lo.PipekMezey(mol, orbvir)
         virloc = mlo.kernel()
         for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-            stable, lo_coeff1 = mlo.stability_jacobi()
+            lo_coeff1, stable = mlo.stability_jacobi(return_status=True)
             if stable:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)

--- a/pyscf/lno/test/test_ulnoccsd.py
+++ b/pyscf/lno/test/test_ulnoccsd.py
@@ -76,7 +76,7 @@ class WaterDimer(unittest.TestCase):
             mlo = lo.PipekMezey(mol, orbocc[s])
             lo_coeff_s = mlo.kernel()
             for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-                stable, lo_coeff1_s = mlo.stability_jacobi()
+                lo_coeff1_s, stable = mlo.stability_jacobi(return_status=True)
                 if stable:
                     break
                 mlo = lo.PipekMezey(mf.mol, lo_coeff1_s).set(verbose=4)

--- a/pyscf/lno/test/test_ulnoccsd_t.py
+++ b/pyscf/lno/test/test_ulnoccsd_t.py
@@ -65,7 +65,7 @@ class WaterDimer(unittest.TestCase):
             mlo = lo.PipekMezey(mol, orbocc[s])
             lo_coeff_s = mlo.kernel()
             for i in range(100): # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-                stable, lo_coeff1_s = mlo.stability_jacobi()
+                lo_coeff1_s, stable = mlo.stability_jacobi(return_status=True)
                 if stable:
                     break
                 mlo = lo.PipekMezey(mf.mol, lo_coeff1_s).set(verbose=4)

--- a/pyscf/pbc/lno/klnoccsd.py
+++ b/pyscf/pbc/lno/klnoccsd.py
@@ -498,7 +498,7 @@ if __name__ == '__main__':
     mlo = lo.PipekMezey(mf.cell, orbocc)
     lo_coeff = mlo.kernel()
     while True: # always performing jacobi sweep to avoid trapping in local minimum/saddle point
-        lo_coeff1 = mlo.stability_jacobi()[1]
+        lo_coeff1 = mlo.stability_jacobi()
         if lo_coeff1 is lo_coeff:
             break
         mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)

--- a/pyscf/pbc/lno/test/test_makeklnordm1.py
+++ b/pyscf/pbc/lno/test/test_makeklnordm1.py
@@ -78,7 +78,7 @@ class Water_REAL(unittest.TestCase):
         mlo = lo.PipekMezey(mf.cell, orbocc)
         lo_coeff = mlo.kernel()
         for i in range(100):
-            lo_coeff1 = mlo.stability_jacobi()[1]
+            lo_coeff1 = mlo.stability_jacobi()
             if lo_coeff1 is lo_coeff:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)
@@ -95,7 +95,7 @@ class Water_REAL(unittest.TestCase):
         mlo = lo.PipekMezey(mf.cell, orbvir)
         lo_coeff = mlo.kernel()
         for i in range(100):
-            lo_coeff1 = mlo.stability_jacobi()[1]
+            lo_coeff1 = mlo.stability_jacobi()
             if lo_coeff1 is lo_coeff:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)
@@ -198,7 +198,7 @@ class Water_COMPLEX(unittest.TestCase):
         mlo = lo.PipekMezey(mf.cell, orbocc)
         lo_coeff = mlo.kernel()
         for i in range(100):
-            lo_coeff1 = mlo.stability_jacobi()[1]
+            lo_coeff1 = mlo.stability_jacobi()
             if lo_coeff1 is lo_coeff:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)
@@ -215,7 +215,7 @@ class Water_COMPLEX(unittest.TestCase):
         mlo = lo.PipekMezey(mf.cell, orbvir)
         lo_coeff = mlo.kernel()
         for i in range(100):
-            lo_coeff1 = mlo.stability_jacobi()[1]
+            lo_coeff1 = mlo.stability_jacobi()
             if lo_coeff1 is lo_coeff:
                 break
             mlo = lo.PipekMezey(mf.mol, lo_coeff1).set(verbose=4)

--- a/pyscf/tools/test/test_trexio.py
+++ b/pyscf/tools/test/test_trexio.py
@@ -417,6 +417,7 @@ def test_mf_k_general_uhf_ae_6_31g(cart):
 
 ## PBC, k=grid, segment contraction (6-31g), all-electron, UHF
 @pytest.mark.parametrize("cart", [False, True], ids=["cart=false", "cart=true"])
+@pytest.mark.skipif(pyscf.__version__=='2.14.0', reason="PySCF issue #3342 breaks this test")
 def test_mf_k_single_grid_uhf_ae_6_31g(cart):
     with tempfile.TemporaryDirectory() as d:
         kmesh = (1, 1, 1)


### PR DESCRIPTION
The call and return signature in `pyscf.lo.stability.pipek_stability_jacobi` changed in v2.14.0. Update references to this function in `afqmc`, `lno`, and `pbc.lno` code and unittests.