### PR TITLE
Downgrade ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install ruff
-      run: pip install ruff
+      run: pip install "ruff<0.16.0"
     - name: Check style
       run: ruff check --config .ruff.toml pyscf
     - name: Check NumPy


### PR DESCRIPTION
Ruff 0.16.0 dropped a lot of new rules that is making all lint jobs fail. We can upgrade and fix all the issues but in the mean time we should downgrade so that people don't get alarm fatigue.