### PR TITLE
Add collinear local-density matrix approximation

### DIFF
--- a/.github/workflows/run_ci.sh
+++ b/.github/workflows/run_ci.sh
@@ -12,6 +12,8 @@ python -m pip install --upgrade pip
 pip install "scipy<1.16"
 pip install pytest
 pip install .
+python -c "import sys; from pyscf import msdft; assert 'torch' not in sys.modules; assert hasattr(msdft, 'NOCI')"
+pip install "torch>=2.0"
 pip install -U jax
 
 pip install trexio

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Unreleased
+----------
+* New features
+  - Collinear local-density matrix approximation for multistate DFT
+
+
 PySCF-Forge 1.1.1 (2026-03-15)
 ------------------------------
 * Fixes

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,7 @@ recursive-include pyscf *.c *.h CMakeLists.txt
 
 # dh xccode JSON data
 recursive-include pyscf/dh *.json
+
+# licenses and documentation for bundled components
+include pyscf/msdft/ldma/LICENSE
+include pyscf/msdft/ldma/README.md

--- a/NOTICE
+++ b/NOTICE
@@ -27,3 +27,9 @@ Yu Jin
 Junjie Yang
 Hong-Zhou Ye
 Arshad Mehmood
+
+The local-density matrix approximation implementation under
+pyscf/msdft/ldma is distributed under the MIT License. It was developed by:
+
+Copyright (c) 2024 Alexander Humeniuk
+Copyright (c) 2024-2026 Yangyi Lu <luyy@szbl.ac.cn>

--- a/examples/msdft/02-ldma-h2.py
+++ b/examples/msdft/02-ldma-h2.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import torch
+from pyscf import gto
+from pyscf.msdft import ldma
+
+
+mol = gto.M(
+    atom="H 0 0 -0.35; H 0 0 0.35",
+    basis="sto-3g",
+    spin=0,
+    verbose=0,
+)
+
+matrix_density = ldma.MultistateMatrixDensityCAS.from_guess(
+    mol,
+    norb=2,
+    nelec=2,
+    spin_symmetry=True,
+    spin_type=ldma.SpinType.UNPOLARIZED,
+    guess="hcore",
+)
+hamiltonian = ldma.HamiltonianSemilocal(
+    mol,
+    spin_type=ldma.SpinType.UNPOLARIZED,
+    grid_level=0,
+)
+
+energies = torch.linalg.eigvalsh(hamiltonian(matrix_density))
+print("LDMA H2 energies (Hartree):", energies.tolist())

--- a/pyscf/msdft/ldma/LICENSE
+++ b/pyscf/msdft/ldma/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Alexander Humeniuk
+Copyright (c) 2024-2026 Yangyi Lu <luyy@szbl.ac.cn>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyscf/msdft/ldma/README.md
+++ b/pyscf/msdft/ldma/README.md
@@ -1,0 +1,63 @@
+# Local-Density Matrix Approximation
+
+`pyscf.msdft.ldma` implements the local-density matrix approximation (LDMA)
+for variational ground- and excited-state calculations in multistate density
+functional theory. The local exchange-correlation energy is evaluated as an
+analytic matrix function of the state and transition densities.
+
+The implementation provides Dirac exchange and Chachiyo correlation for
+unpolarized and collinearly polarized matrix densities. The polarized mode
+spin-scales exchange while retaining the original paramagnetic Chachiyo
+correlation approximation. Mixed-spin and noncollinear functionals are not
+included.
+
+## Installation
+
+Install PySCF-Forge with the LDMA optional dependency:
+
+```bash
+pip install "pyscf-forge[msdft-ldma]"
+```
+
+## Example
+
+```python
+import torch
+from pyscf import gto
+from pyscf.msdft import ldma
+
+mol = gto.M(
+    atom="H 0 0 -0.35; H 0 0 0.35",
+    basis="sto-3g",
+    spin=0,
+)
+
+matrix_density = ldma.MultistateMatrixDensityCAS.from_guess(
+    mol,
+    norb=2,
+    nelec=2,
+    spin_symmetry=True,
+    spin_type=ldma.SpinType.UNPOLARIZED,
+    guess="hcore",
+)
+hamiltonian = ldma.HamiltonianSemilocal(
+    mol,
+    spin_type=ldma.SpinType.UNPOLARIZED,
+)
+
+energies = torch.linalg.eigvalsh(hamiltonian(matrix_density))
+print(energies)
+```
+
+The standalone example in `examples/msdft/02-ldma-h2.py` uses a low-cost grid
+for a quick installation check.
+
+## References
+
+1. Y. Lu and J. Gao, *J. Phys. Chem. Lett.* **2022**, 13, 7762-7769.
+   https://doi.org/10.1021/acs.jpclett.2c02088
+2. A. Humeniuk, *J. Chem. Theory Comput.* **2024**, 20, 5497-5509.
+   https://doi.org/10.1021/acs.jctc.4c00330
+
+This component is distributed under the MIT License. See `LICENSE` in this
+directory.

--- a/pyscf/msdft/ldma/__init__.py
+++ b/pyscf/msdft/ldma/__init__.py
@@ -1,0 +1,26 @@
+"""Local-density matrix approximation for multistate DFT.
+
+This package provides the analytic Dirac exchange and Chachiyo correlation
+functionals with collinear matrix-density and Hamiltonian infrastructure.
+"""
+
+from .dft import (AOGridBatch, CASGuessComponents, ExactExchangeFunctionalAO, HamiltonianSemilocal,
+                  HamiltonianTargetStateLDMA, LDA, PureXCFunctional,
+                  MultistateMatrixDensityCAS,
+                  MultistateMatrixDensityKohnSham, SpinType,
+                  TargetStateMultistateMatrixDensityCAS, lda_c_chachiyo,
+                  lda_x_dirac, lda_xc_dirac_chachiyo,
+                  cas_guess_components, index_within_multiplicity,
+                  lda_xc_dirac_chachiyo_unpolarized,
+                  merge_multiplet_energies,
+                  minimize_subspace_energy)
+
+__all__ = [
+    "AOGridBatch", "CASGuessComponents", "ExactExchangeFunctionalAO", "HamiltonianSemilocal",
+    "HamiltonianTargetStateLDMA", "LDA", "PureXCFunctional",
+    "MultistateMatrixDensityCAS", "MultistateMatrixDensityKohnSham", "SpinType",
+    "TargetStateMultistateMatrixDensityCAS", "lda_c_chachiyo", "lda_x_dirac",
+    "lda_xc_dirac_chachiyo", "lda_xc_dirac_chachiyo_unpolarized",
+    "cas_guess_components", "index_within_multiplicity", "merge_multiplet_energies",
+    "minimize_subspace_energy",
+]

--- a/pyscf/msdft/ldma/dft/__init__.py
+++ b/pyscf/msdft/ldma/dft/__init__.py
@@ -1,0 +1,24 @@
+"""Density-functional building blocks for LDMA."""
+
+from .density import (AOGridBatch, CASGuessComponents, MultistateMatrixDensityCAS,
+                      MultistateMatrixDensityKohnSham,
+                      TargetStateMultistateMatrixDensityCAS,
+                      cas_guess_components)
+from .hamiltonian import (HamiltonianSemilocal, HamiltonianTargetStateLDMA,
+                          minimize_subspace_energy)
+from .exact_exchange import ExactExchangeFunctionalAO
+from .pure import LDA, PureXCFunctional
+from .spin import (SpinType, index_within_multiplicity,
+                   merge_multiplet_energies)
+from .xc import (lda_c_chachiyo, lda_x_dirac, lda_xc_dirac_chachiyo,
+                 lda_xc_dirac_chachiyo_unpolarized)
+
+__all__ = [
+    "AOGridBatch", "CASGuessComponents", "ExactExchangeFunctionalAO", "HamiltonianSemilocal",
+    "HamiltonianTargetStateLDMA", "LDA", "PureXCFunctional",
+    "MultistateMatrixDensityCAS", "MultistateMatrixDensityKohnSham", "SpinType",
+    "TargetStateMultistateMatrixDensityCAS", "lda_c_chachiyo", "lda_x_dirac",
+    "lda_xc_dirac_chachiyo", "lda_xc_dirac_chachiyo_unpolarized",
+    "cas_guess_components", "index_within_multiplicity", "merge_multiplet_energies",
+    "minimize_subspace_energy",
+]

--- a/pyscf/msdft/ldma/dft/active_space.py
+++ b/pyscf/msdft/ldma/dft/active_space.py
@@ -1,0 +1,145 @@
+"""Collinear determinant active spaces used by LDMA matrix densities."""
+
+import numpy
+from pyscf.fci.addons import _unpack_nelec
+from pyscf.fci.cistring import make_strings
+
+
+class ActiveSpaceError(ValueError):
+    pass
+
+
+def int2binvec(value, width):
+    """Return a least-significant-bit-first binary vector of fixed width."""
+    return numpy.asarray([(value >> index) & 1 for index in range(width)])
+
+
+def _bits(value, width):
+    return int2binvec(value, width)
+
+
+def _annihilate(det, orbital):
+    if not ((det >> orbital) & 1):
+        return None
+    phase = -1.0 if bin(det & ((1 << orbital) - 1)).count("1") % 2 else 1.0
+    return det ^ (1 << orbital), phase
+
+
+def _create(det, orbital):
+    if (det >> orbital) & 1:
+        return None
+    phase = -1.0 if bin(det & ((1 << orbital) - 1)).count("1") % 2 else 1.0
+    return det | (1 << orbital), phase
+
+
+class ActiveSpace:
+    """Determinants with one fixed spin projection and bounded excitation rank."""
+
+    def __init__(self, norb, nelec, max_level=numpy.inf, spin_range=None):
+        self.norb = norb
+        self.max_level = max_level
+        neleca, nelecb = _unpack_nelec(nelec)
+        self.nelec = neleca + nelecb
+        if spin_range is None:
+            spin_range = [neleca - nelecb]
+        self.spin_range = list(spin_range)
+        for spin in self.spin_range:
+            if spin % 2 != self.nelec % 2:
+                raise ActiveSpaceError("2*Sz and the electron count must have the same parity")
+
+    def slater_determinants(self):
+        determinants = []
+        orbitals = range(self.norb)
+        for neleca in range(self.nelec + 1):
+            nelecb = self.nelec - neleca
+            if neleca > self.norb or nelecb > self.norb:
+                continue
+            if neleca - nelecb not in self.spin_range:
+                continue
+            reference = (((1 << neleca) - 1) << self.norb) | ((1 << nelecb) - 1)
+            for alpha in make_strings(orbitals, neleca):
+                for beta in make_strings(orbitals, nelecb):
+                    det = (int(alpha) << self.norb) | int(beta)
+                    if bin(det & ~reference).count("1") <= self.max_level:
+                        determinants.append(det)
+        return determinants
+
+    def occupation_labels(self):
+        labels = []
+        for det in self.slater_determinants():
+            occupations = _bits(det, 2 * self.norb)
+            label = ""
+            for orbital in range(self.norb):
+                beta = occupations[orbital]
+                alpha = occupations[self.norb + orbital]
+                label += "2" if alpha and beta else "a" if alpha else "b" if beta else "."
+            labels.append(label)
+        return labels
+
+    def spin_projection_sz(self):
+        result = []
+        for det in self.slater_determinants():
+            occupations = _bits(det, 2 * self.norb)
+            result.append(0.5 * (sum(occupations[self.norb:]) - sum(occupations[:self.norb])))
+        return numpy.asarray(result)
+
+    def total_spin_matrix(self):
+        determinants = self.slater_determinants()
+        size = len(determinants)
+        matrix = numpy.zeros((size, size))
+        # S^2 = Sz^2 + (S+S- + S-S+)/2, evaluated by explicit spin flips.
+        index = {det: position for position, det in enumerate(determinants)}
+        for ket_index, det in enumerate(determinants):
+            sz = self.spin_projection_sz()[ket_index]
+            matrix[ket_index, ket_index] += sz * sz
+            for first_from_beta in (True, False):
+                intermediate_terms = [(det, 1.0)]
+                for from_beta in (first_from_beta, not first_from_beta):
+                    next_terms = []
+                    for current, coefficient in intermediate_terms:
+                        for orbital in range(self.norb):
+                            source = orbital if from_beta else self.norb + orbital
+                            target = self.norb + orbital if from_beta else orbital
+                            removed = _annihilate(current, source)
+                            if removed is None:
+                                continue
+                            created = _create(removed[0], target)
+                            if created is not None:
+                                next_terms.append((created[0], coefficient * removed[1] * created[1]))
+                    intermediate_terms = next_terms
+                for bra_det, coefficient in intermediate_terms:
+                    bra_index = index.get(bra_det)
+                    if bra_index is not None:
+                        matrix[bra_index, ket_index] += 0.5 * coefficient
+        return 0.5 * (matrix + matrix.T)
+
+    def matrix_density_mo(self):
+        determinants = self.slater_determinants()
+        index = {det: position for position, det in enumerate(determinants)}
+        ndet = len(determinants)
+        density = numpy.zeros((2, 2, self.norb, self.norb, ndet, ndet))
+        for ket_index, det in enumerate(determinants):
+            for spin in range(2):
+                for p in range(self.norb):
+                    for q in range(self.norb):
+                        source = q if spin == 1 else self.norb + q
+                        target = p if spin == 1 else self.norb + p
+                        removed = _annihilate(det, source)
+                        if removed is None:
+                            continue
+                        created = _create(removed[0], target)
+                        if created is None:
+                            continue
+                        bra_index = index.get(created[0])
+                        if bra_index is not None:
+                            density[spin, spin, q, p, bra_index, ket_index] = removed[1] * created[1]
+        return density
+
+    def __repr__(self):
+        return (
+            f"ActiveSpace(active orbitals: {self.norb}, active electrons: {self.nelec}, "
+            f"maximum excitation level: {self.max_level})"
+        )
+
+
+__all__ = ["ActiveSpace", "ActiveSpaceError", "int2binvec"]

--- a/pyscf/msdft/ldma/dft/configurations.py
+++ b/pyscf/msdft/ldma/dft/configurations.py
@@ -1,0 +1,82 @@
+"""Collinear determinant configuration utilities."""
+
+import numpy
+import warnings
+from pyscf.fci.addons import _unpack_nelec
+from pyscf.fci.cistring import gen_occslst, make_strings, num_strings
+from pyscf.fci.direct_spin1 import trans_rdm1s
+from pyscf.fci.spin_op import contract_ss
+
+
+def excitation_levels(norb, nelec):
+    if nelec < 0:
+        raise ValueError("nelec must be non-negative")
+    reference = (1 << nelec) - 1
+    return [bin(int(det) & ~reference).count("1") for det in make_strings(range(norb), nelec)]
+
+
+def configurations_by_excitation_levels(norb=2, nelec=2, max_level=numpy.inf):
+    neleca, nelecb = _unpack_nelec(nelec)
+    if neleca != nelecb and max_level < numpy.inf:
+        warnings.warn(
+            "For neleca != nelecb, an excitation-truncated space may contain states "
+            "with incorrect spin.", RuntimeWarning)
+    levels_a = excitation_levels(norb, neleca)
+    levels_b = excitation_levels(norb, nelecb)
+    return [
+        (ia, ib)
+        for ia in range(num_strings(norb, neleca))
+        for ib in range(num_strings(norb, nelecb))
+        if levels_a[ia] + levels_b[ib] <= max_level
+    ]
+
+
+def occupation_labels(norb=2, nelec=2, max_level=numpy.inf):
+    neleca, nelecb = _unpack_nelec(nelec)
+    occ_a = gen_occslst(range(norb), neleca)
+    occ_b = gen_occslst(range(norb), nelecb)
+    labels = []
+    for ia, ib in configurations_by_excitation_levels(norb, nelec, max_level):
+        label = ""
+        for orbital in range(norb):
+            alpha = orbital in occ_a[ia]
+            beta = orbital in occ_b[ib]
+            label += "2" if alpha and beta else "a" if alpha else "b" if beta else "."
+        labels.append(label)
+    return labels
+
+
+def total_spin_matrix(norb=2, nelec=2, max_level=numpy.inf):
+    neleca, nelecb = _unpack_nelec(nelec)
+    na = num_strings(norb, neleca)
+    nb = num_strings(norb, nelecb)
+    selected = configurations_by_excitation_levels(norb, nelec, max_level)
+    matrix = numpy.zeros((len(selected), len(selected)))
+    for ket, (ja, jb) in enumerate(selected):
+        vector = numpy.zeros((na, nb))
+        vector[ja, jb] = 1.0
+        contracted = contract_ss(vector.ravel(), norb, (neleca, nelecb))
+        for bra, (ia, ib) in enumerate(selected):
+            matrix[bra, ket] = contracted[ia, ib]
+    return matrix
+
+
+def matrix_density_mo(norb=2, nelec=2, max_level=numpy.inf):
+    neleca, nelecb = _unpack_nelec(nelec)
+    na = num_strings(norb, neleca)
+    nb = num_strings(norb, nelecb)
+    selected = configurations_by_excitation_levels(norb, nelec, max_level)
+    density = numpy.zeros((2, norb, norb, len(selected), len(selected)))
+    for ket, (ja, jb) in enumerate(selected):
+        ket_vector = numpy.zeros((na, nb))
+        ket_vector[ja, jb] = 1.0
+        for bra, (ia, ib) in enumerate(selected):
+            bra_vector = numpy.zeros((na, nb))
+            bra_vector[ia, ib] = 1.0
+            density[0, :, :, bra, ket], density[1, :, :, bra, ket] = trans_rdm1s(
+                bra_vector.ravel(), ket_vector.ravel(), norb, nelec)
+    return density
+
+
+__all__ = ["excitation_levels", "configurations_by_excitation_levels",
+           "occupation_labels", "total_spin_matrix", "matrix_density_mo"]

--- a/pyscf/msdft/ldma/dft/density.py
+++ b/pyscf/msdft/ldma/dft/density.py
@@ -1,0 +1,789 @@
+"""Collinear Kohn-Sham, CAS, and target-state matrix densities."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy
+import scipy.linalg
+import torch
+import warnings
+from pyscf.dft import numint
+from pyscf.fci.addons import _unpack_nelec
+from pyscf.scf.hf import get_hcore
+
+from .active_space import ActiveSpace, ActiveSpaceError
+from .spin import SpinType
+
+
+@dataclass(frozen=True)
+class AOGridBatch:
+    weights: Optional[torch.Tensor]
+    ao_value: torch.Tensor
+    grad_ao_value: Optional[torch.Tensor] = None
+    lapl_ao_value: Optional[torch.Tensor] = None
+
+
+@dataclass(frozen=True)
+class OneBodyOperatorTable:
+    spin_rows: torch.Tensor
+    spin_cols: torch.Tensor
+    orbital_rows: torch.Tensor
+    orbital_cols: torch.Tensor
+    det_rows: torch.Tensor
+    det_cols: torch.Tensor
+    values: torch.Tensor
+    shape: tuple
+
+
+@dataclass(frozen=True)
+class CASGuessComponents:
+    orbital_coefficients: torch.Tensor
+    orbital_rotation_params: torch.nn.Parameter
+    active_space: ActiveSpace
+    s2_matrix: torch.Tensor
+    det_to_csf: torch.Tensor
+    nstate: int
+    ndet: int
+
+
+def _spin_orbital_index(spin, orbital, norb):
+    if spin == 0:
+        return norb + orbital
+    if spin == 1:
+        return orbital
+    raise ValueError("spin index must be 0 or 1")
+
+
+def _apply_annihilation(det, spin_orbital):
+    if ((det >> spin_orbital) & 1) == 0:
+        return None
+    phase = -1.0 if bin(det & ((1 << spin_orbital) - 1)).count("1") % 2 else 1.0
+    return det ^ (1 << spin_orbital), phase
+
+
+def _apply_creation(det, spin_orbital):
+    if ((det >> spin_orbital) & 1) == 1:
+        return None
+    phase = -1.0 if bin(det & ((1 << spin_orbital) - 1)).count("1") % 2 else 1.0
+    return det | (1 << spin_orbital), phase
+
+
+def _apply_one_body_operator(det, create_spin, annihilate_spin, p, q, norb):
+    annihilated = _apply_annihilation(
+        det, _spin_orbital_index(annihilate_spin, q, norb))
+    if annihilated is None:
+        return None
+    created = _apply_creation(
+        annihilated[0], _spin_orbital_index(create_spin, p, norb))
+    if created is None:
+        return None
+    return created[0], annihilated[1] * created[1]
+
+
+def antisymmetric_matrix(elements, n):
+    expected = (n * (n - 1)) // 2
+    if elements.numel() != expected:
+        raise ValueError(f"expected {expected} independent elements, got {elements.numel()}")
+    result = torch.zeros((n, n), dtype=elements.dtype, device=elements.device)
+    rows, columns = torch.triu_indices(n, n, offset=1, device=elements.device)
+    result[rows, columns] = elements.reshape(-1)
+    result[columns, rows] = -elements.reshape(-1)
+    return result
+
+
+def stiefel_tangent_block_matrix(block, n, k):
+    if block.size() != torch.Size([n - k, k]):
+        raise ValueError(f"Stiefel block must have shape ({n-k}, {k})")
+    result = torch.zeros((n, n), dtype=block.dtype, device=block.device)
+    result[:k, k:] = -block.T
+    result[k:, :k] = block
+    return result
+
+
+def orbital_guess(mol, guess="random", seed=None):
+    nao = mol.nao_nr()
+    if isinstance(guess, numpy.ndarray):
+        if guess.shape != (nao, nao):
+            raise ValueError(f"orbital guess must have shape {(nao, nao)}")
+        return guess
+    if guess == "rohf":
+        from pyscf import scf
+        mean_field = scf.ROHF(mol)
+        mean_field.verbose = 0
+        mean_field.kernel()
+        return mean_field.mo_coeff
+    overlap = mol.intor_symmetric("int1e_ovlp")
+    if guess == "hcore":
+        matrix = get_hcore(mol)
+    elif guess == "random":
+        matrix = numpy.random.default_rng(seed).random((nao, nao))
+        matrix = 0.5 * (matrix + matrix.T)
+    else:
+        raise NotImplementedError(f"orbital guess {guess!r} is not implemented")
+    return scipy.linalg.eigh(matrix, overlap)[1]
+
+
+def reorder_active_orbitals(mol, mo_coeff, active_orbitals, nelecas):
+    active_orbitals = list(active_orbitals)
+    nelec = mol.tot_electrons()
+    nclosed = (nelec - nelecas) // 2
+    homo = (nelec + 1) // 2 - 1
+    lumo = homo + 1
+    for index, value in enumerate(active_orbitals):
+        if isinstance(value, str):
+            active_orbitals[index] = eval(
+                value, {"__builtins__": {}}, {"H": homo, "HOMO": homo, "L": lumo, "LUMO": lumo}
+            )
+    if len(set(active_orbitals)) != len(active_orbitals):
+        raise ValueError("active orbital indices must be unique")
+    result = numpy.copy(mo_coeff)
+    for frontier, active in zip(range(nclosed, nclosed + len(active_orbitals)), active_orbitals):
+        result[:, frontier], result[:, active] = mo_coeff[:, active], mo_coeff[:, frontier]
+    return result
+
+
+def _validate_spin_type(spin_type):
+    if not isinstance(spin_type, SpinType):
+        raise ValueError(f"spin_type must be a SpinType, got {spin_type!r}")
+
+
+def _validate_active_space_for_molecule(mol, norb, nelec):
+    neleca, nelecb = _unpack_nelec(nelec)
+    nactive = neleca + nelecb
+    ntotal = mol.tot_electrons()
+    if neleca > norb or nelecb > norb:
+        raise ActiveSpaceError(
+            "Active-space spin electron counts cannot exceed the number of active orbitals"
+        )
+    if nactive > ntotal:
+        raise ActiveSpaceError(
+            f"More active electrons ({nactive}) than total number of electrons ({ntotal})"
+        )
+    if ntotal % 2 != nactive % 2:
+        raise ActiveSpaceError(
+            "For odd (even) total number of electrons, number of active electrons must "
+            f"be odd (even) as well, got {ntotal} electrons in total, but {nactive} active electrons."
+        )
+    ndouble = (ntotal - nactive) // 2
+    if norb > mol.nao_nr() - ndouble:
+        raise ActiveSpaceError(
+            f"More active orbitals ({norb}) than molecular orbitals (nmo={mol.nao_nr()}) "
+            f"minus doubly occupied orbitals (ndouble={ndouble})."
+        )
+    return ndouble
+
+
+def _cas_components(mol, norb, nelec, spin_symmetry, spin_type, max_level, guess, seed):
+    _validate_spin_type(spin_type)
+    _validate_active_space_for_molecule(mol, norb, nelec)
+    neleca, nelecb = _unpack_nelec(nelec)
+    active_space = ActiveSpace(norb, nelec, max_level=max_level, spin_range=[neleca - nelecb])
+    s2 = active_space.total_spin_matrix()
+    if not len(s2):
+        raise ActiveSpaceError(f"Active space (norb={norb}, nelec={nelec}) is empty")
+    eigenvalues, eigenvectors = numpy.linalg.eigh(s2)
+    if spin_symmetry:
+        target = 0.5 * mol.spin
+        selected = numpy.flatnonzero(numpy.isclose(eigenvalues, target * (target + 1), atol=1.0e-2))
+    else:
+        selected = numpy.arange(len(eigenvalues))
+    if not len(selected):
+        raise ActiveSpaceError("There are no states with total spin matching the molecule")
+    coefficients = torch.from_numpy(orbital_guess(mol, guess, seed)).double()
+    nmo = coefficients.size(1)
+    orbital_params = torch.nn.Parameter(torch.zeros((nmo * (nmo - 1)) // 2, dtype=torch.double))
+    return (
+        coefficients,
+        orbital_params,
+        active_space,
+        torch.from_numpy(s2).double(),
+        torch.from_numpy(eigenvectors[:, selected]).double(),
+    )
+
+
+def cas_guess_components(mol, norb, nelec, spin_symmetry=True,
+                         spin_type=SpinType.UNPOLARIZED, max_level=numpy.inf,
+                         guess="hcore", seed=None):
+    values = _cas_components(
+        mol, norb, nelec, spin_symmetry, spin_type, max_level, guess, seed)
+    orbital_coefficients, orbital_params, active_space, s2_matrix, det_to_csf = values
+    return CASGuessComponents(
+        orbital_coefficients=orbital_coefficients,
+        orbital_rotation_params=orbital_params,
+        active_space=active_space,
+        s2_matrix=s2_matrix,
+        det_to_csf=det_to_csf,
+        nstate=det_to_csf.size(1),
+        ndet=det_to_csf.size(0),
+    )
+
+
+class MultistateMatrixDensity(torch.nn.Module, ABC):
+    def __init__(self, mol):
+        super().__init__()
+        self.mol = mol
+
+    @property
+    @abstractmethod
+    def number_of_states(self):
+        pass
+
+    @property
+    def number_of_electrons(self):
+        return self.mol.tot_electrons()
+
+    @property
+    def device(self):
+        return next(self.parameters(), torch.empty(0)).device
+
+    @abstractmethod
+    def density_matrices_ao(self):
+        pass
+
+    @abstractmethod
+    def spin_multiplicity(self):
+        pass
+
+    def state_weights(self):
+        return self.spin_multiplicity()
+
+    @staticmethod
+    def _check_input(tensor, name, expected_size):
+        if tensor.size() != expected_size:
+            raise ValueError(
+                f"Input '{name}' has to be of size {expected_size}, but got {tensor.size()}")
+        return tensor
+
+    def evaluate(self, coords, dm_ao=None, need_gradient=True, need_laplacian=True):
+        if dm_ao is None:
+            dm_ao = self.density_matrices_ao()
+        need_gradient = need_gradient or need_laplacian
+        deriv = 2 if need_laplacian else 1 if need_gradient else 0
+        ao = torch.from_numpy(numint.eval_ao(self.mol, coords, deriv=deriv)).to(
+            dtype=dm_ao.dtype, device=dm_ao.device
+        )
+        if deriv == 0:
+            batch = AOGridBatch(None, ao)
+        else:
+            laplacian = ao[4] + ao[7] + ao[9] if need_laplacian else None
+            batch = AOGridBatch(None, ao[0], ao[1:4], laplacian)
+        return self.evaluate_from_ao_batch(batch, dm_ao, need_gradient, need_laplacian)
+
+    def evaluate_from_ao_batch(self, batch, dm_ao=None, need_gradient=True, need_laplacian=True):
+        if dm_ao is None:
+            dm_ao = self.density_matrices_ao()
+        need_gradient = need_gradient or need_laplacian
+        ao = batch.ao_value
+        density = torch.einsum("stabij,ra,rb->strij", dm_ao, ao, ao)
+        gradient = None
+        if need_gradient:
+            if batch.grad_ao_value is None:
+                raise ValueError("AO gradients are missing from the grid batch")
+            gradient = (
+                torch.einsum("stabij,xra,rb->strxij", dm_ao, batch.grad_ao_value, ao)
+                + torch.einsum("stabij,ra,xrb->strxij", dm_ao, ao, batch.grad_ao_value)
+            )
+        laplacian = None
+        if need_laplacian:
+            if batch.lapl_ao_value is None:
+                raise ValueError("AO Laplacians are missing from the grid batch")
+            laplacian = (
+                torch.einsum("stabij,ra,rb->strij", dm_ao, batch.lapl_ao_value, ao)
+                + 2 * torch.einsum("stabij,xra,xrb->strij", dm_ao, batch.grad_ao_value, batch.grad_ao_value)
+                + torch.einsum("stabij,ra,rb->strij", dm_ao, ao, batch.lapl_ao_value)
+            )
+        return density, gradient, laplacian
+
+
+class MultistateMatrixDensityKohnSham(MultistateMatrixDensity):
+    @classmethod
+    def from_guess(cls, mol, guess="hcore", seed=None):
+        coefficients = torch.from_numpy(orbital_guess(mol, guess, seed)).double()
+        nmo = coefficients.size(1)
+        params = torch.nn.Parameter(torch.zeros((nmo * (nmo - 1)) // 2, dtype=torch.double))
+        return cls(mol, coefficients, params)
+
+    def __init__(self, mol, orbital_coefficients, orbital_rotation_params):
+        super().__init__(mol)
+        self.register_buffer("mo_coeff_guess", orbital_coefficients.detach())
+        self.nao, self.nmo = orbital_coefficients.size()
+        self.orbital_rotation_params = self._check_input(
+            orbital_rotation_params, "orbital_rotation_params",
+            torch.Size([(self.nmo * (self.nmo - 1)) // 2]))
+
+    @property
+    def number_of_states(self):
+        return 1
+
+    def orbital_coefficients(self):
+        return self.mo_coeff_guess @ torch.matrix_exp(antisymmetric_matrix(self.orbital_rotation_params, self.nmo))
+
+    def density_matrices_ao(self):
+        coefficients = self.orbital_coefficients()
+        occupations = torch.zeros((2, 2, self.nmo), dtype=coefficients.dtype, device=coefficients.device)
+        occupations[0, 0, :self.mol.nelec[0]] = 1
+        occupations[1, 1, :self.mol.nelec[1]] = 1
+        density = torch.einsum("ap,stp,bp->stab", coefficients, occupations, coefficients)
+        return density[..., None, None]
+
+    def spin_multiplicity(self):
+        return torch.tensor([self.mol.spin + 1], device=self.orbital_rotation_params.device)
+
+    def basis_transformation(self, transformation):
+        if transformation.size() != torch.Size([1, 1]):
+            raise ValueError("a Kohn-Sham density contains one state")
+
+
+class MultistateMatrixDensityCAS(MultistateMatrixDensity):
+    @classmethod
+    def from_guess(cls, mol, norb, nelec, spin_symmetry=True, spin_type=SpinType.UNPOLARIZED,
+                   max_level=numpy.inf, guess="hcore", seed=None):
+        coefficients, orbital_params, active_space, s2, det_to_csf = _cas_components(
+            mol, norb, nelec, spin_symmetry, spin_type, max_level, guess, seed
+        )
+        nstate = det_to_csf.size(1)
+        state_params = torch.nn.Parameter(torch.zeros((nstate * (nstate - 1)) // 2, dtype=torch.double))
+        return cls(mol, norb, nelec, coefficients, orbital_params, torch.eye(nstate, dtype=torch.double),
+                   state_params, spin_symmetry, spin_type, max_level)
+
+    def __init__(self, mol, norb, nelec, orbital_coefficients, orbital_rotation_params,
+                 state_coefficients, state_rotation_params, spin_symmetry=True,
+                 spin_type=SpinType.UNPOLARIZED, max_level=numpy.inf):
+        super().__init__(mol)
+        _validate_spin_type(spin_type)
+        coefficients, _, active_space, s2, det_to_csf = _cas_components(
+            mol, norb, nelec, spin_symmetry, spin_type, max_level,
+            orbital_coefficients.detach().cpu().numpy(), None
+        )
+        self.active_space = active_space
+        self.spin_type = spin_type
+        self.spin_symmetry = spin_symmetry
+        self.register_buffer("mo_coeff_guess", coefficients)
+        self.register_buffer("s2_matrix", s2)
+        self.register_buffer("det_to_csf", det_to_csf)
+        self.register_buffer("ci_coeff_guess", state_coefficients.detach())
+        self.nao, self.nmo = coefficients.size()
+        self.orbital_rotation_params = self._check_input(
+            orbital_rotation_params, "orbital_rotation_params",
+            torch.Size([(self.nmo * (self.nmo - 1)) // 2]))
+        self.nstate = det_to_csf.size(1)
+        self.ndet = det_to_csf.size(0)
+        self._check_input(state_coefficients, "state_coefficients",
+                          torch.Size([self.nstate, self.nstate]))
+        self.state_rotation_params = self._check_input(
+            state_rotation_params, "state_rotation_params",
+            torch.Size([(self.nstate * (self.nstate - 1)) // 2]))
+        neleca, nelecb = _unpack_nelec(nelec)
+        ndouble = _validate_active_space_for_molecule(mol, norb, (neleca, nelecb))
+        active_density = active_space.matrix_density_mo()
+        density = numpy.zeros((2, 2, self.nmo, self.nmo, self.ndet, self.ndet))
+        for orbital in range(ndouble):
+            density[0, 0, orbital, orbital] = numpy.eye(self.ndet)
+            density[1, 1, orbital, orbital] = numpy.eye(self.ndet)
+        density[:, :, ndouble:ndouble+norb, ndouble:ndouble+norb] = active_density
+        density = numpy.einsum("stpqIJ,IS,JT->stpqST", density, det_to_csf.numpy(), det_to_csf.numpy())
+        self.register_buffer("dm_mo_spin", torch.from_numpy(density).double())
+
+    @property
+    def number_of_states(self):
+        return self.nstate
+
+    @property
+    def number_of_determinants(self):
+        return self.ndet
+
+    def orbital_coefficients(self):
+        return self.mo_coeff_guess @ torch.matrix_exp(antisymmetric_matrix(self.orbital_rotation_params, self.nmo))
+
+    def state_coefficients(self):
+        return self.ci_coeff_guess @ torch.matrix_exp(antisymmetric_matrix(self.state_rotation_params, self.nstate))
+
+    def determinant_coefficients(self):
+        return self.det_to_csf @ self.state_coefficients()
+
+    def density_matrices_ao(self):
+        ci = self.state_coefficients()
+        density_mo = torch.einsum("...st,si,tj->...ij", self.dm_mo_spin, ci, ci)
+        coefficients = self.orbital_coefficients()
+        return torch.einsum("stpqij,ap,bq->stabij", density_mo, coefficients, coefficients)
+
+    def spin_s2_expectation(self):
+        coefficients = self.determinant_coefficients()
+        return torch.einsum("ab,ai,bi->i", self.s2_matrix, coefficients, coefficients)
+
+    def spin_multiplicity(self):
+        return torch.round(torch.sqrt(1.0 + 4.0 * self.spin_s2_expectation())).int()
+
+    def occupation_labels(self):
+        return self.active_space.occupation_labels()
+
+    def basis_transformation(self, transformation):
+        ci = self.state_coefficients() @ transformation.T
+        self.register_buffer("ci_coeff_guess", ci.detach())
+        self.state_rotation_params = torch.nn.Parameter(torch.zeros_like(self.state_rotation_params))
+
+
+class TargetStateMultistateMatrixDensityCAS(MultistateMatrixDensity):
+    RESTART_SCHEMA_VERSION = 2
+    TARGET_PARAMETERIZATION_FULL_ROTATION = "full_rotation"
+    TARGET_PARAMETERIZATION_STIEFEL_K = "stiefel_k"
+    TARGET_PARAMETERIZATIONS = {
+        TARGET_PARAMETERIZATION_FULL_ROTATION,
+        TARGET_PARAMETERIZATION_STIEFEL_K,
+    }
+    FULL_ROTATION = TARGET_PARAMETERIZATION_FULL_ROTATION
+    STIEFEL_K = TARGET_PARAMETERIZATION_STIEFEL_K
+
+    @classmethod
+    def from_guess(cls, mol, norb, nelec, target_states, spin_symmetry=True,
+                   spin_type=SpinType.UNPOLARIZED, max_level=numpy.inf, guess="hcore",
+                   seed=None, target_parameterization=FULL_ROTATION):
+        if spin_type is not SpinType.UNPOLARIZED:
+            raise NotImplementedError("target-state LDMA supports SpinType.UNPOLARIZED only")
+        coefficients, orbital_params, active_space, s2, det_to_csf = _cas_components(
+            mol, norb, nelec, spin_symmetry, spin_type, max_level, guess, seed
+        )
+        if not 1 <= target_states <= det_to_csf.size(1):
+            raise ActiveSpaceError("target_states exceeds the selected CSF dimension")
+        return cls(mol, norb, nelec, target_states, coefficients, orbital_params,
+                   det_to_csf, s2, active_space, spin_symmetry, spin_type,
+                   target_parameterization=target_parameterization)
+
+    def __init__(self, mol, norb, nelec, target_states, orbital_coefficients,
+                 orbital_rotation_params, det_to_csf, s2_matrix, active_space,
+                 spin_symmetry=True, spin_type=SpinType.UNPOLARIZED,
+                 target_rotation_params=None, target_parameterization=FULL_ROTATION,
+                 orthonormality_threshold=1.0e-8, spin_mixing_threshold=1.0e-8):
+        super().__init__(mol)
+        if spin_type is not SpinType.UNPOLARIZED:
+            raise NotImplementedError("target-state LDMA supports SpinType.UNPOLARIZED only")
+        if target_parameterization not in (self.FULL_ROTATION, self.STIEFEL_K):
+            raise ValueError("target_parameterization must be 'full_rotation' or 'stiefel_k'")
+        self.norb, self.nelec, self.ntarget = norb, nelec, target_states
+        self.nao, self.nmo = orbital_coefficients.size()
+        self.nspin = 2
+        self.ncsf = det_to_csf.size(1)
+        self.ndet = det_to_csf.size(0)
+        self.active_space = active_space
+        self.spin_symmetry = spin_symmetry
+        self.spin_type = spin_type
+        self.target_parameterization = target_parameterization
+        self.orthonormality_threshold = orthonormality_threshold
+        self.spin_mixing_threshold = spin_mixing_threshold
+        self.register_buffer("mo_coeff_guess", orbital_coefficients.detach())
+        self.register_buffer("det_to_csf", det_to_csf.detach())
+        self.register_buffer("s2_matrix", s2_matrix.detach())
+        self.orbital_rotation_params = self._check_input(
+            orbital_rotation_params, "orbital_rotation_params",
+            torch.Size([(self.nmo * (self.nmo - 1)) // 2]))
+        neleca, nelecb = _unpack_nelec(nelec)
+        self.ndouble = _validate_active_space_for_molecule(mol, norb, (neleca, nelecb))
+        if target_parameterization == self.FULL_ROTATION:
+            shape = ((self.ncsf * (self.ncsf - 1)) // 2,)
+        else:
+            shape = (self.ncsf - self.ntarget, self.ntarget)
+        if target_rotation_params is None:
+            target_rotation_params = torch.nn.Parameter(torch.zeros(shape, dtype=orbital_coefficients.dtype))
+        if target_rotation_params.size() != torch.Size(shape):
+            raise ValueError(f"target_rotation_params must have shape {shape}")
+        self.target_rotation_params = target_rotation_params
+        table = self._build_one_body_operator_table(orbital_coefficients.dtype)
+        self.register_buffer("one_body_spin_rows", table.spin_rows)
+        self.register_buffer("one_body_spin_cols", table.spin_cols)
+        self.register_buffer("one_body_orbital_rows", table.orbital_rows)
+        self.register_buffer("one_body_orbital_cols", table.orbital_cols)
+        self.register_buffer("one_body_det_rows", table.det_rows)
+        self.register_buffer("one_body_det_cols", table.det_cols)
+        self.register_buffer("one_body_values", table.values)
+        self.one_body_shape = table.shape
+        self._last_orbital_grid_density = None
+        self.enforce_invariants()
+
+    @property
+    def number_of_states(self):
+        return self.ntarget
+
+    @property
+    def number_of_csfs(self):
+        return self.ncsf
+
+    @property
+    def number_of_determinants(self):
+        return self.ndet
+
+    def _build_one_body_operator_table(self, dtype):
+        entries = []
+        determinants = self.active_space.slater_determinants()
+        determinant_indices = {det: index for index, det in enumerate(determinants)}
+        for ket, determinant in enumerate(determinants):
+            for create_spin in range(self.nspin):
+                for annihilate_spin in range(self.nspin):
+                    for p in range(self.norb):
+                        for q in range(self.norb):
+                            result = _apply_one_body_operator(
+                                determinant, create_spin, annihilate_spin,
+                                p, q, self.norb)
+                            if result is None:
+                                continue
+                            bra = determinant_indices.get(result[0])
+                            if bra is not None:
+                                entries.append((
+                                    create_spin, annihilate_spin,
+                                    self.ndouble + q, self.ndouble + p,
+                                    bra, ket, result[1]))
+        for orbital in range(self.ndouble):
+            for determinant in range(self.ndet):
+                for spin in range(self.nspin):
+                    entries.append((spin, spin, orbital, orbital,
+                                    determinant, determinant, 1.0))
+        if entries:
+            data = numpy.asarray(entries, dtype=numpy.float64)
+            integer_columns = [torch.from_numpy(data[:, index].astype(numpy.int64))
+                               for index in range(6)]
+            values = torch.from_numpy(data[:, 6]).to(dtype=dtype)
+        else:
+            integer_columns = [torch.empty(0, dtype=torch.long) for _ in range(6)]
+            values = torch.empty(0, dtype=dtype)
+        return OneBodyOperatorTable(
+            integer_columns[0], integer_columns[1], integer_columns[2],
+            integer_columns[3], integer_columns[4], integer_columns[5],
+            values,
+            (self.nspin, self.nspin, self.nmo, self.nmo, self.ndet, self.ndet))
+
+    def orbital_coefficients(self):
+        return self.mo_coeff_guess @ torch.matrix_exp(antisymmetric_matrix(self.orbital_rotation_params, self.nmo))
+
+    def target_coefficients(self):
+        if self.target_parameterization == self.FULL_ROTATION:
+            generator = antisymmetric_matrix(self.target_rotation_params, self.ncsf)
+        else:
+            generator = stiefel_tangent_block_matrix(self.target_rotation_params, self.ncsf, self.ntarget)
+        return torch.matrix_exp(generator)[:, :self.ntarget]
+
+    def determinant_coefficients(self):
+        return self.det_to_csf @ self.target_coefficients()
+
+    def transition_1rdm_mo(self):
+        coefficients = self.determinant_coefficients()
+        gamma = torch.zeros((2, 2, self.nmo, self.nmo, self.ntarget, self.ntarget),
+                            dtype=coefficients.dtype, device=coefficients.device)
+        values = self.one_body_values.to(coefficients)
+        entry_values = (
+            values[:, None, None]
+            * coefficients[self.one_body_det_rows, :, None]
+            * coefficients[self.one_body_det_cols, None, :]
+        )
+        gamma.index_put_(
+            (
+                self.one_body_spin_rows,
+                self.one_body_spin_cols,
+                self.one_body_orbital_rows,
+                self.one_body_orbital_cols,
+            ),
+            entry_values,
+            accumulate=True,
+        )
+        return gamma
+
+    def density_matrices_ao(self):
+        return torch.einsum("stpqij,ap,bq->stabij", self.transition_1rdm_mo(),
+                            self.orbital_coefficients(), self.orbital_coefficients())
+
+    def evaluate_from_mo_grid_batch(self, batch, gamma_mo=None):
+        gamma_mo = self.transition_1rdm_mo() if gamma_mo is None else gamma_mo
+        mo_values = batch.ao_value @ self.orbital_coefficients()
+        return torch.einsum("stpqij,gp,gq->stgij", gamma_mo, mo_values, mo_values), None, None
+
+    def spin_s2_expectation(self):
+        coefficients = self.determinant_coefficients()
+        return torch.einsum("ab,ai,bi->i", self.s2_matrix, coefficients, coefficients)
+
+    def spin_multiplicity(self):
+        return torch.round(torch.sqrt(1.0 + 4.0 * self.spin_s2_expectation())).int()
+
+    def target_orthonormality_error(self):
+        coefficients = self.target_coefficients()
+        identity = torch.eye(
+            self.ntarget, dtype=coefficients.dtype, device=coefficients.device)
+        return torch.linalg.norm(coefficients.T @ coefficients - identity)
+
+    def orbital_orthonormality_error(self):
+        coefficients = self.orbital_coefficients()
+        overlap = torch.from_numpy(self.mol.intor_symmetric("int1e_ovlp")).to(coefficients)
+        identity = torch.eye(
+            self.nmo, dtype=coefficients.dtype, device=coefficients.device)
+        return torch.linalg.norm(coefficients.T @ overlap @ coefficients - identity)
+
+    def invariant_diagnostics(self):
+        spin_s2 = self.spin_s2_expectation().detach()
+        return {
+            "target_orthonormality_error": float(self.target_orthonormality_error().detach()),
+            "orbital_orthonormality_error": float(self.orbital_orthonormality_error().detach()),
+            "spin_s2_min": float(torch.min(spin_s2)),
+            "spin_s2_max": float(torch.max(spin_s2)),
+        }
+
+    def check_invariants(self, fail=True):
+        diagnostics = self.invariant_diagnostics()
+        errors = []
+        if diagnostics["target_orthonormality_error"] > self.orthonormality_threshold:
+            errors.append("target coefficients are not orthonormal")
+        if diagnostics["orbital_orthonormality_error"] > self.orthonormality_threshold:
+            errors.append("orbital coefficients are not orthonormal")
+        if errors:
+            message = "; ".join(errors)
+            if fail:
+                raise RuntimeError(message)
+            warnings.warn(message, RuntimeWarning)
+        return diagnostics
+
+    def state_diagnostics(self, reference_target_coefficients=None, dominant_count=5):
+        coefficients = self.target_coefficients().detach()
+        diagnostics = {
+            "spin_s2": self.spin_s2_expectation().detach().cpu().tolist(),
+            "spin_multiplicity": self.spin_multiplicity().detach().cpu().tolist(),
+            "dominant_csfs": [],
+        }
+        nitems = min(dominant_count, self.ncsf)
+        for state in range(self.ntarget):
+            values, indices = torch.topk(coefficients[:, state].square(), k=nitems)
+            diagnostics["dominant_csfs"].append([
+                {"csf_index": int(index), "weight": float(value),
+                 "label": f"CSF {int(index)}"}
+                for value, index in zip(values.cpu(), indices.cpu())
+            ])
+        if reference_target_coefficients is not None:
+            reference = reference_target_coefficients.detach().to(coefficients)
+            overlap = reference.T @ coefficients
+            diagnostics["reference_overlap"] = overlap.cpu().tolist()
+            diagnostics["reference_overlap_abs"] = torch.abs(overlap).cpu().tolist()
+        return diagnostics
+
+    def warn_if_spin_mixed(self):
+        if not self.spin_symmetry or self.ntarget <= 1:
+            return None
+        coefficients = self.determinant_coefficients()
+        s2_matrix = self.s2_matrix.to(coefficients)
+        target_s2 = coefficients.T @ s2_matrix @ coefficients
+        off_diagonal = target_s2 - torch.diag(torch.diagonal(target_s2))
+        defect = torch.max(torch.abs(off_diagonal)).detach()
+        if defect > self.spin_mixing_threshold:
+            warnings.warn(
+                "Target-state coefficients mix spin sectors: off-diagonal S^2 defect "
+                f"{float(defect)} > {self.spin_mixing_threshold}", RuntimeWarning)
+        return defect
+
+    def enforce_spin_symmetry(self):
+        defect = self.warn_if_spin_mixed()
+        if defect is not None and defect > self.spin_mixing_threshold:
+            raise RuntimeError(
+                "Target-state coefficients mix spin sectors: off-diagonal S^2 defect "
+                f"{float(defect)} > {self.spin_mixing_threshold}")
+        return defect
+
+    def enforce_invariants(self):
+        diagnostics = self.check_invariants(fail=True)
+        self.enforce_spin_symmetry()
+        return diagnostics
+
+    def basis_transformation(self, transformation):
+        target = self.target_coefficients() @ transformation.T
+        target, _ = torch.linalg.qr(target.detach())
+        completion = torch.eye(self.ncsf, dtype=target.dtype, device=target.device)
+        completion[:, :self.ntarget] = target[:, :self.ntarget]
+        full_basis, _ = torch.linalg.qr(completion)
+        self.register_buffer("det_to_csf", self.det_to_csf @ full_basis)
+        shape = self.target_rotation_params.size()
+        self.target_rotation_params = torch.nn.Parameter(
+            torch.zeros(shape, dtype=target.dtype, device=target.device)
+        )
+        self.enforce_invariants()
+
+    def restart_state(self):
+        return {
+            "schema_version": self.RESTART_SCHEMA_VERSION,
+            "class": self.__class__.__name__,
+            "norb": self.norb,
+            "nelec": self.nelec,
+            "target_states": self.ntarget,
+            "ncsf": self.ncsf,
+            "nmo": self.nmo,
+            "spin_symmetry": self.spin_symmetry,
+            "spin_type": self.spin_type.name,
+            "target_parameterization": self.target_parameterization,
+            "orthonormality_threshold": self.orthonormality_threshold,
+            "spin_mixing_threshold": self.spin_mixing_threshold,
+            "orbital_rotation_params": self.orbital_rotation_params.detach().cpu().clone(),
+            "target_rotation_params": self.target_rotation_params.detach().cpu().clone(),
+            "diagnostics": self.invariant_diagnostics(),
+        }
+
+    def _validate_restart_state(self, state):
+        schema_version = state.get("schema_version")
+        if schema_version not in {1, self.RESTART_SCHEMA_VERSION}:
+            raise ValueError(
+                "Unsupported restart schema version: "
+                f"{schema_version} not in {{1, {self.RESTART_SCHEMA_VERSION}}}"
+            )
+        restart_parameterization = state.get(
+            "target_parameterization", self.TARGET_PARAMETERIZATION_FULL_ROTATION)
+        if restart_parameterization != self.target_parameterization:
+            raise ValueError(
+                "Restart target_parameterization does not match this object: "
+                f"{restart_parameterization} != {self.target_parameterization}."
+            )
+        expected = {
+            "target_states": self.ntarget,
+            "ncsf": self.ncsf,
+            "nmo": self.nmo,
+            "norb": self.norb,
+            "nelec": self.nelec,
+            "spin_symmetry": self.spin_symmetry,
+            "spin_type": self.spin_type.name,
+        }
+        for key, value in expected.items():
+            if state.get(key) != value:
+                raise ValueError(
+                    f"Restart {key} does not match this object: {state.get(key)} != {value}."
+                )
+
+    def load_restart_state(self, state):
+        if "schema_version" not in state:
+            if self.target_parameterization != self.TARGET_PARAMETERIZATION_FULL_ROTATION:
+                raise ValueError(
+                    "Legacy target-state restart files can only be loaded into "
+                    "target_parameterization='full_rotation'."
+                )
+            if state["target_states"] != self.ntarget:
+                raise ValueError("Restart target-state count does not match this object.")
+        else:
+            self._validate_restart_state(state)
+        with torch.no_grad():
+            self.orbital_rotation_params.copy_(torch.as_tensor(
+                state["orbital_rotation_params"]).to(self.orbital_rotation_params))
+            self.target_rotation_params.copy_(torch.as_tensor(
+                state["target_rotation_params"]).to(self.target_rotation_params))
+        self.enforce_invariants()
+
+    def save_restart_file(self, path):
+        state = self.restart_state()
+        state["orbital_rotation_params"] = state["orbital_rotation_params"].tolist()
+        state["target_rotation_params"] = state["target_rotation_params"].tolist()
+        path = Path(path)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+
+    def load_restart_file(self, path):
+        self.load_restart_state(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+__all__ = [
+    "AOGridBatch", "CASGuessComponents", "OneBodyOperatorTable",
+    "MultistateMatrixDensity", "MultistateMatrixDensityKohnSham",
+    "MultistateMatrixDensityCAS", "TargetStateMultistateMatrixDensityCAS",
+    "antisymmetric_matrix", "cas_guess_components", "stiefel_tangent_block_matrix", "orbital_guess",
+    "reorder_active_orbitals",
+]

--- a/pyscf/msdft/ldma/dft/exact_exchange.py
+++ b/pyscf/msdft/ldma/dft/exact_exchange.py
@@ -1,0 +1,55 @@
+"""Exact-exchange matrix functional in an atomic-orbital basis."""
+
+import numpy
+import pyscf.pbc.gto
+import pyscf.scf
+import torch
+from torch.autograd import Function
+from torch.autograd.function import once_differentiable
+
+
+class _ExactExchangeFunctionalAO(Function):
+    @staticmethod
+    def forward(ctx, density_matrices_ao, mol):
+        nbasis, _, nstate, _ = density_matrices_ao.size()
+        matrices = [
+            density_matrices_ao[:, :, i, j].detach().cpu().numpy()
+            for i in range(nstate)
+            for j in range(nstate)
+        ]
+        potentials = pyscf.scf.jk.get_jk(
+            mol, matrices, len(matrices) * ["ijkl,kj->il"])
+        exchange_potentials = numpy.zeros((nbasis, nbasis, nstate, nstate))
+        offset = 0
+        for i in range(nstate):
+            for j in range(nstate):
+                exchange_potentials[:, :, i, j] = potentials[offset]
+                offset += 1
+        exchange_potentials = torch.from_numpy(exchange_potentials).to(density_matrices_ao)
+        ctx.save_for_backward(exchange_potentials)
+        return -0.5 * torch.einsum(
+            "rsik,rskj->ij", density_matrices_ao, exchange_potentials)
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output):
+        exchange_potentials, = ctx.saved_tensors
+        gradient = -0.5 * (
+            torch.einsum("mj,rsnj->rsmn", grad_output, exchange_potentials)
+            + torch.einsum("rsjm,jn->rsmn", exchange_potentials, grad_output)
+        )
+        return gradient, None
+
+
+class ExactExchangeFunctionalAO(torch.nn.Module):
+    def __init__(self, mol):
+        super().__init__()
+        if isinstance(mol, pyscf.pbc.gto.cell.Cell):
+            raise NotImplementedError("Exact exchange not implemented for periodic cells")
+        self.mol = mol
+
+    def forward(self, density_matrices_ao):
+        return _ExactExchangeFunctionalAO.apply(density_matrices_ao, self.mol)
+
+
+__all__ = ["ExactExchangeFunctionalAO"]

--- a/pyscf/msdft/ldma/dft/hamiltonian.py
+++ b/pyscf/msdft/ldma/dft/hamiltonian.py
@@ -1,0 +1,337 @@
+"""Collinear LDMA Hamiltonians and state-averaged optimization."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+import numpy
+import torch
+from pyscf import dft
+from pyscf.dft import numint
+
+from ..nn.functional import trace_average
+from ..optim.torch_optimizer import TorchLBFGSOptimizer, WrappedOptimizer
+from .density import AOGridBatch, MultistateMatrixDensity, TargetStateMultistateMatrixDensityCAS
+from .hartree import HartreeFunctionalAO
+from .integrals import OneElectronIntegralCache
+from .kinetic import KineticFunctionalAO
+from .nuclear import NuclearFunctionalAO
+from .spin import SpinType
+from .xc import lda_c_chachiyo, lda_x_dirac
+
+
+class Hamiltonian(ABC):
+    @abstractmethod
+    def matrix_elements(self, msmd: MultistateMatrixDensity):
+        pass
+
+
+class HamiltonianSemilocal(Hamiltonian):
+    """Semilocal Hamiltonian for unpolarized or collinearly polarized densities."""
+
+    def __init__(self, mol, kinetic_functional=None, exchange_functional=lda_x_dirac,
+                 correlation_functional=lda_c_chachiyo, exact_exchange_functional=None,
+                 exchange_correlation_functional=None,
+                 spin_type=SpinType.UNPOLARIZED, grid_level=3,
+                 grid_chunks=1, target_memory_fraction=None,
+                 max_grid_points_per_chunk=None, min_grid_points_per_chunk=1):
+        if not isinstance(spin_type, SpinType):
+            raise ValueError("spin_type must be a SpinType")
+        if isinstance(grid_chunks, int):
+            if grid_chunks < 1:
+                raise ValueError("grid_chunks must be at least 1")
+        elif grid_chunks not in (None, "auto"):
+            raise ValueError("grid_chunks must be an integer, 'auto', or None")
+        if min_grid_points_per_chunk < 1:
+            raise ValueError("min_grid_points_per_chunk must be at least 1")
+        if max_grid_points_per_chunk is not None and max_grid_points_per_chunk < min_grid_points_per_chunk:
+            raise ValueError("max_grid_points_per_chunk is smaller than the minimum")
+        self.mol = mol
+        self.spin_type = spin_type
+        self.kinetic = kinetic_functional
+        self.exchange = exchange_functional
+        self.correlation = correlation_functional
+        self.exact_exchange = exact_exchange_functional
+        self.exchange_correlation = exchange_correlation_functional
+        self.grid_level = grid_level
+        self.grid_chunks = grid_chunks
+        self.target_memory_fraction = target_memory_fraction
+        self.max_grid_points_per_chunk = max_grid_points_per_chunk
+        self.min_grid_points_per_chunk = min_grid_points_per_chunk
+        self.grids = dft.gen_grid.Grids(mol)
+        self.grids.level = grid_level
+        self.grids.build()
+        self.nuclear_ao = NuclearFunctionalAO(mol)
+        self.hartree_ao = HartreeFunctionalAO(mol)
+        self.kinetic_ao = KineticFunctionalAO(mol)
+        functionals = (self.kinetic, self.exchange, self.correlation, self.exchange_correlation)
+        self.need_laplacian = any(getattr(functional, "need_laplacian", False) for functional in functionals)
+        self.need_gradient = self.need_laplacian or any(
+            getattr(functional, "need_gradient", False) for functional in functionals
+        )
+        self._ao_grid_cache = None
+        self._ao_grid_cache_key = None
+        self._resolved_grid_chunks = None
+
+    def __call__(self, msmd):
+        return self.matrix_elements(msmd)
+
+    @property
+    def resolved_grid_chunks(self):
+        return self._resolved_grid_chunks
+
+    def _estimate_bytes_per_grid_point(self, dtype, nstate):
+        element_size = torch.empty((), dtype=dtype).element_size()
+        derivative_factor = 5 if self.need_laplacian else 4 if self.need_gradient else 1
+        channels = 4 if self.spin_type is SpinType.POLARIZED else 3
+        return int(element_size * 4 * (self.mol.nao_nr() * derivative_factor + channels * nstate**2 + 3 * nstate))
+
+    def _available_memory_bytes(self, device):
+        if device.type == "cuda" and torch.cuda.is_available():
+            free, _ = torch.cuda.mem_get_info(device)
+            return int(free * (self.target_memory_fraction or 0.35))
+        try:
+            import psutil
+            return int(psutil.virtual_memory().available * (self.target_memory_fraction or 0.5))
+        except ImportError:
+            return 1024**3
+
+    def _resolve_grid_chunks(self, dtype, device, msmd=None):
+        if isinstance(self.grid_chunks, int):
+            return self.grid_chunks
+        if msmd is None:
+            return 1
+        ngrids = len(self.grids.coords)
+        budget = self._available_memory_bytes(device)
+        points = max(1, budget // max(1, self._estimate_bytes_per_grid_point(dtype, msmd.number_of_states)))
+        points = max(points, self.min_grid_points_per_chunk)
+        if self.max_grid_points_per_chunk is not None:
+            points = min(points, self.max_grid_points_per_chunk)
+        return max(1, int(numpy.ceil(ngrids / points)))
+
+    def _get_ao_grid_cache(self, dtype, device, msmd=None):
+        chunks = self._resolve_grid_chunks(dtype, device, msmd)
+        chunks = min(chunks, max(1, len(self.grids.coords)))
+        self._resolved_grid_chunks = chunks
+        key = (dtype, device, chunks, self.need_gradient, self.need_laplacian)
+        if key == self._ao_grid_cache_key and self._ao_grid_cache is not None:
+            return self._ao_grid_cache
+        deriv = 2 if self.need_laplacian else 1 if self.need_gradient else 0
+        batches = []
+        for coords, weights in zip(numpy.array_split(self.grids.coords, chunks),
+                                   numpy.array_split(self.grids.weights, chunks)):
+            ao = torch.from_numpy(numint.eval_ao(self.mol, coords, deriv=deriv)).to(dtype=dtype, device=device)
+            weights = torch.from_numpy(weights).to(dtype=dtype, device=device)
+            if deriv == 0:
+                batches.append(AOGridBatch(weights, ao))
+            else:
+                laplacian = ao[4] + ao[7] + ao[9] if self.need_laplacian else None
+                batches.append(AOGridBatch(weights, ao[0], ao[1:4], laplacian))
+        self._ao_grid_cache_key = key
+        self._ao_grid_cache = batches
+        return batches
+
+    @staticmethod
+    def _scale(value, factor):
+        return None if value is None else factor * value
+
+    def _unpolarized_xc(self, density, gradient, laplacian):
+        if self.exchange_correlation is not None:
+            return self.exchange_correlation(density, gradient, laplacian)
+        result = 0.0
+        if self.exchange is not None:
+            result = result + 2.0 * self.exchange(
+                density / 2.0, self._scale(gradient, 0.5), self._scale(laplacian, 0.5)
+            )
+        if self.correlation is not None:
+            result = result + self.correlation(density, gradient, laplacian)
+        return result
+
+    def _polarized_xc(self, spin_density, spin_gradient, spin_laplacian, density, gradient, laplacian):
+        if self.exchange_correlation is not None:
+            raise NotImplementedError("fused XC is available only for SpinType.UNPOLARIZED")
+        result = 0.0
+        if self.exchange is not None:
+            result = result + self.exchange(
+                spin_density[0, 0], None if spin_gradient is None else spin_gradient[0, 0],
+                None if spin_laplacian is None else spin_laplacian[0, 0]
+            ) + self.exchange(
+                spin_density[1, 1], None if spin_gradient is None else spin_gradient[1, 1],
+                None if spin_laplacian is None else spin_laplacian[1, 1]
+            )
+        if self.correlation is not None:
+            result = result + self.correlation(density, gradient, laplacian)
+        return result
+
+    def matrix_elements(self, msmd):
+        if self.mol is not msmd.mol:
+            raise ValueError("Hamiltonian and matrix density must use the same molecule")
+        if hasattr(msmd, "spin_type") and msmd.spin_type is not self.spin_type:
+            raise ValueError("Hamiltonian and matrix density must use the same spin_type")
+        spin_dm = msmd.density_matrices_ao()
+        dm = torch.einsum("ss...->...", spin_dm)
+        hamiltonian = self.nuclear_ao(dm) + self.hartree_ao(dm)
+        hamiltonian = hamiltonian + self.mol.get_enuc() * torch.eye(
+            msmd.number_of_states, dtype=dm.dtype, device=dm.device
+        )
+        if self.kinetic is None:
+            hamiltonian = hamiltonian + self.kinetic_ao(dm)
+        if self.exact_exchange is not None:
+            if self.spin_type is SpinType.UNPOLARIZED:
+                hamiltonian = hamiltonian + 2.0 * self.exact_exchange(dm / 2.0)
+            else:
+                hamiltonian = hamiltonian + self.exact_exchange(spin_dm[0, 0]) + self.exact_exchange(spin_dm[1, 1])
+        for batch in self._get_ao_grid_cache(spin_dm.dtype, spin_dm.device, msmd):
+            spin_density, spin_gradient, spin_laplacian = msmd.evaluate_from_ao_batch(
+                batch, spin_dm, self.need_gradient, self.need_laplacian
+            )
+            density = torch.einsum("ss...->...", spin_density)
+            gradient = None if spin_gradient is None else torch.einsum("ss...->...", spin_gradient)
+            laplacian = None if spin_laplacian is None else torch.einsum("ss...->...", spin_laplacian)
+            if self.spin_type is SpinType.UNPOLARIZED:
+                xc = self._unpolarized_xc(density, gradient, laplacian)
+            else:
+                xc = self._polarized_xc(spin_density, spin_gradient, spin_laplacian,
+                                        density, gradient, laplacian)
+            weights = batch.weights[:, None, None]
+            hamiltonian = hamiltonian + torch.sum(xc * weights, dim=0)
+            if self.kinetic is not None:
+                hamiltonian = hamiltonian + torch.sum(
+                    self.kinetic(density, gradient, laplacian) * weights, dim=0
+                )
+        if not torch.isfinite(hamiltonian).all():
+            raise RuntimeError("Hamiltonian contains non-finite values")
+        return hamiltonian
+
+
+class HamiltonianTargetStateLDMA(Hamiltonian):
+    """Unpolarized target-state Hamiltonian with MO integral contraction."""
+
+    def __init__(self, mol, exchange_functional=lda_x_dirac,
+                 correlation_functional=lda_c_chachiyo,
+                 exchange_correlation_functional=None,
+                 spin_type=SpinType.UNPOLARIZED, grid_level=3, grid_chunks=1,
+                 hartree_backend="ao"):
+        if spin_type is not SpinType.UNPOLARIZED:
+            raise NotImplementedError("target-state LDMA supports SpinType.UNPOLARIZED only")
+        if hartree_backend != "ao":
+            raise ValueError("the core port provides only hartree_backend='ao'")
+        if not isinstance(grid_chunks, int) or grid_chunks < 1:
+            raise ValueError("grid_chunks must be an integer of at least 1")
+        self.mol = mol
+        self.exchange = exchange_functional
+        self.correlation = correlation_functional
+        self.exchange_correlation = exchange_correlation_functional
+        self.spin_type = spin_type
+        self.grid_chunks = grid_chunks
+        self.grids = dft.gen_grid.Grids(mol)
+        self.grids.level = grid_level
+        self.grids.build()
+        self.one_electron_cache = OneElectronIntegralCache(mol)
+        self.hartree = HartreeFunctionalAO(mol)
+
+    def __call__(self, msmd):
+        return self.matrix_elements(msmd)
+
+    def one_electron_matrix(self, msmd):
+        return self.one_electron_cache.matrix_elements_from_gamma(
+            msmd.transition_1rdm_mo(), msmd.orbital_coefficients()
+        )
+
+    def hartree_matrix(self, msmd):
+        return self.hartree(torch.einsum("ss...->...", msmd.density_matrices_ao()))
+
+    def exchange_correlation_matrix(self, msmd):
+        gamma = msmd.transition_1rdm_mo()
+        result = torch.zeros((msmd.number_of_states, msmd.number_of_states),
+                             dtype=gamma.dtype, device=gamma.device)
+        chunks = min(self.grid_chunks, max(1, len(self.grids.coords)))
+        for coords, weights in zip(numpy.array_split(self.grids.coords, chunks),
+                                   numpy.array_split(self.grids.weights, chunks)):
+            ao = torch.from_numpy(numint.eval_ao(self.mol, coords, deriv=0)).to(gamma)
+            weights = torch.from_numpy(weights).to(gamma)
+            spin_density, _, _ = msmd.evaluate_from_mo_grid_batch(AOGridBatch(weights, ao), gamma)
+            density = torch.einsum("ss...->...", spin_density)
+            if self.exchange_correlation is not None:
+                xc = self.exchange_correlation(density, None, None)
+            else:
+                xc = 0.0
+                if self.exchange is not None:
+                    xc = xc + 2.0 * self.exchange(density / 2.0, None, None)
+                if self.correlation is not None:
+                    xc = xc + self.correlation(density, None, None)
+            result = result + torch.sum(xc * weights[:, None, None], dim=0)
+        return result
+
+    def matrix_elements(self, msmd: TargetStateMultistateMatrixDensityCAS):
+        if self.mol is not msmd.mol:
+            raise ValueError("Hamiltonian and matrix density must use the same molecule")
+        identity = torch.eye(msmd.number_of_states, dtype=msmd.orbital_rotation_params.dtype,
+                             device=msmd.orbital_rotation_params.device)
+        return (self.mol.get_enuc() * identity + self.one_electron_matrix(msmd)
+                + self.hartree_matrix(msmd) + self.exchange_correlation_matrix(msmd))
+
+
+def minimize_subspace_energy(hamiltonian, msmd, state_average=None, optimizer="wrapped",
+                             enforce_invariants=True, convergence=None, return_info=False,
+                             **optimizer_kwds):
+    if optimizer in ("wrapped", "numpy", "bfgs"):
+        optimizer_instance = WrappedOptimizer(msmd.parameters(), **optimizer_kwds)
+    elif optimizer == "torch_lbfgs":
+        optimizer_instance = TorchLBFGSOptimizer(msmd.parameters(), **optimizer_kwds)
+    else:
+        raise ValueError("optimizer must be 'wrapped' or 'torch_lbfgs'")
+    for parameter in msmd.parameters():
+        parameter.requires_grad_(True)
+    if enforce_invariants and hasattr(msmd, "enforce_invariants"):
+        msmd.enforce_invariants()
+    convergence = convergence or {}
+    history = []
+
+    def closure():
+        optimizer_instance.zero_grad()
+        with torch.no_grad():
+            weights = msmd.state_weights()
+        value = trace_average(
+            hamiltonian(msmd), weights=weights, subspace_dim=state_average
+        )
+        if convergence or return_info:
+            value.backward(retain_graph=True)
+            gradients = [parameter.grad.detach().norm() for parameter in msmd.parameters()
+                         if parameter.grad is not None]
+            history.append({"loss": float(value.detach()),
+                            "grad_norm": float(torch.linalg.norm(torch.stack(gradients))) if gradients else 0.0})
+            optimizer_instance.zero_grad()
+        return value
+
+    optimizer_instance.step(closure)
+    msmd.optimizer_telemetry = optimizer_instance.telemetry.as_dict()
+    final = history[-1] if history else {"loss": None, "grad_norm": None}
+    loss_delta = abs(history[-1]["loss"] - history[-2]["loss"]) if len(history) > 1 else None
+    gtol = convergence.get("gtol")
+    ftol = convergence.get("ftol")
+    converged_grad = None if gtol is None or final["grad_norm"] is None else final["grad_norm"] <= gtol
+    converged_loss = None if ftol is None or loss_delta is None else loss_delta <= ftol
+    checks = [value for value in (converged_grad, converged_loss) if value is not None]
+    msmd.optimizer_convergence = {
+        "closure_count": len(history), "final_loss": final["loss"],
+        "final_grad_norm": final["grad_norm"], "loss_delta": loss_delta,
+        "gtol": gtol, "ftol": ftol, "converged_grad": converged_grad,
+        "converged_loss": converged_loss,
+        "converged": all(checks) if checks else None,
+        "history_tail": history[-10:],
+    }
+    if enforce_invariants and hasattr(msmd, "enforce_invariants"):
+        msmd.enforce_invariants()
+    matrix = hamiltonian(msmd)
+    energies, eigenvectors = torch.linalg.eigh(matrix)
+    msmd.basis_transformation(eigenvectors.T)
+    if enforce_invariants and hasattr(msmd, "enforce_invariants"):
+        msmd.enforce_invariants()
+    if return_info:
+        return energies, msmd, {"optimizer_telemetry": msmd.optimizer_telemetry,
+                                "optimizer_convergence": msmd.optimizer_convergence}
+    return energies, msmd
+
+
+__all__ = ["Hamiltonian", "HamiltonianSemilocal", "HamiltonianTargetStateLDMA",
+           "minimize_subspace_energy"]

--- a/pyscf/msdft/ldma/dft/hartree.py
+++ b/pyscf/msdft/ldma/dft/hartree.py
@@ -1,0 +1,54 @@
+"""Differentiable Hartree-like matrix functional in the AO basis."""
+
+import numpy
+import torch
+from pyscf.scf import hf
+import pyscf.pbc.gto
+import pyscf.pbc.scf
+from torch.autograd import Function
+from torch.autograd.function import once_differentiable
+
+
+class _HartreeFunctionalAO(Function):
+    @staticmethod
+    def forward(ctx, density_matrices_ao, mol):
+        nbasis, _, nstate, _ = density_matrices_ao.size()
+        matrices = [density_matrices_ao[:, :, i, j].detach().cpu().numpy()
+                    for i in range(nstate) for j in range(i, nstate)]
+        if isinstance(mol, pyscf.pbc.gto.cell.Cell):
+            potentials = pyscf.pbc.scf.hf.get_j(
+                mol, matrices, kpt=numpy.array([0.0, 0.0, 0.0]))
+        else:
+            potentials, _ = hf.get_jk(mol, matrices, with_j=True, with_k=False)
+        potential_tensor = numpy.zeros((nbasis, nbasis, nstate, nstate))
+        offset = 0
+        for i in range(nstate):
+            for j in range(i, nstate):
+                potential_tensor[:, :, i, j] = potentials[offset]
+                potential_tensor[:, :, j, i] = potentials[offset]
+                offset += 1
+        potential_tensor = torch.from_numpy(potential_tensor).to(density_matrices_ao)
+        ctx.save_for_backward(potential_tensor)
+        return 0.5 * torch.einsum("abik,abkj->ij", density_matrices_ao, potential_tensor)
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output):
+        potentials, = ctx.saved_tensors
+        gradient = 0.5 * (
+            torch.einsum("mj,abjn->abmn", grad_output, potentials)
+            + torch.einsum("abmj,jn->abmn", potentials, grad_output)
+        )
+        return gradient, None
+
+
+class HartreeFunctionalAO(torch.nn.Module):
+    def __init__(self, mol):
+        super().__init__()
+        self.mol = mol
+
+    def forward(self, density_matrices_ao):
+        return _HartreeFunctionalAO.apply(density_matrices_ao, self.mol)
+
+
+__all__ = ["HartreeFunctionalAO"]

--- a/pyscf/msdft/ldma/dft/integrals.py
+++ b/pyscf/msdft/ldma/dft/integrals.py
@@ -1,0 +1,33 @@
+"""Cached one-electron integral contractions for target-state densities."""
+
+import torch
+import pyscf.pbc.gto
+
+
+class OneElectronIntegralCache(torch.nn.Module):
+    def __init__(self, mol, intor=None):
+        super().__init__()
+        self.mol = mol
+        if isinstance(mol, pyscf.pbc.gto.cell.Cell):
+            if intor is None:
+                values = mol.pbc_intor("int1e_kin") + mol.pbc_intor("int1e_nuc")
+            else:
+                values = mol.pbc_intor(intor)
+        elif intor is None:
+            values = mol.intor_symmetric("int1e_kin") + mol.intor_symmetric("int1e_nuc")
+            if mol.has_ecp():
+                values = values + mol.intor_symmetric("ECPscalar")
+        else:
+            values = mol.intor_symmetric(intor)
+        self.register_buffer("integrals_ao", torch.from_numpy(values).double())
+
+    def integrals_mo(self, mo_coeff):
+        values = self.integrals_ao.to(dtype=mo_coeff.dtype, device=mo_coeff.device)
+        return torch.einsum("ap,ab,bq->pq", mo_coeff, values, mo_coeff)
+
+    def matrix_elements_from_gamma(self, gamma_mo, mo_coeff):
+        gamma_total = torch.einsum("ss...->...", gamma_mo)
+        return torch.einsum("pq,pqij->ij", self.integrals_mo(mo_coeff), gamma_total)
+
+
+__all__ = ["OneElectronIntegralCache"]

--- a/pyscf/msdft/ldma/dft/kinetic.py
+++ b/pyscf/msdft/ldma/dft/kinetic.py
@@ -1,0 +1,12 @@
+import torch
+
+from .operator1e import OneElectronOperatorAO
+
+
+class KineticFunctionalAO(torch.nn.Module):
+    def __init__(self, mol):
+        super().__init__()
+        self.mol = mol
+
+    def forward(self, density_matrices_ao):
+        return OneElectronOperatorAO.apply(density_matrices_ao, self.mol, "int1e_kin")

--- a/pyscf/msdft/ldma/dft/nuclear.py
+++ b/pyscf/msdft/ldma/dft/nuclear.py
@@ -1,0 +1,15 @@
+import torch
+
+from .operator1e import OneElectronOperatorAO
+
+
+class NuclearFunctionalAO(torch.nn.Module):
+    def __init__(self, mol):
+        super().__init__()
+        self.mol = mol
+
+    def forward(self, density_matrices_ao):
+        result = OneElectronOperatorAO.apply(density_matrices_ao, self.mol, "int1e_nuc")
+        if self.mol.has_ecp():
+            result = result + OneElectronOperatorAO.apply(density_matrices_ao, self.mol, "ECPscalar")
+        return result

--- a/pyscf/msdft/ldma/dft/operator1e.py
+++ b/pyscf/msdft/ldma/dft/operator1e.py
@@ -1,0 +1,27 @@
+"""Differentiable contractions with one-electron AO integrals."""
+
+import torch
+import pyscf.pbc.gto
+from torch.autograd import Function
+
+
+class OneElectronOperatorAO(Function):
+    @staticmethod
+    def forward(ctx, density_matrices_ao, mol, intor):
+        if isinstance(mol, pyscf.pbc.gto.cell.Cell):
+            integrals_ao = mol.pbc_intor(intor)
+        else:
+            integrals_ao = mol.intor_symmetric(intor)
+        integrals = torch.from_numpy(integrals_ao).to(
+            dtype=density_matrices_ao.dtype, device=density_matrices_ao.device
+        )
+        ctx.save_for_backward(integrals)
+        return torch.einsum("ab,abij->ij", integrals, density_matrices_ao)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        integrals, = ctx.saved_tensors
+        return torch.einsum("ab,ij->abij", integrals, grad_output), None, None
+
+
+__all__ = ["OneElectronOperatorAO"]

--- a/pyscf/msdft/ldma/dft/pure.py
+++ b/pyscf/msdft/ldma/dft/pure.py
@@ -1,0 +1,36 @@
+"""Composite analytic LDMA functionals."""
+
+from abc import ABC
+
+from .xc import lda_c_chachiyo, lda_x_dirac, lda_xc_dirac_chachiyo_unpolarized
+
+
+class PureXCFunctional(ABC):
+    exact_exchange = None
+
+    def __init__(self, mol=None):
+        pass
+
+    def exchange(self, matrix_density, grad_density=None, lapl_density=None):
+        return 0.0 * matrix_density
+
+    def correlation(self, matrix_density, grad_density=None, lapl_density=None):
+        return 0.0 * matrix_density
+
+    def exchange_correlation(self, matrix_density, grad_density=None, lapl_density=None):
+        return self.exchange(matrix_density, grad_density, lapl_density) + self.correlation(
+            matrix_density, grad_density, lapl_density)
+
+
+class LDA(PureXCFunctional):
+    def exchange(self, matrix_density, grad_density=None, lapl_density=None):
+        return lda_x_dirac(matrix_density)
+
+    def correlation(self, matrix_density, grad_density=None, lapl_density=None):
+        return lda_c_chachiyo(matrix_density)
+
+    def exchange_correlation(self, matrix_density, grad_density=None, lapl_density=None):
+        return lda_xc_dirac_chachiyo_unpolarized(matrix_density)
+
+
+__all__ = ["PureXCFunctional", "LDA"]

--- a/pyscf/msdft/ldma/dft/spin.py
+++ b/pyscf/msdft/ldma/dft/spin.py
@@ -1,0 +1,40 @@
+"""Collinear spin choices for LDMA."""
+
+from enum import Enum
+import numpy
+
+
+class SpinType(str, Enum):
+    """Supported collinear treatments of the matrix density."""
+
+    UNPOLARIZED = "spin_unpolarized"
+    POLARIZED = "spin_polarized"
+
+
+def merge_multiplet_energies(energies, spin_multiplicities):
+    energies_merged = []
+    multiplicities_merged = []
+    index = 0
+    while index < len(energies):
+        multiplicity = spin_multiplicities[index]
+        numpy.testing.assert_allclose(
+            energies[index:index + multiplicity] - energies[index],
+            numpy.zeros(multiplicity), atol=1.0e-5)
+        energies_merged.append(energies[index])
+        multiplicities_merged.append(multiplicity)
+        index += multiplicity
+    return numpy.asarray(energies_merged), numpy.asarray(multiplicities_merged)
+
+
+def index_within_multiplicity(spin_multiplicities):
+    indices = numpy.zeros_like(spin_multiplicities, dtype=int)
+    for multiplicity in numpy.unique(spin_multiplicities):
+        counter = 1
+        for index, value in enumerate(spin_multiplicities):
+            if value == multiplicity:
+                indices[index] = counter
+                counter += 1
+    return indices
+
+
+__all__ = ["SpinType", "merge_multiplet_energies", "index_within_multiplicity"]

--- a/pyscf/msdft/ldma/dft/xc.py
+++ b/pyscf/msdft/ldma/dft/xc.py
@@ -1,0 +1,94 @@
+"""Analytic Dirac exchange and Chachiyo correlation matrix functionals."""
+
+import math
+
+import torch
+from torch import Tensor
+
+from ..nn.functional import MatrixFunction, ScalarFunction
+
+
+class _LDAExchangeDirac(ScalarFunction):
+    coefficient = 2.0 ** (1.0 / 3.0) * 0.75 * (3.0 / math.pi) ** (1.0 / 3.0)
+
+    @staticmethod
+    def value(density: Tensor) -> Tensor:
+        return -_LDAExchangeDirac.coefficient * torch.abs(density) ** (4.0 / 3.0)
+
+    @staticmethod
+    def derivative1(density: Tensor) -> Tensor:
+        return -(4.0 / 3.0) * _LDAExchangeDirac.coefficient * torch.abs(density) ** (1.0 / 3.0)
+
+
+class _LDACorrelationChachiyo(ScalarFunction):
+    @staticmethod
+    def parameters(spin: int):
+        if spin not in (0, 1):
+            raise ValueError("spin must be 0 or 1")
+        a = (math.log(2.0) - 1.0) / (2.0 * math.pi**2)
+        b = 20.4562557
+        if spin == 1:
+            a *= 0.5
+            b = 27.4203609
+        return a, (4.0 * math.pi / 3.0) ** (1.0 / 3.0) * b, (4.0 * math.pi / 3.0) ** (2.0 / 3.0) * b
+
+    @staticmethod
+    def value(density: Tensor, spin: int) -> Tensor:
+        a, b1, b2 = _LDACorrelationChachiyo.parameters(spin)
+        rho = torch.abs(density) + 1.0e-15
+        argument = 1.0 + b1 * rho ** (1.0 / 3.0) + b2 * rho ** (2.0 / 3.0)
+        return a * torch.log(argument) * rho
+
+    @staticmethod
+    def derivative1(density: Tensor, spin: int) -> Tensor:
+        a, b1, b2 = _LDACorrelationChachiyo.parameters(spin)
+        rho = torch.abs(density) + 1.0e-15
+        argument = 1.0 + b1 * rho ** (1.0 / 3.0) + b2 * rho ** (2.0 / 3.0)
+        return a * (
+            ((b1 / 3.0) * rho ** (1.0 / 3.0) + (2.0 * b2 / 3.0) * rho ** (2.0 / 3.0)) / argument
+            + torch.log(argument)
+        )
+
+
+class _LDAXCDiracChachiyo(ScalarFunction):
+    @staticmethod
+    def value(density: Tensor, spin: int) -> Tensor:
+        return _LDAExchangeDirac.value(density) + _LDACorrelationChachiyo.value(density, spin)
+
+    @staticmethod
+    def derivative1(density: Tensor, spin: int) -> Tensor:
+        return _LDAExchangeDirac.derivative1(density) + _LDACorrelationChachiyo.derivative1(density, spin)
+
+
+class _LDAXCDiracChachiyoUnpolarized(ScalarFunction):
+    @staticmethod
+    def value(density: Tensor, spin: int) -> Tensor:
+        return 2.0 * _LDAExchangeDirac.value(density / 2.0) + _LDACorrelationChachiyo.value(density, spin)
+
+    @staticmethod
+    def derivative1(density: Tensor, spin: int) -> Tensor:
+        return _LDAExchangeDirac.derivative1(density / 2.0) + _LDACorrelationChachiyo.derivative1(density, spin)
+
+
+def lda_x_dirac(matrix_density: Tensor, grad_dummy=None, lapl_dummy=None) -> Tensor:
+    return MatrixFunction.apply(_LDAExchangeDirac, matrix_density)
+
+
+def lda_c_chachiyo(matrix_density: Tensor, grad_dummy=None, lapl_dummy=None, spin=0) -> Tensor:
+    return MatrixFunction.apply(_LDACorrelationChachiyo, matrix_density, spin)
+
+
+def lda_xc_dirac_chachiyo(matrix_density: Tensor, grad_dummy=None, lapl_dummy=None, spin=0) -> Tensor:
+    return MatrixFunction.apply(_LDAXCDiracChachiyo, matrix_density, spin)
+
+
+def lda_xc_dirac_chachiyo_unpolarized(matrix_density: Tensor, grad_dummy=None, lapl_dummy=None, spin=0) -> Tensor:
+    return MatrixFunction.apply(_LDAXCDiracChachiyoUnpolarized, matrix_density, spin)
+
+
+__all__ = [
+    "lda_x_dirac",
+    "lda_c_chachiyo",
+    "lda_xc_dirac_chachiyo",
+    "lda_xc_dirac_chachiyo_unpolarized",
+]

--- a/pyscf/msdft/ldma/nn/__init__.py
+++ b/pyscf/msdft/ldma/nn/__init__.py
@@ -1,0 +1,5 @@
+"""Differentiable matrix-function utilities used by LDMA."""
+
+from .functional import MatrixFunction, ScalarFunction, robust_symmetric_eigh, trace_average
+
+__all__ = ["MatrixFunction", "ScalarFunction", "robust_symmetric_eigh", "trace_average"]

--- a/pyscf/msdft/ldma/nn/functional.py
+++ b/pyscf/msdft/ldma/nn/functional.py
@@ -1,0 +1,123 @@
+"""Differentiable analytic functions of symmetric matrices."""
+
+from abc import ABC, abstractmethod
+
+import torch
+from torch import Size, Tensor
+from torch.autograd import Function
+from torch.autograd.function import once_differentiable
+
+
+def robust_symmetric_eigh(tensor, epsilon=1.0e-12):
+    """Diagonalize a finite symmetric tensor, retrying with small diagonal jitter."""
+    _check_dimensions(tensor, "tensor")
+    if not torch.isfinite(tensor).all():
+        raise ValueError("symmetric eigendecomposition requires finite input")
+    if not torch.allclose(tensor, tensor.transpose(-1, -2), rtol=0.0, atol=epsilon):
+        raise ValueError("symmetric eigendecomposition requires symmetric input")
+    try:
+        return torch.linalg.eigh(tensor)
+    except torch.linalg.LinAlgError:
+        identity = torch.eye(tensor.size(-1), dtype=tensor.dtype, device=tensor.device)
+        for scale in (1.0, 1.0e2, 1.0e4, 1.0e6, 1.0e8):
+            try:
+                return torch.linalg.eigh(tensor + epsilon * scale * identity)
+            except torch.linalg.LinAlgError:
+                continue
+        raise
+
+
+class ScalarFunction(ABC):
+    """Scalar function used to define an analytic matrix function."""
+
+    @staticmethod
+    @abstractmethod
+    def value(x: Tensor, *args) -> Tensor:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def derivative1(x: Tensor, *args) -> Tensor:
+        pass
+
+
+def _check_dimensions(tensor: Tensor, name: str) -> None:
+    if tensor.ndim < 2 or tensor.size(-1) != tensor.size(-2):
+        raise ValueError(
+            f"The tensor {name} must have shape (..., n, n); got {tensor.size()}."
+        )
+
+
+class MatrixFunction(Function):
+    """Apply a scalar function to the eigenvalues of symmetric matrices."""
+
+    @staticmethod
+    def forward(ctx, function: ScalarFunction, tensor: Tensor, *args) -> Tensor:
+        _check_dimensions(tensor, "tensor")
+        with torch.no_grad():
+            eigenvalues, eigenvectors = robust_symmetric_eigh(tensor)
+            function_values = function.value(eigenvalues, *args)
+            result = torch.einsum(
+                "...ia,...a,...ja->...ij",
+                eigenvectors,
+                function_values,
+                eigenvectors,
+            )
+        ctx.save_for_backward(eigenvalues, function_values, eigenvectors)
+        ctx.function = function
+        ctx.args = args
+        return result
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output: Tensor):
+        _check_dimensions(grad_output, "grad_output")
+        eigenvalues, function_values, eigenvectors = ctx.saved_tensors
+        la = eigenvalues.unsqueeze(-1)
+        lb = eigenvalues.unsqueeze(-2)
+        fla = function_values.unsqueeze(-1)
+        flb = function_values.unsqueeze(-2)
+        difference = la - lb
+        same = torch.abs(difference) < 1.0e-12
+        safe_difference = torch.where(same, torch.ones_like(difference), difference)
+        divided_difference = (fla - flb) / safe_difference
+        derivative = ctx.function.derivative1(0.5 * (la + lb), *ctx.args)
+        spectral_derivative = torch.where(same, derivative, divided_difference)
+        transformed_gradient = torch.einsum(
+            "...ia,...ij,...jb->...ab", eigenvectors, grad_output, eigenvectors
+        )
+        grad_input = torch.einsum(
+            "...ka,...ab,...lb->...kl",
+            eigenvectors,
+            spectral_derivative * transformed_gradient,
+            eigenvectors,
+        )
+        return (None, grad_input, *(None for _ in ctx.args))
+
+
+def trace_average(tensor: Tensor, weights=None, subspace_dim=None) -> Tensor:
+    """Average the trace, optionally over the lowest weighted eigenvalues."""
+    _check_dimensions(tensor, "tensor")
+    nstate = tensor.size(-1)
+    naverage = nstate if subspace_dim is None else subspace_dim
+    if not 0 < naverage <= nstate:
+        raise ValueError("subspace_dim must be between 1 and the matrix dimension")
+    if weights is None:
+        weights = torch.ones(nstate, dtype=tensor.dtype, device=tensor.device)
+    elif weights.size() != Size([nstate]):
+        raise ValueError(f"weights must have shape ({nstate},), got {weights.size()}")
+    weights = weights.to(dtype=tensor.dtype, device=tensor.device)
+    if not torch.isfinite(weights).all() or torch.any(weights < 0.0):
+        raise ValueError("weights must be finite and non-negative")
+    if torch.sum(weights) <= 0.0:
+        raise ValueError("at least one weight must be positive")
+    weights = nstate * weights / torch.sum(weights)
+    sqrt_weights = torch.sqrt(weights)
+    weighted_tensor = torch.einsum(
+        "i,...ij,j->...ij", sqrt_weights, tensor, sqrt_weights)
+    eigenvalues = torch.linalg.eigvalsh(weighted_tensor)
+    result = torch.sum(eigenvalues[..., :naverage], dim=-1) / naverage
+    return result.unsqueeze(-1).unsqueeze(-1)
+
+
+__all__ = ["MatrixFunction", "ScalarFunction", "robust_symmetric_eigh", "trace_average"]

--- a/pyscf/msdft/ldma/optim/__init__.py
+++ b/pyscf/msdft/ldma/optim/__init__.py
@@ -1,0 +1,4 @@
+from .torch_optimizer import (ClosureProfiler, OptimizerTelemetry,
+                              TorchLBFGSOptimizer, WrappedOptimizer)
+
+__all__ = ["ClosureProfiler", "OptimizerTelemetry", "TorchLBFGSOptimizer", "WrappedOptimizer"]

--- a/pyscf/msdft/ldma/optim/finite_differences.py
+++ b/pyscf/msdft/ldma/optim/finite_differences.py
@@ -1,0 +1,14 @@
+import numpy
+
+
+def numerical_hessian_G(gradient, x0, h=1.0e-8):
+    hessian = numpy.zeros((len(x0), len(x0)))
+    for index in range(len(x0)):
+        direction = numpy.zeros(len(x0))
+        direction[index] = 1.0
+        hessian[index] = (gradient(x0 + h * direction) - gradient(x0 - h * direction)) / (2.0 * h)
+    return 0.5 * (hessian + hessian.T)
+
+
+def condition_number(matrix):
+    return numpy.linalg.norm(numpy.linalg.inv(matrix)) * numpy.linalg.norm(matrix)

--- a/pyscf/msdft/ldma/optim/minimize.py
+++ b/pyscf/msdft/ldma/optim/minimize.py
@@ -1,0 +1,211 @@
+"""Unconstrained and log-barrier Newton, steepest-descent, and BFGS methods."""
+
+import numpy as np
+import numpy.linalg as la
+
+from . import finite_differences
+
+
+def line_search_backtracking(xk, fk, grad_fk, pk, func, constraints=None,
+                             a0=1.0, rho=0.3, c=0.0001, lmax=100):
+    a = a0
+    directional_derivative = np.dot(grad_fk, pk)
+    if directional_derivative > 0.0:
+        raise ValueError("search direction is not a descent direction")
+    for _ in range(lmax):
+        candidate = xk + a * pk
+        if constraints is not None and np.any(constraints(candidate)[0] <= 0.0):
+            a *= rho
+            continue
+        if func(candidate) <= fk + c * a * directional_derivative:
+            return candidate
+        a *= rho
+    raise RuntimeError("Linesearch failed to satisfy the sufficient decrease condition")
+
+
+def line_search_wolfe(xk, fk, grad_fk, pk, func, constraints=None,
+                      max_steplen=None, a0=1.0, amax=50.0,
+                      c1=0.0001, c2=0.9, lmax=100, debug=0):
+    if not 0 < c1 < c2 < 1:
+        raise ValueError("Wolfe constants must satisfy 0 < c1 < c2 < 1")
+    s0 = fk
+    ds0 = np.dot(grad_fk, pk)
+    if ds0 > 0.0:
+        raise ValueError("search direction is not a descent direction")
+
+    def scalar_function(a):
+        value, gradient = func(xk + a * pk)
+        return value, np.dot(gradient, pk)
+
+    def zoom(alo, ahi, slo):
+        for _ in range(lmax):
+            aj = 0.5 * (alo + ahi)
+            sj, dsj = scalar_function(aj)
+            if sj > s0 + c1 * aj * ds0 or sj >= slo:
+                ahi = aj
+            else:
+                if abs(dsj) <= c2 * abs(ds0):
+                    return aj
+                if dsj * (ahi - alo) >= 0.0:
+                    ahi = alo
+                alo, slo = aj, sj
+        if debug:
+            print("WARNING: zoom did not satisfy the Wolfe conditions")
+        return 0.5 * (alo + ahi)
+
+    def feasible(a):
+        return constraints is None or np.all(constraints(xk + a * pk)[0] > 0.0)
+
+    if max_steplen is not None:
+        maximum = max_steplen(xk, pk)
+        if maximum != np.inf:
+            amax = maximum
+    else:
+        while not feasible(amax):
+            amax *= 0.99
+    if amax <= 0.0:
+        raise RuntimeError("No positive feasible step length")
+    if a0 >= amax:
+        a0 = 0.5 * amax
+
+    previous_a = 0.0
+    previous_s = s0
+    a = a0
+    for iteration in range(1, lmax):
+        value, derivative = scalar_function(a)
+        if value > s0 + c1 * a * ds0 or (iteration > 1 and value >= previous_s):
+            return xk + zoom(previous_a, a, previous_s) * pk
+        if abs(derivative) <= c2 * abs(ds0):
+            return xk + a * pk
+        if derivative >= 0.0:
+            return xk + zoom(a, previous_a, value) * pk
+        previous_a, previous_s = a, value
+        a = 2.0 * previous_a
+        if a >= amax:
+            a = 0.5 * (previous_a + amax)
+    raise RuntimeError("Linesearch failed to satisfy the Wolfe conditions")
+
+
+def bfgs_update(inv_hessian, step, gradient_difference, iteration):
+    identity = np.eye(len(step))
+    if iteration < 1:
+        raise ValueError("BFGS update iteration must be at least 1")
+    if iteration == 1:
+        return np.dot(gradient_difference, step) / np.dot(
+            gradient_difference, gradient_difference) * identity
+    rho = 1.0 / np.dot(gradient_difference, step)
+    left = identity - rho * np.outer(step, gradient_difference)
+    right = identity - rho * np.outer(gradient_difference, step)
+    return left.dot(inv_hessian).dot(right) + rho * np.outer(step, step)
+
+
+def log_barrier(values, gradients):
+    return -np.sum(np.log(values)), -np.dot(1.0 / values, gradients)
+
+
+class OptimizationResult:
+    def __init__(self, x, fun, grad, nit):
+        self.x = x
+        self.fun = fun
+        self.grad = grad
+        self.nit = nit
+
+
+def minimize(objfunc, x0, method="BFGS", line_search_method="Wolfe",
+             constraints=None, max_steplen=None, callback=None,
+             maxiter=100000, gtol=1.0e-6, ftol=1.0e-8, debug=0):
+    if ftol <= 0.0 or gtol <= 0.0:
+        raise ValueError("ftol and gtol must be positive")
+    if method not in ("Newton", "Steepest Descent", "BFGS"):
+        raise ValueError("method must be 'Newton', 'Steepest Descent', or 'BFGS'")
+    if line_search_method not in ("Armijo", "Wolfe"):
+        raise ValueError("line_search_method must be 'Armijo' or 'Wolfe'")
+    nvariable = len(x0)
+
+    def barrier(x):
+        if constraints is None:
+            return 0.0, np.zeros(nvariable)
+        values, gradients = constraints(x)
+        barrier_value, barrier_gradient = log_barrier(values, gradients)
+        return 1.0e-5 * barrier_value, 1.0e-5 * barrier_gradient
+
+    def function(x):
+        value = objfunc(x, requires_grad=False)
+        return value + barrier(x)[0]
+
+    def gradient(x):
+        _, objective_gradient = objfunc(x, requires_grad=True)
+        return objective_gradient + barrier(x)[1]
+
+    def function_gradient(x):
+        value, objective_gradient = objfunc(x, requires_grad=True)
+        barrier_value, barrier_gradient = barrier(x)
+        return value + barrier_value, objective_gradient + barrier_gradient
+
+    xk = np.asarray(x0)
+    fk, grad_fk = function_gradient(xk)
+    inverse_hessian = None
+    step = None
+    gradient_difference = None
+    epsilon = np.finfo(float).eps
+
+    for iteration in range(maxiter):
+        if method == "Newton":
+            hessian = finite_differences.numerical_hessian_G(gradient, xk)
+            positive_hessian, _ = modified_cholesky(hessian)
+            direction = la.solve(positive_hessian, -grad_fk)
+        elif method == "Steepest Descent":
+            direction = -grad_fk
+        else:
+            if iteration == 0:
+                inverse_hessian = np.eye(nvariable)
+            else:
+                if np.dot(gradient_difference, step) <= 0.0 and debug:
+                    print("WARNING: BFGS curvature condition y.s > 0 was not satisfied")
+                inverse_hessian = bfgs_update(
+                    inverse_hessian, step, gradient_difference, iteration)
+            direction = np.dot(inverse_hessian, -grad_fk)
+
+        if line_search_method == "Armijo":
+            next_x = line_search_backtracking(
+                xk, fk, grad_fk, direction, function, constraints=constraints)
+        else:
+            next_x = line_search_wolfe(
+                xk, fk, grad_fk, direction, function_gradient,
+                constraints=constraints, max_steplen=max_steplen, debug=debug)
+        next_f, next_gradient = function_gradient(next_x)
+        function_change = abs(next_f - fk)
+        gradient_norm = la.norm(next_gradient)
+        converged = function_change < ftol and gradient_norm < gtol
+        if function_change < epsilon:
+            converged = True
+        step = next_x - xk
+        gradient_difference = next_gradient - grad_fk
+        xk, fk, grad_fk = next_x, next_f, next_gradient
+        if callback is not None:
+            callback(xk)
+        if debug:
+            print("k=%d f(x)=%.10f |step|=%e |df|=%e |grad|=%e" % (
+                iteration, fk, la.norm(step), function_change, gradient_norm))
+        if converged:
+            return OptimizationResult(xk, fk, grad_fk, iteration)
+    raise RuntimeError("No convergence in %s method after %d iterations" % (method, maxiter))
+
+
+def modified_cholesky(matrix, beta=0.01):
+    nrow, ncol = matrix.shape
+    if nrow != ncol:
+        raise ValueError("matrix must be square")
+    minimum_diagonal = np.diag(matrix).min()
+    tau = 0.0 if minimum_diagonal > 0.0 else -minimum_diagonal + beta
+    identity = np.eye(nrow)
+    while True:
+        try:
+            la.cholesky(matrix + tau * identity)
+            return matrix + tau * identity, tau
+        except la.LinAlgError:
+            tau = max(2.0 * tau, beta)
+
+
+__all__ = ["OptimizationResult", "bfgs_update", "line_search_backtracking",
+           "line_search_wolfe", "log_barrier", "minimize", "modified_cholesky"]

--- a/pyscf/msdft/ldma/optim/torch_optimizer.py
+++ b/pyscf/msdft/ldma/optim/torch_optimizer.py
@@ -1,0 +1,120 @@
+"""Torch optimizers and host-synchronization telemetry for LDMA."""
+
+import numpy
+import torch
+
+from .minimize import minimize
+
+
+class OptimizerTelemetry:
+    def __init__(self):
+        self.numpy_parameter_transfers = 0
+        self.numpy_gradient_transfers = 0
+        self.scalar_item_calls = 0
+        self.closure_calls = 0
+
+    def as_dict(self):
+        return vars(self).copy()
+
+
+class ClosureProfiler:
+    def __init__(self):
+        self.telemetry = OptimizerTelemetry()
+
+    def wrap(self, closure):
+        def profiled_closure(*args, **kwargs):
+            self.telemetry.closure_calls += 1
+            return closure(*args, **kwargs)
+        return profiled_closure
+
+    def as_dict(self):
+        return self.telemetry.as_dict()
+
+
+def parameters_to_vector(parameters, telemetry=None):
+    values = []
+    for parameter in parameters:
+        values.append(parameter.detach().reshape(-1).numpy(force=True))
+        if telemetry is not None:
+            telemetry.numpy_parameter_transfers += 1
+    return numpy.hstack(values)
+
+
+def parameter_gradients(parameters, telemetry=None):
+    values = []
+    for parameter in parameters:
+        values.append(parameter.grad.detach().reshape(-1).numpy(force=True))
+        if telemetry is not None:
+            telemetry.numpy_gradient_transfers += 1
+    return numpy.hstack(values)
+
+
+def vector_to_parameters(vector, parameters):
+    offset = 0
+    with torch.no_grad():
+        for parameter in parameters:
+            count = parameter.numel()
+            value = torch.as_tensor(vector[offset:offset + count], dtype=parameter.dtype, device=parameter.device)
+            parameter.copy_(value.reshape(parameter.size()))
+            offset += count
+
+
+class WrappedOptimizer(torch.optim.Optimizer):
+    def __init__(self, params, method="BFGS", line_search_method="Wolfe",
+                 constraints=None, max_steplen=None, callback=None,
+                 maxiter=100000, gtol=1.0e-6, ftol=1.0e-8, debug=0):
+        defaults = {
+            "method": method,
+            "line_search_method": line_search_method,
+            "constraints": constraints,
+            "max_steplen": max_steplen,
+            "callback": callback,
+            "maxiter": maxiter,
+            "gtol": gtol,
+            "ftol": ftol,
+            "debug": debug,
+        }
+        super().__init__(params, defaults)
+        if len(self.param_groups) != 1:
+            raise ValueError("per-parameter options are unsupported")
+        self._params = self.param_groups[0]["params"]
+        self.telemetry = OptimizerTelemetry()
+
+    def step(self, closure):
+        def objective(vector, requires_grad=True):
+            vector_to_parameters(vector, self._params)
+            self.zero_grad()
+            value = closure()
+            self.telemetry.closure_calls += 1
+            if requires_grad:
+                value.backward()
+                gradient = parameter_gradients(self._params, self.telemetry)
+                self.telemetry.scalar_item_calls += 1
+                return value.item(), gradient
+            self.telemetry.scalar_item_calls += 1
+            return value.item()
+
+        initial = parameters_to_vector(self._params, self.telemetry)
+        result = minimize(objective, initial, **self.defaults)
+        vector_to_parameters(result.x, self._params)
+        return result.fun
+
+
+class TorchLBFGSOptimizer(torch.optim.LBFGS):
+    def __init__(self, params, maxiter=100, gtol=1.0e-6, line_search_fn="strong_wolfe", **kwargs):
+        super().__init__(params, max_iter=maxiter, tolerance_grad=gtol,
+                         line_search_fn=line_search_fn, **kwargs)
+        self.telemetry = OptimizerTelemetry()
+
+    def step(self, closure):
+        def profiled():
+            with torch.enable_grad():
+                self.zero_grad()
+                value = closure()
+                self.telemetry.closure_calls += 1
+                value.backward()
+                return value
+        return super().step(profiled)
+
+
+__all__ = ["ClosureProfiler", "OptimizerTelemetry", "WrappedOptimizer", "TorchLBFGSOptimizer"]

--- a/pyscf/msdft/ldma/tests/__init__.py
+++ b/pyscf/msdft/ldma/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the native LDMA port."""

--- a/pyscf/msdft/ldma/tests/test_core_utils.py
+++ b/pyscf/msdft/ldma/tests/test_core_utils.py
@@ -1,0 +1,68 @@
+import numpy
+import pytest
+import torch
+
+from pyscf.msdft.ldma.dft.configurations import (
+    configurations_by_excitation_levels, excitation_levels, matrix_density_mo,
+    occupation_labels, total_spin_matrix)
+from pyscf.msdft.ldma.dft.pure import LDA, PureXCFunctional
+from pyscf.msdft.ldma.dft.spin import (index_within_multiplicity,
+                                      merge_multiplet_energies)
+from pyscf.msdft.ldma.nn.functional import robust_symmetric_eigh, trace_average
+from pyscf.msdft.ldma.optim import ClosureProfiler
+
+
+def test_robust_symmetric_eigh_validates_input():
+    matrix = torch.tensor([[2.0, 0.3], [0.3, 1.0]], dtype=torch.double)
+    values, vectors = robust_symmetric_eigh(matrix)
+    torch.testing.assert_close(vectors @ torch.diag(values) @ vectors.T, matrix)
+    with pytest.raises(ValueError, match="symmetric"):
+        robust_symmetric_eigh(torch.tensor([[1.0, 1.0], [0.0, 1.0]]))
+    with pytest.raises(ValueError, match="finite"):
+        robust_symmetric_eigh(torch.tensor([[1.0, 0.0], [0.0, float("nan")]]))
+
+
+def test_weighted_trace_average_uses_a_symmetric_similarity_transform():
+    matrix = torch.tensor([[2.0, 1.0], [1.0, 4.0]], dtype=torch.double)
+    weights = torch.tensor([1.0, 3.0], dtype=torch.double)
+    normalized = 2.0 * weights / weights.sum()
+    sqrt_weights = torch.sqrt(normalized)
+    expected = torch.linalg.eigvalsh(
+        sqrt_weights[:, None] * matrix * sqrt_weights[None, :]
+    )[0]
+    torch.testing.assert_close(
+        trace_average(matrix, weights=weights, subspace_dim=1).squeeze(), expected)
+    with pytest.raises(ValueError, match="non-negative"):
+        trace_average(matrix, weights=torch.tensor([1.0, -1.0]))
+
+
+def test_configuration_reference_values():
+    assert excitation_levels(4, 2) == [0, 1, 1, 1, 1, 2]
+    assert configurations_by_excitation_levels(2, (1, 1), 1) == [(0, 0), (0, 1), (1, 0)]
+    assert occupation_labels(2, 2) == ["2.", "ab", "ba", ".2"]
+    numpy.testing.assert_allclose(numpy.linalg.eigvalsh(total_spin_matrix(2, 2)),
+                                  [0.0, 0.0, 0.0, 2.0])
+    density = matrix_density_mo(2, (1, 1))
+    numpy.testing.assert_allclose(numpy.einsum("sppij->sij", density),
+                                  numpy.stack([numpy.eye(4), numpy.eye(4)]))
+
+
+def test_spin_multiplet_helpers():
+    energies, multiplicities = merge_multiplet_energies(
+        numpy.array([1.0, 2.0, 2.0, 2.0]), numpy.array([1, 3, 3, 3]))
+    numpy.testing.assert_array_equal(energies, [1.0, 2.0])
+    numpy.testing.assert_array_equal(multiplicities, [1, 3])
+    numpy.testing.assert_array_equal(index_within_multiplicity([1, 3, 1, 1, 3]),
+                                     [1, 1, 2, 3, 2])
+
+
+def test_pure_functional_base_and_closure_profiler():
+    density = torch.eye(2, dtype=torch.double)
+    base = PureXCFunctional()
+    torch.testing.assert_close(base.exchange_correlation(density, None),
+                               torch.zeros_like(density))
+    assert torch.isfinite(LDA().exchange_correlation(density, None)).all()
+    profiler = ClosureProfiler()
+    wrapped = profiler.wrap(lambda value: value + 1)
+    assert wrapped(2) == 3
+    assert profiler.as_dict()["closure_calls"] == 1

--- a/pyscf/msdft/ldma/tests/test_density.py
+++ b/pyscf/msdft/ldma/tests/test_density.py
@@ -1,0 +1,126 @@
+import numpy
+import pytest
+import torch
+from pyscf import gto
+
+from pyscf.msdft.ldma import (MultistateMatrixDensityCAS,
+                              MultistateMatrixDensityKohnSham, SpinType)
+
+
+@pytest.fixture
+def h2():
+    return gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g", spin=0,
+                 verbose=0)
+
+
+def test_spin_type_is_strictly_collinear():
+    assert list(SpinType) == [SpinType.UNPOLARIZED, SpinType.POLARIZED]
+
+
+@pytest.mark.parametrize("spin_type", [SpinType.UNPOLARIZED, SpinType.POLARIZED])
+def test_cas_density_is_normalized_and_collinear(h2, spin_type):
+    density = MultistateMatrixDensityCAS.from_guess(
+        h2, 2, 2, spin_symmetry=True, spin_type=spin_type, guess="hcore"
+    )
+    dm = density.density_matrices_ao()
+    overlap = torch.from_numpy(h2.intor_symmetric("int1e_ovlp")).to(dm)
+    integrated = torch.einsum("ssabij,ab->ij", dm, overlap)
+    torch.testing.assert_close(
+        integrated,
+        h2.tot_electrons() * torch.eye(density.number_of_states, dtype=dm.dtype),
+        atol=1.0e-10,
+        rtol=1.0e-10,
+    )
+    assert torch.count_nonzero(dm[0, 1]) == 0
+    assert torch.count_nonzero(dm[1, 0]) == 0
+
+
+def test_ao_batch_matches_direct_density_evaluation(h2):
+    density = MultistateMatrixDensityKohnSham.from_guess(h2, guess="hcore")
+    coords = numpy.array([[0.0, 0.0, 0.0], [0.1, -0.2, 0.3]])
+    value, gradient, laplacian = density.evaluate(
+        coords, need_gradient=False, need_laplacian=False
+    )
+    assert value.shape[2] == len(coords)
+    assert gradient is None
+    assert laplacian is None
+
+
+def test_density_gradient_matches_finite_difference(h2):
+    density = MultistateMatrixDensityCAS.from_guess(h2, 2, 2, guess="hcore")
+    coords = numpy.array([[0.21, -0.13, 0.34]])
+    value, gradient, _ = density.evaluate(coords, need_gradient=True, need_laplacian=False)
+    step = 1.0e-5
+    for axis in range(3):
+        direction = numpy.zeros(3)
+        direction[axis] = step
+        plus = density.evaluate(coords + direction, need_gradient=False,
+                                need_laplacian=False)[0]
+        minus = density.evaluate(coords - direction, need_gradient=False,
+                                 need_laplacian=False)[0]
+        torch.testing.assert_close(
+            gradient[:, :, :, axis], (plus - minus) / (2.0 * step),
+            rtol=1.0e-5, atol=1.0e-6)
+
+
+def test_density_laplacian_matches_finite_difference(h2):
+    density = MultistateMatrixDensityCAS.from_guess(h2, 2, 2, guess="hcore")
+    coords = numpy.array([[0.21, -0.13, 0.34]])
+    value, _, laplacian = density.evaluate(
+        coords, need_gradient=False, need_laplacian=True)
+    step = 1.0e-3
+    numerical = torch.zeros_like(value)
+    for axis in range(3):
+        direction = numpy.zeros(3)
+        direction[axis] = step
+        plus = density.evaluate(coords + direction, need_gradient=False,
+                                need_laplacian=False)[0]
+        minus = density.evaluate(coords - direction, need_gradient=False,
+                                 need_laplacian=False)[0]
+        numerical += (plus - 2.0 * value + minus) / step**2
+    torch.testing.assert_close(laplacian, numerical, rtol=2.0e-4, atol=2.0e-5)
+
+
+def test_density_parameter_autograd(h2):
+    original = MultistateMatrixDensityCAS.from_guess(h2, 2, 2, guess="hcore")
+    orbital = original.orbital_coefficients().detach()
+    states = original.state_coefficients().detach()
+    coords = numpy.array([[0.2, 0.1, -0.3]])
+
+    def evaluate(orbital_params, state_params):
+        density = MultistateMatrixDensityCAS(
+            h2, 2, 2, orbital, orbital_params, states, state_params)
+        return density.evaluate(coords, need_gradient=False, need_laplacian=False)[0]
+
+    orbital_params = torch.zeros_like(original.orbital_rotation_params, requires_grad=True)
+    state_params = torch.zeros_like(original.state_rotation_params, requires_grad=True)
+    assert torch.autograd.gradcheck(evaluate, (orbital_params, state_params),
+                                    eps=1.0e-6, atol=1.0e-5)
+
+
+def test_cas_basis_transformation(h2):
+    density = MultistateMatrixDensityCAS.from_guess(h2, 2, 2, guess="hcore")
+    coords = numpy.array([[0.1, 0.2, 0.3]])
+    before = density.evaluate(coords, need_gradient=False, need_laplacian=False)[0]
+    generator = torch.randn(density.number_of_states, density.number_of_states,
+                            dtype=torch.double)
+    rotation = torch.matrix_exp(generator - generator.T)
+    expected = torch.einsum("ia,strab,bj->strij", rotation, before, rotation.T)
+    density.basis_transformation(rotation)
+    after = density.evaluate(coords, need_gradient=False, need_laplacian=False)[0]
+    torch.testing.assert_close(after, expected)
+
+
+def test_invalid_active_spaces_restore_source_checks():
+    lithium = gto.M(atom="Li 0 0 0", basis="sto-3g", spin=1, verbose=0)
+    with pytest.raises(ValueError, match="odd.*even|Odd.*even"):
+        MultistateMatrixDensityCAS.from_guess(lithium, 2, 2)
+    hydrogen = gto.M(atom="H 0 0 0", basis="sto-3g", spin=1, verbose=0)
+    with pytest.raises(ValueError, match="More active electrons"):
+        MultistateMatrixDensityCAS.from_guess(hydrogen, 2, 3)
+    molecule = gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g",
+                     spin=0, verbose=0)
+    with pytest.raises(ValueError, match="spin electron counts"):
+        MultistateMatrixDensityCAS.from_guess(molecule, 1, (2, 0))
+    with pytest.raises(ValueError, match="More active orbitals"):
+        MultistateMatrixDensityCAS.from_guess(hydrogen, 4, 1)

--- a/pyscf/msdft/ldma/tests/test_hamiltonian.py
+++ b/pyscf/msdft/ldma/tests/test_hamiltonian.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+import pytest
+import torch
+from pyscf import dft, gto
+
+from pyscf.msdft.ldma import (HamiltonianSemilocal,
+                              MultistateMatrixDensityCAS,
+                              MultistateMatrixDensityKohnSham, SpinType)
+
+
+def h2_density():
+    mol = gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g",
+                spin=0, verbose=0)
+    density = MultistateMatrixDensityCAS.from_guess(
+        mol, 2, 2, spin_symmetry=True, spin_type=SpinType.POLARIZED,
+        guess="hcore"
+    )
+    return mol, density
+
+
+def test_grid_chunking_and_cache_preserve_hamiltonian():
+    mol, density = h2_density()
+    single = HamiltonianSemilocal(mol, spin_type=SpinType.POLARIZED,
+                                  grid_level=0, grid_chunks=1)
+    chunked = HamiltonianSemilocal(mol, spin_type=SpinType.POLARIZED,
+                                   grid_level=0, grid_chunks=3)
+    torch.testing.assert_close(single(density), chunked(density), atol=1.0e-10,
+                               rtol=1.0e-10)
+    dm = density.density_matrices_ao()
+    with mock.patch("pyscf.msdft.ldma.dft.hamiltonian.numint.eval_ao",
+                    wraps=__import__("pyscf").dft.numint.eval_ao) as eval_ao:
+        first = chunked._get_ao_grid_cache(dm.dtype, dm.device, density)
+        second = chunked._get_ao_grid_cache(dm.dtype, dm.device, density)
+    assert first is second
+    assert eval_ao.call_count == 0  # Existing matrix evaluation populated the cache.
+    assert all(batch.grad_ao_value is None for batch in first)
+
+
+def test_auto_chunking_respects_point_limit():
+    mol, density = h2_density()
+    hamiltonian = HamiltonianSemilocal(
+        mol, spin_type=SpinType.POLARIZED, grid_level=0, grid_chunks="auto",
+        max_grid_points_per_chunk=8,
+    )
+    assert hamiltonian._resolve_grid_chunks(torch.double, torch.device("cpu"), density) > 1
+
+
+def test_hamiltonian_rejects_mismatched_spin_type():
+    mol, density = h2_density()
+    hamiltonian = HamiltonianSemilocal(
+        mol, spin_type=SpinType.UNPOLARIZED, grid_level=0)
+    with pytest.raises(ValueError, match="same spin_type"):
+        hamiltonian(density)
+
+
+def test_default_unpolarized_hamiltonian_matches_pyscf_rks():
+    mol = gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g",
+                spin=0, verbose=0)
+    mean_field = dft.RKS(mol)
+    mean_field.xc = "LDA_X,LDA_C_CHACHIYO"
+    mean_field.grids.level = 0
+    mean_field.verbose = 0
+    mean_field.kernel()
+    density = MultistateMatrixDensityKohnSham.from_guess(
+        mol, guess=mean_field.mo_coeff)
+    hamiltonian = HamiltonianSemilocal(mol, grid_level=0)
+    assert hamiltonian.spin_type is SpinType.UNPOLARIZED
+    torch.testing.assert_close(
+        hamiltonian(density)[0, 0],
+        torch.tensor(mean_field.e_tot, dtype=torch.double),
+        rtol=1.0e-7, atol=1.0e-7)

--- a/pyscf/msdft/ldma/tests/test_operators.py
+++ b/pyscf/msdft/ldma/tests/test_operators.py
@@ -1,0 +1,76 @@
+import numpy
+import pytest
+import torch
+from pyscf import gto
+from pyscf.pbc import gto as pbcgto
+
+from pyscf.msdft.ldma.dft.exact_exchange import ExactExchangeFunctionalAO
+from pyscf.msdft.ldma.dft.hartree import HartreeFunctionalAO
+from pyscf.msdft.ldma.dft.integrals import OneElectronIntegralCache
+from pyscf.msdft.ldma.dft.operator1e import OneElectronOperatorAO
+
+
+def molecule():
+    return gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g",
+                 spin=0, verbose=0)
+
+
+def test_one_electron_operator_value_and_gradcheck():
+    mol = molecule()
+    nao = mol.nao_nr()
+    density = torch.randn(nao, nao, 2, 2, dtype=torch.double, requires_grad=True)
+    value = OneElectronOperatorAO.apply(density, mol, "int1e_kin")
+    reference = torch.einsum(
+        "ab,abij->ij", torch.from_numpy(mol.intor_symmetric("int1e_kin")), density)
+    torch.testing.assert_close(value, reference)
+    assert torch.autograd.gradcheck(
+        lambda dm: OneElectronOperatorAO.apply(dm, mol, "int1e_kin"), (density,))
+
+
+def test_hartree_and_exact_exchange_gradients_are_finite():
+    mol = molecule()
+    nao = mol.nao_nr()
+    factor = torch.randn(nao, nao, 2, 2, dtype=torch.double)
+    density = 0.5 * (factor + factor.permute(1, 0, 3, 2))
+    density.requires_grad_(True)
+    energy = HartreeFunctionalAO(mol)(density).sum() + ExactExchangeFunctionalAO(mol)(density).sum()
+    energy.backward()
+    assert torch.isfinite(density.grad).all()
+
+
+@pytest.mark.parametrize("functional_class", [HartreeFunctionalAO,
+                                               ExactExchangeFunctionalAO])
+def test_two_electron_functional_gradcheck(functional_class):
+    mol = molecule()
+    nao = mol.nao_nr()
+    density = torch.randn(nao, nao, 1, 1, dtype=torch.double,
+                          requires_grad=True)
+    assert torch.autograd.gradcheck(functional_class(mol), (density,),
+                                    eps=1.0e-6, atol=1.0e-5, rtol=1.0e-4)
+
+
+def periodic_cell():
+    cell = pbcgto.Cell()
+    cell.atom = "H 0 0 0; H 0 0 1.4"
+    cell.a = numpy.eye(3) * 4.0
+    cell.basis = "sto-3g"
+    cell.spin = 0
+    cell.mesh = [7, 7, 7]
+    cell.verbose = 0
+    cell.build()
+    return cell
+
+
+def test_periodic_one_electron_and_integral_cache_branches():
+    cell = periodic_cell()
+    nao = cell.nao_nr()
+    density = torch.eye(nao, dtype=torch.double)[:, :, None, None]
+    kinetic = OneElectronOperatorAO.apply(density, cell, "int1e_kin")
+    reference = torch.trace(torch.from_numpy(cell.pbc_intor("int1e_kin"))).reshape(1, 1)
+    torch.testing.assert_close(kinetic, reference)
+    cache = OneElectronIntegralCache(cell, "int1e_kin")
+    torch.testing.assert_close(cache.integrals_ao,
+                               torch.from_numpy(cell.pbc_intor("int1e_kin")))
+    assert torch.isfinite(HartreeFunctionalAO(cell)(density)).all()
+    with pytest.raises(NotImplementedError, match="periodic"):
+        ExactExchangeFunctionalAO(cell)

--- a/pyscf/msdft/ldma/tests/test_optimizer.py
+++ b/pyscf/msdft/ldma/tests/test_optimizer.py
@@ -1,0 +1,60 @@
+import numpy
+import pytest
+import torch
+
+from pyscf.msdft.ldma.optim.minimize import minimize
+from pyscf.msdft.ldma.optim.torch_optimizer import (TorchLBFGSOptimizer,
+                                                    WrappedOptimizer)
+
+
+def rosenbrock(x, requires_grad=True):
+    value = (1.0 - x[0]) ** 2 + 100.0 * (x[1] - x[0] ** 2) ** 2
+    if not requires_grad:
+        return value
+    gradient = numpy.array([
+        -2.0 * (1.0 - x[0]) - 400.0 * x[0] * (x[1] - x[0] ** 2),
+        200.0 * (x[1] - x[0] ** 2),
+    ])
+    return value, gradient
+
+
+def circle_constraint(x):
+    return numpy.array([1.0 - x[0] ** 2 - x[1] ** 2]), numpy.array([[-2*x[0], -2*x[1]]])
+
+
+@pytest.mark.parametrize("method", ["Newton", "BFGS", "Steepest Descent"])
+@pytest.mark.parametrize("line_search", ["Armijo", "Wolfe"])
+def test_original_minimizer_algorithms(method, line_search):
+    result = minimize(rosenbrock, numpy.zeros(2), method=method,
+                      line_search_method=line_search,
+                      gtol=1.0e-7 if method == "Steepest Descent" else 1.0e-6)
+    numpy.testing.assert_allclose(result.x, [1.0, 1.0], atol=1.0e-4, rtol=1.0e-4)
+
+
+@pytest.mark.parametrize("method", ["Newton", "BFGS", "Steepest Descent"])
+def test_original_minimizer_constraints(method):
+    result = minimize(rosenbrock, numpy.zeros(2), method=method,
+                      constraints=circle_constraint, gtol=1.0e-7)
+    numpy.testing.assert_allclose(result.x, [0.7864, 0.6177], atol=1.0e-4)
+    numpy.testing.assert_allclose(result.fun, 0.0457, atol=1.0e-4)
+
+
+def test_unsupported_optimizer_modes_fail_explicitly():
+    with pytest.raises(ValueError, match="method"):
+        minimize(rosenbrock, numpy.zeros(2), method="CG")
+    with pytest.raises(ValueError, match="line_search"):
+        minimize(rosenbrock, numpy.zeros(2), line_search_method="fake")
+
+
+@pytest.mark.parametrize("optimizer_class", [WrappedOptimizer, TorchLBFGSOptimizer])
+def test_torch_optimizer_wrappers_and_telemetry(optimizer_class):
+    parameter = torch.nn.Parameter(torch.tensor([0.0], dtype=torch.double))
+    optimizer = optimizer_class([parameter], maxiter=20, gtol=1.0e-8)
+
+    def closure():
+        optimizer.zero_grad()
+        return torch.sum((parameter - 1.0) ** 2)
+
+    optimizer.step(closure)
+    torch.testing.assert_close(parameter, torch.ones_like(parameter), atol=1.0e-5, rtol=1.0e-5)
+    assert optimizer.telemetry.closure_calls > 0

--- a/pyscf/msdft/ldma/tests/test_target_optimizer.py
+++ b/pyscf/msdft/ldma/tests/test_target_optimizer.py
@@ -1,0 +1,161 @@
+import torch
+import copy
+import pytest
+import numpy
+from unittest import mock
+from pyscf.dft import numint
+from pyscf import gto
+from pyscf.scf.hf import get_hcore
+
+from pyscf.msdft.ldma import (HamiltonianTargetStateLDMA, SpinType,
+                              TargetStateMultistateMatrixDensityCAS,
+                              minimize_subspace_energy)
+from pyscf.msdft.ldma.dft.integrals import OneElectronIntegralCache
+from pyscf.msdft.ldma.dft.active_space import ActiveSpace
+from pyscf.msdft.ldma.dft.density import AOGridBatch
+from pyscf.msdft.ldma.dft.density import cas_guess_components
+
+
+def target_density(parameterization="full_rotation"):
+    mol = gto.M(atom="H 0 0 -0.35; H 0 0 0.35", basis="sto-3g",
+                spin=0, verbose=0)
+    density = TargetStateMultistateMatrixDensityCAS.from_guess(
+        mol, 2, 2, target_states=2, spin_symmetry=True,
+        spin_type=SpinType.UNPOLARIZED, guess="hcore",
+        target_parameterization=parameterization,
+    )
+    return mol, density
+
+
+def test_target_parameterizations_agree_at_origin():
+    mol, full = target_density("full_rotation")
+    _, stiefel = target_density("stiefel_k")
+    torch.testing.assert_close(full.transition_1rdm_mo(), stiefel.transition_1rdm_mo())
+    assert full.target_orthonormality_error() < 1.0e-12
+    components = cas_guess_components(mol, 2, 2)
+    assert components.nstate == components.det_to_csf.size(1)
+    assert components.ndet == components.det_to_csf.size(0)
+
+
+def test_target_full_space_matches_dense_without_dense_table_construction():
+    mol, _ = target_density()
+    from pyscf.msdft.ldma import MultistateMatrixDensityCAS
+    dense = MultistateMatrixDensityCAS.from_guess(mol, 2, 2, guess="hcore")
+    full = TargetStateMultistateMatrixDensityCAS.from_guess(
+        mol, 2, 2, target_states=dense.number_of_states, guess="hcore")
+    torch.testing.assert_close(full.density_matrices_ao(), dense.density_matrices_ao())
+    with mock.patch.object(ActiveSpace, "matrix_density_mo",
+                           side_effect=AssertionError("dense path used")):
+        sparse = TargetStateMultistateMatrixDensityCAS.from_guess(
+            mol, 2, 2, target_states=2, guess="hcore")
+    assert sparse.one_body_values.numel() > 0
+    assert sparse.one_body_shape[-2:] == (sparse.number_of_determinants,) * 2
+    assert sparse._last_orbital_grid_density is None
+
+
+def test_target_density_autograd():
+    mol, original = target_density()
+    coords = torch.from_numpy(numint.eval_ao(
+        mol, numpy.asarray([[0.1, -0.2, 0.3]]), deriv=0)).double()
+    batch = AOGridBatch(None, coords)
+
+    def evaluate(orbital_params, target_params):
+        density = TargetStateMultistateMatrixDensityCAS(
+            mol, 2, 2, 2, original.mo_coeff_guess, orbital_params,
+            original.det_to_csf, original.s2_matrix, original.active_space,
+            target_rotation_params=target_params)
+        return density.evaluate_from_mo_grid_batch(batch)[0]
+
+    orbital_params = torch.zeros_like(original.orbital_rotation_params,
+                                      requires_grad=True)
+    target_params = torch.zeros_like(original.target_rotation_params,
+                                     requires_grad=True)
+    assert torch.autograd.gradcheck(evaluate, (orbital_params, target_params),
+                                    eps=1.0e-6, atol=1.0e-5)
+
+
+def test_cached_mo_integrals_match_ao_contraction():
+    mol, density = target_density()
+    cache = OneElectronIntegralCache(mol)
+    from_mo = cache.matrix_elements_from_gamma(
+        density.transition_1rdm_mo(), density.orbital_coefficients()
+    )
+    dm = torch.einsum("ss...->...", density.density_matrices_ao())
+    from_ao = torch.einsum("ab,abij->ij", cache.integrals_ao, dm)
+    torch.testing.assert_close(from_mo, from_ao, atol=1.0e-10, rtol=1.0e-10)
+
+
+def test_one_electron_cache_includes_scalar_ecp():
+    mol = gto.M(
+        atom="Na 0 0 0", basis="lanl2dz", ecp="lanl2dz",
+        spin=1, verbose=0)
+    cache = OneElectronIntegralCache(mol)
+    torch.testing.assert_close(
+        cache.integrals_ao,
+        torch.from_numpy(get_hcore(mol)).double(),
+        atol=1.0e-12,
+        rtol=1.0e-12,
+    )
+
+
+def test_torch_optimizer_reports_telemetry_and_preserves_targets():
+    mol, density = target_density()
+    hamiltonian = HamiltonianTargetStateLDMA(mol, grid_level=0, grid_chunks=2)
+    energies, optimized, info = minimize_subspace_energy(
+        hamiltonian, density, optimizer="torch_lbfgs", maxiter=1,
+        return_info=True, convergence={"gtol": 1.0e6},
+    )
+    assert torch.isfinite(energies).all()
+    assert optimized.target_orthonormality_error() < 1.0e-10
+    assert info["optimizer_telemetry"]["numpy_parameter_transfers"] == 0
+    assert info["optimizer_telemetry"]["closure_calls"] > 0
+    assert "converged_grad" in info["optimizer_convergence"]
+
+
+def test_restart_schema_2_round_trip_and_validation(tmp_path):
+    _, density = target_density()
+    with torch.no_grad():
+        density.orbital_rotation_params.add_(0.01)
+        density.target_rotation_params.add_(0.02)
+    state = density.restart_state()
+    assert state["schema_version"] == 2
+    _, restored = target_density()
+    restored.load_restart_state(state)
+    torch.testing.assert_close(restored.orbital_rotation_params,
+                               density.orbital_rotation_params)
+    torch.testing.assert_close(restored.target_rotation_params,
+                               density.target_rotation_params)
+    path = density.save_restart_file(tmp_path / "restart.json")
+    restored.load_restart_file(path)
+    invalid = copy.deepcopy(state)
+    invalid["ncsf"] += 1
+    with pytest.raises(ValueError, match="ncsf"):
+        restored.load_restart_state(invalid)
+    invalid = copy.deepcopy(state)
+    invalid["schema_version"] = 99
+    with pytest.raises(ValueError, match="Unsupported restart schema"):
+        restored.load_restart_state(invalid)
+
+
+def test_legacy_restart_only_supports_full_rotation():
+    _, full = target_density("full_rotation")
+    legacy = {
+        "target_states": full.number_of_states,
+        "orbital_rotation_params": full.orbital_rotation_params.detach().clone(),
+        "target_rotation_params": full.target_rotation_params.detach().clone(),
+    }
+    full.load_restart_state(legacy)
+    _, stiefel = target_density("stiefel_k")
+    with pytest.raises(ValueError, match="Legacy"):
+        stiefel.load_restart_state(legacy)
+
+
+def test_schema_1_restart_defaults_to_full_rotation():
+    _, density = target_density("full_rotation")
+    state = density.restart_state()
+    state["schema_version"] = 1
+    state.pop("target_parameterization")
+    _, restored = target_density("full_rotation")
+    restored.load_restart_state(state)
+    torch.testing.assert_close(restored.target_rotation_params,
+                               density.target_rotation_params)

--- a/pyscf/msdft/ldma/tests/test_xc.py
+++ b/pyscf/msdft/ldma/tests/test_xc.py
@@ -1,0 +1,62 @@
+import torch
+import numpy
+from pyscf.dft import libxc
+
+from pyscf.msdft.ldma import (lda_c_chachiyo, lda_x_dirac,
+                              lda_xc_dirac_chachiyo,
+                              lda_xc_dirac_chachiyo_unpolarized)
+
+
+def positive_density(nbatch=3, nstate=3):
+    torch.manual_seed(12)
+    factor = torch.randn(nbatch, nstate, nstate, dtype=torch.double)
+    return factor @ factor.transpose(-1, -2) + 0.2 * torch.eye(nstate, dtype=torch.double)
+
+
+def test_fused_functionals_match_analytic_terms():
+    density = positive_density()
+    torch.testing.assert_close(
+        lda_xc_dirac_chachiyo(density),
+        lda_x_dirac(density) + lda_c_chachiyo(density),
+    )
+    torch.testing.assert_close(
+        lda_xc_dirac_chachiyo_unpolarized(density),
+        2.0 * lda_x_dirac(density / 2.0) + lda_c_chachiyo(density),
+    )
+
+
+def test_matrix_function_backward_handles_repeated_eigenvalues():
+    density = torch.eye(3, dtype=torch.double).repeat(2, 1, 1).requires_grad_(True)
+    lda_xc_dirac_chachiyo(density).sum().backward()
+    assert torch.isfinite(density.grad).all()
+
+
+def test_matrix_function_gradcheck():
+    density = positive_density(1, 2).requires_grad_(True)
+    def symmetric_xc(value):
+        return lda_xc_dirac_chachiyo(0.5 * (value + value.transpose(-1, -2)))
+
+    assert torch.autograd.gradcheck(symmetric_xc, (density,),
+                                    eps=1.0e-6, atol=1.0e-5, rtol=1.0e-4)
+
+
+def test_scalar_functionals_match_libxc():
+    density = torch.linspace(0.05, 2.0, 12, dtype=torch.double)[:, None, None]
+    rho = density[:, 0, 0].numpy()[None, :]
+    exchange_reference = libxc.eval_xc("LDA_X,", rho)[0] * rho[0]
+    correlation_reference = libxc.eval_xc(",LDA_C_CHACHIYO", rho)[0] * rho[0]
+    torch.testing.assert_close(
+        2.0 * lda_x_dirac(density / 2.0)[:, 0, 0],
+        torch.from_numpy(exchange_reference), rtol=1.0e-5, atol=1.0e-5)
+    torch.testing.assert_close(
+        lda_c_chachiyo(density)[:, 0, 0],
+        torch.from_numpy(correlation_reference), rtol=1.0e-5, atol=1.0e-5)
+
+
+def test_matrix_function_is_orthogonally_equivariant():
+    density = positive_density(2, 3)
+    generator = torch.randn(3, 3, dtype=torch.double)
+    rotation = torch.matrix_exp(generator - generator.T)
+    transformed = rotation @ density @ rotation.T
+    expected = rotation @ lda_xc_dirac_chachiyo(density) @ rotation.T
+    torch.testing.assert_close(lda_xc_dirac_chachiyo(transformed), expected)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ EXTRAS = {
     'afqmc-cpu': ['jax'],
     'afqmc-cuda12': ['jax[cuda12]'],
     'afqmc-cuda13': ['jax[cuda13]'],
+    'msdft-ldma': ['torch>=2.0'],
 }
 VERSION = '1.1.1'
 


### PR DESCRIPTION
## Summary
- add the analytic local-density matrix approximation under `pyscf.msdft.ldma`
- support unpolarized and collinearly polarized matrix densities while preserving the existing `pyscf.msdft.NOCI` API
- include variational CAS/target-state infrastructure, operator components, optimizers, documentation, and an H2 example

## Functional scope
- Dirac exchange and Chachiyo correlation only
- no mixed-spin, noncollinear, spectral-clustering, eta/chi, or fitted Level-0 functionality
- polarized mode spin-scales exchange and retains the original paramagnetic Chachiyo correlation approximation

## Packaging and license
- Torch is available through the optional `msdft-ldma` extra
- base `pyscf.msdft` import remains independent of Torch
- the LDMA component retains its MIT license and contributor notices in `NOTICE`

## Validation
- `python -m pytest -q pyscf/msdft/tests pyscf/msdft/ldma/tests`: 52 passed
- Ruff, Flake8, and pycodestyle checks passed for `pyscf/msdft/ldma`
- optional dependency metadata dry-run passed
- H2 smoke example produced finite energies
- final publication review found no blocking issues

A local full wheel build reached existing Forge CMake targets but could not complete because the macOS environment lacked the `pwscf` OpenMP/FFTW inputs. The LDMA code is pure Python; upstream Linux CI remains the authoritative full build check.